### PR TITLE
fix(sdlc): enforce human-only PR approval and merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,8 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
 4. Get CI green (lint, test, commit-messages)
 5. **Human reviews and approves the PR** — Claude must never approve or merge PRs
 6. Squash merge to main — branch auto-deletes, linked issue auto-closes
-6. Release-please auto-creates/updates a "Release PR" with version bump + CHANGELOG
-7. When ready to ship: merge the Release PR → auto-tags, creates GitHub Release, CI builds binaries
+7. Release-please auto-creates/updates a "Release PR" with version bump + CHANGELOG
+8. When ready to ship: merge the Release PR → auto-tags, creates GitHub Release, CI builds binaries
 
 Version bumps are determined from Conventional Commits: `fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE` → major.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 A CLI tool for provisioning and managing development machines. Currently Python (Typer + Rich), evolving to TypeScript + Ink in v2.
 
+## Hard rules
+
+- **Never approve PRs.** Claude may review and post comments (`event=COMMENT`) but must never submit approvals (`event=APPROVE`) or merge PRs. Only the human maintainer approves and merges.
+- **Never force-push to main.**
+
 ## Dev commands
 
 ```bash
@@ -128,7 +133,8 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
 2. Open PR with `Closes #N` in the body to link the issue
 3. Add the PR to the **devlair roadmap** project board and set status to **In Progress**
 4. Get CI green (lint, test, commit-messages)
-5. Squash merge to main — branch auto-deletes, linked issue auto-closes
+5. **Human reviews and approves the PR** — Claude must never approve or merge PRs
+6. Squash merge to main — branch auto-deletes, linked issue auto-closes
 6. Release-please auto-creates/updates a "Release PR" with version bump + CHANGELOG
 7. When ready to ship: merge the Release PR → auto-tags, creates GitHub Release, CI builds binaries
 


### PR DESCRIPTION
## Summary

- Add hard rules to CLAUDE.md: Claude must never approve or merge PRs
- Update release process to include explicit human review step (step 5)
- Branch protection updated to require 1 approving review with stale review dismissal

Closes #52

## Test plan

- [ ] Verify branch protection requires approval before merge (try merging without approval)
- [ ] Verify CLAUDE.md hard rules section is visible at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)