### PR TITLE
feat(cli): JSON module protocol and TypeScript runner

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
+        "@types/bun": "^1.3.12",
         "@types/node": "^25.5.2",
         "@types/react": "^18.3.0",
         "ink-spinner": "^5.0.0",
@@ -41,6 +42,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
@@ -54,6 +57,8 @@
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
+    "@types/bun": "^1.3.12",
     "@types/node": "^25.5.2",
     "@types/react": "^18.3.0",
     "ink-spinner": "^5.0.0",

--- a/cli/src/lib/runner.ts
+++ b/cli/src/lib/runner.ts
@@ -1,0 +1,179 @@
+// Spawns module shell scripts and parses the JSON Lines protocol.
+//
+// Contract (see modules/_lib.sh):
+//   - Child reads a single JSON object from stdin (ModuleContext).
+//   - Child writes JSON Lines to stdout, one ModuleEvent per line.
+//   - Exit codes: 0 = ok, 1 = fail, 2 = skip.
+//   - stderr is buffered and surfaced to callers opting into verbose output.
+
+import { spawn } from "node:child_process";
+import type { ModuleContext, ModuleEvent, ModuleMode, Status } from "./types.js";
+import { ModuleExitCode } from "./types.js";
+
+export interface RunOptions {
+  /** Kill the child with SIGTERM after this many milliseconds. */
+  timeoutMs?: number;
+  /** Abort signal — triggers SIGTERM on the child when aborted. */
+  signal?: AbortSignal;
+  /** Invoked for each stderr line (no trailing newline). */
+  onStderr?: (line: string) => void;
+  /** Override the bash executable (defaults to "bash"). Useful for tests. */
+  bashPath?: string;
+}
+
+export interface RunResult {
+  exitCode: number;
+  status: Status;
+  /** Full accumulated stderr. */
+  stderr: string;
+  /** True when the run ended because of a timeout. */
+  timedOut: boolean;
+}
+
+function statusFromExitCode(code: number): Status {
+  if (code === ModuleExitCode.Success) return "ok";
+  if (code === ModuleExitCode.Skip) return "skip";
+  return "fail";
+}
+
+function isStatus(value: unknown): value is Status {
+  return value === "ok" || value === "warn" || value === "skip" || value === "fail";
+}
+
+function isModuleEvent(value: unknown): value is ModuleEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  switch (v.type) {
+    case "progress":
+      return typeof v.message === "string" && (v.percent === undefined || typeof v.percent === "number");
+    case "result":
+      return isStatus(v.status) && typeof v.detail === "string";
+    case "check":
+      return (
+        typeof v.label === "string" && isStatus(v.status) && (v.detail === undefined || typeof v.detail === "string")
+      );
+    case "install":
+      return typeof v.tool === "string" && typeof v.source === "string" && typeof v.verified === "boolean";
+    default:
+      return false;
+  }
+}
+
+function parseEventLine(line: string): ModuleEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return isModuleEvent(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a module script, yielding each parsed event. The generator's return value
+ * is a RunResult summarizing the exit code, derived status, and captured stderr.
+ *
+ * Malformed JSON lines are silently dropped — modules may emit arbitrary noise
+ * to stdout (e.g. tool output before suppression is wired up), and we treat
+ * only well-formed protocol events as meaningful.
+ */
+export async function* runModule(
+  scriptPath: string,
+  context: ModuleContext,
+  mode: ModuleMode,
+  options: RunOptions = {},
+): AsyncGenerator<ModuleEvent, RunResult> {
+  // `detached: true` puts the child in its own process group so we can kill
+  // the entire tree on abort/timeout. Without this, grandchildren (e.g. a
+  // sleeping curl/apt inside the script) inherit stdout and keep our pipe
+  // open long after bash itself has been signalled.
+  const child = spawn(options.bashPath ?? "bash", [scriptPath, mode], {
+    stdio: ["pipe", "pipe", "pipe"],
+    detached: true,
+  });
+
+  const killTree = (sig: NodeJS.Signals = "SIGTERM") => {
+    if (child.pid === undefined) return;
+    try {
+      process.kill(-child.pid, sig);
+    } catch {
+      // Process group may already be gone — fine.
+    }
+  };
+
+  let timedOut = false;
+  const timeoutId =
+    options.timeoutMs !== undefined
+      ? setTimeout(() => {
+          timedOut = true;
+          killTree("SIGTERM");
+        }, options.timeoutMs)
+      : undefined;
+
+  const abortHandler = () => killTree("SIGTERM");
+  if (options.signal) {
+    if (options.signal.aborted) {
+      abortHandler();
+    } else {
+      options.signal.addEventListener("abort", abortHandler, { once: true });
+    }
+  }
+
+  const closePromise = new Promise<number>((resolve, reject) => {
+    child.on("close", (code) => resolve(code ?? ModuleExitCode.Failure));
+    child.on("error", reject);
+  });
+
+  let stderrBuf = "";
+  let stderrCarry = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderrBuf += chunk;
+    if (!options.onStderr) return;
+    stderrCarry += chunk;
+    const lines = stderrCarry.split("\n");
+    stderrCarry = lines.pop() ?? "";
+    for (const line of lines) options.onStderr(line);
+  });
+
+  // Close stdin so `read_context` in the child sees EOF.
+  child.stdin.write(`${JSON.stringify(context)}\n`);
+  child.stdin.end();
+
+  let exited = false;
+  try {
+    child.stdout.setEncoding("utf8");
+    let carry = "";
+    for await (const chunk of child.stdout as AsyncIterable<string>) {
+      carry += chunk;
+      const lines = carry.split("\n");
+      carry = lines.pop() ?? "";
+      for (const line of lines) {
+        const event = parseEventLine(line);
+        if (event) yield event;
+      }
+    }
+    if (carry) {
+      const event = parseEventLine(carry);
+      if (event) yield event;
+    }
+
+    const exitCode = await closePromise;
+    exited = true;
+    if (stderrCarry && options.onStderr) options.onStderr(stderrCarry);
+
+    return {
+      exitCode,
+      status: timedOut ? "fail" : statusFromExitCode(exitCode),
+      stderr: stderrBuf,
+      timedOut,
+    };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    options.signal?.removeEventListener("abort", abortHandler);
+    // If the consumer abandoned the generator (early return / thrown error),
+    // kill the process group so detached children don't linger.
+    if (!exited) killTree("SIGTERM");
+  }
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -26,3 +26,11 @@ export interface CheckItem {
   status: Status;
   detail?: string;
 }
+
+export type ModuleMode = "run" | "check";
+
+export const ModuleExitCode = {
+  Success: 0,
+  Failure: 1,
+  Skip: 2,
+} as const;

--- a/cli/src/test/runner.test.ts
+++ b/cli/src/test/runner.test.ts
@@ -1,0 +1,302 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type RunResult, runModule } from "../lib/runner.js";
+import type { ModuleContext, ModuleEvent, ModuleMode } from "../lib/types.js";
+
+const LIB_PATH = join(import.meta.dir, "../../../modules/_lib.sh");
+
+function ctx(overrides: Partial<ModuleContext> = {}): ModuleContext {
+  return {
+    username: "tester",
+    userHome: "/home/tester",
+    platform: "linux",
+    wslVersion: null,
+    config: {},
+    ...overrides,
+  };
+}
+
+async function collect(
+  script: string,
+  context: ModuleContext = ctx(),
+  mode: ModuleMode = "run",
+  options: Parameters<typeof runModule>[3] = {},
+) {
+  const events: ModuleEvent[] = [];
+  const iter = runModule(script, context, mode, options);
+  while (true) {
+    const { value, done } = await iter.next();
+    if (done) return { events, result: value };
+    events.push(value);
+  }
+}
+
+let tmpDir: string;
+
+function writeScript(name: string, body: string): string {
+  const path = join(tmpDir, name);
+  writeFileSync(path, `#!/usr/bin/env bash\n${body}`, { mode: 0o755 });
+  return path;
+}
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "devlair-runner-"));
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("runModule", () => {
+  test("parses progress, install, and result events", async () => {
+    const script = writeScript(
+      "happy.sh",
+      `source "${LIB_PATH}"
+read_context
+json_progress "starting" 10
+json_install "uv" "astral.sh" true
+json_result "ok" "done"
+exit 0`,
+    );
+
+    const { events, result } = await collect(script);
+
+    expect(events).toEqual([
+      { type: "progress", message: "starting", percent: 10 },
+      { type: "install", tool: "uv", source: "astral.sh", verified: true },
+      { type: "result", status: "ok", detail: "done" },
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.status).toBe("ok");
+    expect(result.timedOut).toBe(false);
+  });
+
+  test("emits check events in check mode", async () => {
+    const script = writeScript(
+      "check.sh",
+      `source "${LIB_PATH}"
+read_context
+mode=\${1:-run}
+if [[ "$mode" == "check" ]]; then
+  json_check "zsh installed" "ok"
+  json_check ".zimrc present" "fail" "missing"
+fi
+exit 0`,
+    );
+
+    const { events } = await collect(script, ctx(), "check");
+
+    expect(events).toEqual([
+      { type: "check", label: "zsh installed", status: "ok", detail: "" },
+      { type: "check", label: ".zimrc present", status: "fail", detail: "missing" },
+    ]);
+  });
+
+  test("maps exit code 1 to fail", async () => {
+    const script = writeScript(
+      "fail.sh",
+      `source "${LIB_PATH}"
+read_context
+json_result "fail" "boom"
+exit 1`,
+    );
+    const { result } = await collect(script);
+    expect(result.exitCode).toBe(1);
+    expect(result.status).toBe("fail");
+  });
+
+  test("maps exit code 2 to skip", async () => {
+    const script = writeScript(
+      "skip.sh",
+      `source "${LIB_PATH}"
+read_context
+json_result "skip" "not applicable"
+exit 2`,
+    );
+    const { result } = await collect(script);
+    expect(result.exitCode).toBe(2);
+    expect(result.status).toBe("skip");
+  });
+
+  test("delivers context via stdin", async () => {
+    const script = writeScript(
+      "ctx.sh",
+      `source "${LIB_PATH}"
+read_context
+user=$(ctx_get username)
+home=$(ctx_get userHome)
+json_result "ok" "hello $user at $home"
+exit 0`,
+    );
+    const { events } = await collect(script, ctx({ username: "alice", userHome: "/home/alice" }));
+    expect(events).toContainEqual({
+      type: "result",
+      status: "ok",
+      detail: "hello alice at /home/alice",
+    });
+  });
+
+  test("drops malformed JSON lines without failing", async () => {
+    const script = writeScript(
+      "noisy.sh",
+      `source "${LIB_PATH}"
+read_context
+echo "not json"
+json_progress "ok"
+echo "{broken"
+json_result "ok" "done"
+exit 0`,
+    );
+    const { events, result } = await collect(script);
+    expect(events).toEqual([
+      { type: "progress", message: "ok" },
+      { type: "result", status: "ok", detail: "done" },
+    ]);
+    expect(result.status).toBe("ok");
+  });
+
+  test("captures stderr and streams via onStderr callback", async () => {
+    const script = writeScript(
+      "stderr.sh",
+      `source "${LIB_PATH}"
+read_context
+echo "debug line 1" >&2
+echo "debug line 2" >&2
+json_result "ok" "done"
+exit 0`,
+    );
+    const stderrLines: string[] = [];
+    const { result } = await collect(script, ctx(), "run", { onStderr: (line) => stderrLines.push(line) });
+    expect(stderrLines).toEqual(["debug line 1", "debug line 2"]);
+    expect(result.stderr).toContain("debug line 1");
+    expect(result.stderr).toContain("debug line 2");
+  });
+
+  test("timeout kills child and sets timedOut flag", async () => {
+    const script = writeScript(
+      "slow.sh",
+      `source "${LIB_PATH}"
+read_context
+json_progress "starting"
+sleep 10
+json_result "ok" "finished"
+exit 0`,
+    );
+    const { result } = await collect(script, ctx(), "run", { timeoutMs: 200 });
+    expect(result.timedOut).toBe(true);
+    expect(result.status).toBe("fail");
+  });
+
+  test("abort signal kills child", async () => {
+    const script = writeScript(
+      "abortable.sh",
+      `source "${LIB_PATH}"
+read_context
+json_progress "started"
+sleep 10
+exit 0`,
+    );
+    const controller = new AbortController();
+    const iter = runModule(script, ctx(), "run", { signal: controller.signal });
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+    controller.abort();
+    let final: IteratorResult<ModuleEvent, RunResult>;
+    do {
+      final = await iter.next();
+    } while (!final.done);
+    expect(final.value.status).toBe("fail");
+  });
+
+  test("passes mode argument to the script", async () => {
+    const script = writeScript(
+      "mode.sh",
+      `source "${LIB_PATH}"
+read_context
+json_result "ok" "mode=\${1:-none}"
+exit 0`,
+    );
+    const { events: runEvents } = await collect(script, ctx(), "run");
+    const { events: checkEvents } = await collect(script, ctx(), "check");
+    expect(runEvents).toContainEqual({ type: "result", status: "ok", detail: "mode=run" });
+    expect(checkEvents).toContainEqual({ type: "result", status: "ok", detail: "mode=check" });
+  });
+});
+
+describe("_lib.sh json helpers", () => {
+  function runLibScript(body: string): { stdout: string; code: number } {
+    const scriptPath = join(tmpDir, `lib-${Math.random().toString(36).slice(2)}.sh`);
+    writeFileSync(scriptPath, `#!/usr/bin/env bash\nsource "${LIB_PATH}"\n${body}`, { mode: 0o755 });
+    const out = spawnSync("bash", [scriptPath], { encoding: "utf8", input: "{}" });
+    return { stdout: out.stdout, code: out.status ?? -1 };
+  }
+
+  test("json_escape handles quotes, newlines, tabs, and backslashes", () => {
+    const { stdout } = runLibScript(String.raw`
+input='He said "hi"
+line2	tab\back'
+json_escape "$input"
+`);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed).toBe('He said "hi"\nline2\ttab\\back');
+  });
+
+  test("json_progress with and without percent", () => {
+    const { stdout } = runLibScript(`json_progress "hello"
+json_progress "halfway" 50`);
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0]).toEqual({ type: "progress", message: "hello" });
+    expect(lines[1]).toEqual({ type: "progress", message: "halfway", percent: 50 });
+  });
+
+  test("json_result requires valid JSON", () => {
+    const { stdout } = runLibScript(`json_result "ok" "14 packages installed"`);
+    expect(JSON.parse(stdout.trim())).toEqual({
+      type: "result",
+      status: "ok",
+      detail: "14 packages installed",
+    });
+  });
+
+  test("json_check with and without detail", () => {
+    const { stdout } = runLibScript(`json_check "zsh" "ok"
+json_check "zimrc" "fail" "missing"`);
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0]).toEqual({ type: "check", label: "zsh", status: "ok", detail: "" });
+    expect(lines[1]).toEqual({ type: "check", label: "zimrc", status: "fail", detail: "missing" });
+  });
+
+  test("json_install default verified is false", () => {
+    const { stdout } = runLibScript(`json_install "uv" "astral.sh"
+json_install "awscli" "aws.amazon.com" true`);
+    const lines = stdout
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0]).toEqual({ type: "install", tool: "uv", source: "astral.sh", verified: false });
+    expect(lines[1]).toEqual({ type: "install", tool: "awscli", source: "aws.amazon.com", verified: true });
+  });
+
+  test("ctx_get reads top-level keys from context", () => {
+    const scriptPath = join(tmpDir, "ctx-get.sh");
+    writeFileSync(
+      scriptPath,
+      `#!/usr/bin/env bash\nsource "${LIB_PATH}"\nread_context\necho "user=$(ctx_get username)"\necho "home=$(ctx_get userHome)"\necho "missing=$(ctx_get nope)"\n`,
+      { mode: 0o755 },
+    );
+    const out = spawnSync("bash", [scriptPath], {
+      encoding: "utf8",
+      input: JSON.stringify({ username: "bob", userHome: "/home/bob" }),
+    });
+    expect(out.stdout).toBe("user=bob\nhome=/home/bob\nmissing=\n");
+  });
+});

--- a/modules/_lib.sh
+++ b/modules/_lib.sh
@@ -1,0 +1,74 @@
+# devlair module shell helpers
+#
+# Each module script sources this library, reads a context JSON object from
+# stdin, and emits JSON Lines events to stdout. stderr is reserved for debug
+# output and is surfaced only when the CLI runs with --verbose.
+#
+# Exit codes: 0 = success, 1 = failure, 2 = skip
+
+set -euo pipefail
+
+CONTEXT=""
+
+# json_escape STRING -- emit a JSON-encoded string (including the quotes).
+# Prefers jq for full correctness; falls back to a minimal sed-based escape
+# that handles backslash, double-quote, newline, carriage return, and tab.
+json_escape() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rn --arg s "$1" '$s'
+  else
+    local s=$1
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    printf '"%s"' "$s"
+  fi
+}
+
+json_progress() {
+  local message=$1 percent=${2:-}
+  if [[ -n "$percent" ]]; then
+    printf '{"type":"progress","message":%s,"percent":%s}\n' "$(json_escape "$message")" "$percent"
+  else
+    printf '{"type":"progress","message":%s}\n' "$(json_escape "$message")"
+  fi
+}
+
+json_result() {
+  local status=$1 detail=${2:-}
+  printf '{"type":"result","status":%s,"detail":%s}\n' \
+    "$(json_escape "$status")" "$(json_escape "$detail")"
+}
+
+json_check() {
+  local label=$1 status=$2 detail=${3:-}
+  printf '{"type":"check","label":%s,"status":%s,"detail":%s}\n' \
+    "$(json_escape "$label")" "$(json_escape "$status")" "$(json_escape "$detail")"
+}
+
+json_install() {
+  local tool=$1 source=$2 verified=${3:-false}
+  printf '{"type":"install","tool":%s,"source":%s,"verified":%s}\n' \
+    "$(json_escape "$tool")" "$(json_escape "$source")" "$verified"
+}
+
+# read_context -- consume all of stdin into the CONTEXT global.
+# Must be called before ctx_get. Aborts with an error if jq is unavailable,
+# since the whole protocol (ctx_get and json_escape) depends on it; silently
+# returning empty values would let modules proceed on broken input.
+read_context() {
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'devlair: jq is required but not installed\n' >&2
+    exit 1
+  fi
+  CONTEXT=$(cat)
+}
+
+# ctx_get KEY -- extract a top-level key from CONTEXT as a string.
+# Returns empty string on missing keys.
+ctx_get() {
+  [[ -z "$CONTEXT" ]] && return 0
+  jq -r --arg k "$1" '.[$k] // empty' <<<"$CONTEXT"
+}


### PR DESCRIPTION
## Summary

Implements the bidirectional JSON protocol between the v2 TypeScript CLI and shell-based module scripts — the foundation for Phase 2 of the v2 rewrite.

- **`modules/_lib.sh`** — shared shell helpers: `json_progress`, `json_result`, `json_check`, `json_install` emit JSON Lines events; `read_context` / `ctx_get` expose the stdin-delivered `SetupContext`. `json_escape` prefers `jq` for correctness with a sed fallback for minimal hosts. `read_context` hard-fails when `jq` is unavailable so modules never run on broken context.
- **`cli/src/lib/runner.ts`** — async generator that spawns module scripts, pipes context JSON to stdin, parses JSON Lines from stdout, and returns a `RunResult { exitCode, status, stderr, timedOut }` with the status derived from the exit code (0→ok, 1→fail, 2→skip). Supports `timeoutMs`, `AbortSignal` cancellation, and an `onStderr` line callback for verbose mode. Uses detached process groups so grandchildren (apt, curl, sleep inside module scripts) are reaped on abort instead of holding stdout open.
- **`cli/src/lib/types.ts`** — adds `ModuleMode` (`"run" | "check"`) and `ModuleExitCode` const.
- **`cli/src/test/runner.test.ts`** — 16 Bun unit tests covering event parsing for all four event types, exit-code→status mapping, context delivery via stdin, malformed-line resilience, stderr capture + streaming, timeout, abort signal, and the `_lib.sh` helpers (including `json_escape` with quotes/newlines/tabs/backslashes).

Closes #39

## Test plan

- [x] `bun test` — 16 pass, 0 fail
- [x] `bun run lint` — biome clean
- [x] `bun run typecheck` — tsc clean
- [ ] Manual smoke test: `echo '{"username":"test","userHome":"/tmp","platform":"linux","wslVersion":null,"config":{}}' | bash -c 'source modules/_lib.sh; read_context; json_progress "hello"; json_result "ok" "done"'` emits valid JSON Lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)