### PR TITLE
feat(cli): module registry, platform detection, and context builder

### DIFF
--- a/cli/src/lib/context.ts
+++ b/cli/src/lib/context.ts
@@ -1,0 +1,28 @@
+import { homedir, userInfo } from "node:os";
+import type { ModuleContext, Platform } from "./types.js";
+
+/**
+ * Resolve the real user behind sudo. Returns [username, homeDir].
+ * Falls back to the current OS user when not running under sudo.
+ */
+export function resolveInvokingUser(): [username: string, homeDir: string] {
+  const sudoUser = process.env.SUDO_USER;
+  if (sudoUser && sudoUser !== "root") {
+    // Under sudo HOME points to root's home. SUDO_HOME is non-standard but
+    // set by some wrappers; fall back to /home/<user> which covers Linux.
+    const home = process.env.SUDO_HOME ?? `/home/${sudoUser}`;
+    return [sudoUser, home];
+  }
+  const info = userInfo({ encoding: "utf8" });
+  return [info.username, info.homedir || homedir()];
+}
+
+/** Build the ModuleContext that gets piped to module scripts via stdin. */
+export function buildModuleContext(
+  platform: Platform,
+  wslVersion: 1 | 2 | null,
+  config: Record<string, unknown> = {},
+): ModuleContext {
+  const [username, userHome] = resolveInvokingUser();
+  return { username, userHome, platform, wslVersion, config };
+}

--- a/cli/src/lib/modules.ts
+++ b/cli/src/lib/modules.ts
@@ -1,0 +1,112 @@
+import type { Platform } from "./types.js";
+
+export const GROUPS = ["core", "network", "coding", "cloud-sync", "ai", "desktop"] as const;
+export type Group = (typeof GROUPS)[number];
+
+export interface ModuleSpec {
+  key: string;
+  label: string;
+  group: Group;
+  deps: string[];
+  reapply: boolean;
+  /** Platforms this module can run on. */
+  platforms: Set<Platform>;
+  /** Platforms where this module runs by default (null = same as `platforms`). */
+  defaultOn: Set<Platform> | null;
+}
+
+function spec(
+  key: string,
+  label: string,
+  group: Group,
+  opts: {
+    deps?: string[];
+    reapply?: boolean;
+    platforms?: Platform[];
+    defaultOn?: Platform[];
+  } = {},
+): ModuleSpec {
+  return {
+    key,
+    label,
+    group,
+    deps: opts.deps ?? [],
+    reapply: opts.reapply ?? false,
+    platforms: new Set(opts.platforms ?? (["linux", "wsl"] as Platform[])),
+    defaultOn: opts.defaultOn !== undefined ? new Set(opts.defaultOn) : null,
+  };
+}
+
+export const MODULE_SPECS: readonly ModuleSpec[] = [
+  spec("system", "System update", "core"),
+  spec("timezone", "Timezone", "core", { platforms: ["linux"] }),
+  spec("tailscale", "Tailscale", "network", { defaultOn: ["linux"] }),
+  spec("ssh", "SSH", "network", { deps: ["tailscale"], platforms: ["linux"] }),
+  spec("firewall", "Firewall + Fail2Ban", "network", { deps: ["ssh"], platforms: ["linux"] }),
+  spec("zsh", "Zsh + Dracula", "core", { reapply: true }),
+  spec("tmux", "tmux", "coding", { reapply: true }),
+  spec("devtools", "Dev tools", "coding", { reapply: true }),
+  spec("rclone", "rclone sync", "cloud-sync", { defaultOn: [] }),
+  spec("github", "GitHub SSH key", "coding"),
+  spec("shell", "Shell aliases", "core", { deps: ["zsh"], reapply: true }),
+  spec("gnome_terminal", "Gnome Terminal Dracula", "desktop", { reapply: true, platforms: ["linux"] }),
+  spec("claude", "Claude Code", "ai", { deps: ["devtools"], reapply: true, defaultOn: [] }),
+  spec("claw", "PicoCLAW Agent", "ai", { deps: ["devtools"], reapply: true, defaultOn: [] }),
+];
+
+export const REAPPLY_KEYS: ReadonlySet<string> = new Set(MODULE_SPECS.filter((s) => s.reapply).map((s) => s.key));
+
+const SPEC_MAP: ReadonlyMap<string, ModuleSpec> = new Map(MODULE_SPECS.map((s) => [s.key, s]));
+
+/**
+ * Assert that MODULE_SPECS is in valid topological (dependency) order.
+ * Throws on unknown deps or forward references.
+ */
+export function validateDag(): void {
+  const seen = new Set<string>();
+  for (const s of MODULE_SPECS) {
+    for (const dep of s.deps) {
+      if (!SPEC_MAP.has(dep)) {
+        throw new Error(`Module '${s.key}' depends on unknown module '${dep}'`);
+      }
+      if (!seen.has(dep)) {
+        throw new Error(`Module '${s.key}' depends on '${dep}' which appears later in MODULE_SPECS`);
+      }
+    }
+    seen.add(s.key);
+  }
+}
+
+// Validate on import — catches ordering bugs early.
+validateDag();
+
+/**
+ * Return ModuleSpecs in dependency-safe order, optionally filtered to `keys`.
+ * Dependencies are auto-expanded when keys is provided.
+ * Modules incompatible with `platform` are excluded when specified.
+ */
+export function resolveOrder(keys?: Set<string>, platform?: Platform): ModuleSpec[] {
+  let filter: Set<string> | undefined = keys;
+  if (filter !== undefined) {
+    const expanded = new Set<string>();
+    const expand = (k: string) => {
+      if (expanded.has(k)) return;
+      expanded.add(k);
+      const s = SPEC_MAP.get(k);
+      if (s) for (const dep of s.deps) expand(dep);
+    };
+    for (const k of filter) expand(k);
+    filter = expanded;
+  }
+
+  let specs = filter === undefined ? [...MODULE_SPECS] : MODULE_SPECS.filter((s) => filter.has(s.key));
+  if (platform !== undefined) {
+    specs = specs.filter((s) => s.platforms.has(platform));
+  }
+  return specs;
+}
+
+/** Return all module keys belonging to the given groups. */
+export function keysForGroups(groups: Set<string>): Set<string> {
+  return new Set(MODULE_SPECS.filter((s) => groups.has(s.group)).map((s) => s.key));
+}

--- a/cli/src/lib/platform.ts
+++ b/cli/src/lib/platform.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import type { Platform } from "./types.js";
+
+/**
+ * Detect the current platform. Checks for WSL first (via environment variable
+ * or /proc/version), then macOS, defaulting to bare Linux.
+ */
+export function detectPlatform(): Platform {
+  if (process.env.WSL_DISTRO_NAME) return "wsl";
+  try {
+    const procVersion = readFileSync("/proc/version", "utf8").toLowerCase();
+    if (procVersion.includes("microsoft")) return "wsl";
+  } catch {
+    // /proc/version doesn't exist (macOS, etc.) — fine.
+  }
+  if (process.platform === "darwin") return "macos";
+  return "linux";
+}
+
+/**
+ * Return 1 or 2 for WSL, null otherwise. WSL2 is identified by "WSL2" or
+ * "microsoft-standard" in /proc/version; anything else is assumed WSL1.
+ */
+export function detectWslVersion(platform?: Platform): 1 | 2 | null {
+  if ((platform ?? detectPlatform()) !== "wsl") return null;
+  try {
+    const procVersion = readFileSync("/proc/version", "utf8");
+    if (procVersion.includes("WSL2") || procVersion.toLowerCase().includes("microsoft-standard")) {
+      return 2;
+    }
+  } catch {
+    // Can't read — assume WSL1.
+  }
+  return 1;
+}

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import { GROUPS, MODULE_SPECS, REAPPLY_KEYS, keysForGroups, resolveOrder, validateDag } from "../lib/modules.js";
+
+describe("MODULE_SPECS", () => {
+  test("has 14 modules", () => {
+    expect(MODULE_SPECS).toHaveLength(14);
+  });
+
+  test("all keys are unique", () => {
+    const keys = MODULE_SPECS.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test("all groups are valid", () => {
+    const groupSet = new Set<string>(GROUPS);
+    for (const s of MODULE_SPECS) {
+      expect(groupSet.has(s.group)).toBe(true);
+    }
+  });
+});
+
+describe("validateDag", () => {
+  test("succeeds on the real MODULE_SPECS (already validated on import)", () => {
+    expect(() => validateDag()).not.toThrow();
+  });
+});
+
+describe("REAPPLY_KEYS", () => {
+  test("matches modules with reapply=true", () => {
+    const expected = new Set(MODULE_SPECS.filter((s) => s.reapply).map((s) => s.key));
+    expect(REAPPLY_KEYS).toEqual(expected);
+  });
+
+  test("includes known reapply modules", () => {
+    for (const key of ["zsh", "tmux", "devtools", "shell", "gnome_terminal", "claude", "claw"]) {
+      expect(REAPPLY_KEYS.has(key)).toBe(true);
+    }
+  });
+});
+
+describe("keysForGroups", () => {
+  test("returns core modules", () => {
+    const keys = keysForGroups(new Set(["core"]));
+    expect(keys).toEqual(new Set(["system", "timezone", "zsh", "shell"]));
+  });
+
+  test("returns network modules", () => {
+    const keys = keysForGroups(new Set(["network"]));
+    expect(keys).toEqual(new Set(["tailscale", "ssh", "firewall"]));
+  });
+
+  test("returns multiple groups", () => {
+    const keys = keysForGroups(new Set(["core", "coding"]));
+    expect(keys).toEqual(new Set(["system", "timezone", "zsh", "shell", "tmux", "devtools", "github"]));
+  });
+
+  test("returns empty set for unknown group", () => {
+    expect(keysForGroups(new Set(["nonexistent"]))).toEqual(new Set());
+  });
+});
+
+describe("resolveOrder", () => {
+  test("returns all 14 modules when no keys are specified", () => {
+    const specs = resolveOrder();
+    expect(specs).toHaveLength(14);
+  });
+
+  test("preserves topological order", () => {
+    const specs = resolveOrder();
+    const keys = specs.map((s) => s.key);
+    // Dependencies must appear before dependents
+    expect(keys.indexOf("tailscale")).toBeLessThan(keys.indexOf("ssh"));
+    expect(keys.indexOf("ssh")).toBeLessThan(keys.indexOf("firewall"));
+    expect(keys.indexOf("zsh")).toBeLessThan(keys.indexOf("shell"));
+    expect(keys.indexOf("devtools")).toBeLessThan(keys.indexOf("claude"));
+    expect(keys.indexOf("devtools")).toBeLessThan(keys.indexOf("claw"));
+  });
+
+  test("auto-expands dependencies", () => {
+    // Requesting just "shell" should pull in "zsh" as a dependency
+    const specs = resolveOrder(new Set(["shell"]));
+    const keys = specs.map((s) => s.key);
+    expect(keys).toContain("zsh");
+    expect(keys).toContain("shell");
+    expect(keys.indexOf("zsh")).toBeLessThan(keys.indexOf("shell"));
+  });
+
+  test("auto-expands transitive dependencies", () => {
+    // "firewall" depends on "ssh" which depends on "tailscale"
+    const specs = resolveOrder(new Set(["firewall"]));
+    const keys = specs.map((s) => s.key);
+    expect(keys).toContain("tailscale");
+    expect(keys).toContain("ssh");
+    expect(keys).toContain("firewall");
+  });
+
+  test("filters by platform", () => {
+    const wslSpecs = resolveOrder(undefined, "wsl");
+    const wslKeys = wslSpecs.map((s) => s.key);
+    // Linux-only modules should be excluded on WSL
+    expect(wslKeys).not.toContain("timezone");
+    expect(wslKeys).not.toContain("ssh");
+    expect(wslKeys).not.toContain("firewall");
+    expect(wslKeys).not.toContain("gnome_terminal");
+    // Cross-platform modules should still be present
+    expect(wslKeys).toContain("system");
+    expect(wslKeys).toContain("zsh");
+    expect(wslKeys).toContain("devtools");
+  });
+
+  test("combines keys + platform filter", () => {
+    // Request firewall on WSL — firewall is linux-only, so result should be empty
+    // even though dependencies would be pulled in
+    const specs = resolveOrder(new Set(["firewall"]), "wsl");
+    const keys = specs.map((s) => s.key);
+    expect(keys).not.toContain("firewall");
+    expect(keys).not.toContain("ssh");
+    // tailscale is linux+wsl, so it stays (it was pulled in as a transitive dep)
+    expect(keys).toContain("tailscale");
+  });
+
+  test("handles empty keys set", () => {
+    const specs = resolveOrder(new Set());
+    expect(specs).toHaveLength(0);
+  });
+
+  test("produces identical ordering to Python version", () => {
+    // The Python MODULE_SPECS order is the canonical topological sort.
+    const expectedOrder = [
+      "system",
+      "timezone",
+      "tailscale",
+      "ssh",
+      "firewall",
+      "zsh",
+      "tmux",
+      "devtools",
+      "rclone",
+      "github",
+      "shell",
+      "gnome_terminal",
+      "claude",
+      "claw",
+    ];
+    const actualOrder = resolveOrder().map((s) => s.key);
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+});

--- a/cli/src/test/platform.test.ts
+++ b/cli/src/test/platform.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { detectPlatform, detectWslVersion } from "../lib/platform.js";
+
+describe("detectPlatform", () => {
+  test("returns a valid platform value", () => {
+    const platform = detectPlatform();
+    expect(["linux", "wsl", "macos"]).toContain(platform);
+  });
+
+  test("returns linux on a standard Linux host (no WSL env)", () => {
+    // This test only makes sense when running on actual Linux (not WSL).
+    // On WSL it will return "wsl" which is also correct.
+    const platform = detectPlatform();
+    if (!process.env.WSL_DISTRO_NAME) {
+      if (process.platform === "linux") {
+        expect(platform).toBe("linux");
+      } else if (process.platform === "darwin") {
+        expect(platform).toBe("macos");
+      }
+    } else {
+      expect(platform).toBe("wsl");
+    }
+  });
+});
+
+describe("detectWslVersion", () => {
+  test("returns null when platform is linux", () => {
+    expect(detectWslVersion("linux")).toBeNull();
+  });
+
+  test("returns null when platform is macos", () => {
+    expect(detectWslVersion("macos")).toBeNull();
+  });
+
+  test("returns 1 or 2 when platform is wsl", () => {
+    // Only meaningful on actual WSL; on other platforms the /proc/version
+    // check either fails or doesn't contain WSL markers, so we skip.
+    if (detectPlatform() === "wsl") {
+      const version = detectWslVersion("wsl");
+      expect(version === 1 || version === 2).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **`cli/src/lib/modules.ts`** — `ModuleSpec` interface and all 14 `MODULE_SPECS` in topological order matching Python v1. `resolveOrder()` with auto-dependency expansion and platform filtering, `keysForGroups()`, `validateDag()` (runs on import for fail-fast), `REAPPLY_KEYS` set.
- **`cli/src/lib/platform.ts`** — `detectPlatform()` (linux/wsl/macos) via `WSL_DISTRO_NAME` env, `/proc/version`, and `process.platform`. `detectWslVersion()` identifies WSL2 via markers in `/proc/version`.
- **`cli/src/lib/context.ts`** — `resolveInvokingUser()` (sudo-aware username + home dir resolution) and `buildModuleContext()` to construct the wire-format `ModuleContext` for module scripts.
- **23 unit tests** covering DAG validation, dependency expansion (direct + transitive), platform filtering, group resolution, ordering parity with Python, and platform detection on the current host.

Closes #41

## Test plan

- [x] `bun test` — 39 tests pass (23 new + 16 from #39)
- [x] `bun run lint` — biome clean
- [x] `bun run typecheck` — tsc clean
- [ ] Verify `resolveOrder()` output matches Python: `bun -e "import {resolveOrder} from './cli/src/lib/modules.js'; console.log(resolveOrder().map(s=>s.key))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)