### PR TITLE
feat(cli): add interactive wizard for init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ SSH hardening, UFW firewall, Fail2Ban, and Tailscale VPN are set up out of the b
   vX.Y.Z
 
   Setup & Health
-    init [--only MOD] [--skip MOD] [--group GRP] [--config FILE]  Set up this machine from scratch
+    init [--only MOD] [--skip MOD] [--group GRP] [--config FILE]  Interactive wizard (or non-interactive with flags)
     doctor [--fix]                      Check system health & fix drift
     upgrade [--no-self]                 Upgrade tools & re-apply configs
     disable-password                    Lock SSH to key-only auth
@@ -99,7 +99,7 @@ SSH hardening, UFW firewall, Fail2Ban, and Tailscale VPN are set up out of the b
 ## Usage examples
 
 ```bash
-# Full setup from scratch
+# Interactive wizard — walks you through group and module selection
 devlair init
 
 # Run specific modules only
@@ -418,9 +418,9 @@ devlair/                # v1 Python CLI (stable)
 cli/                    # v2 TypeScript CLI (alpha)
   src/
     index.tsx           # Ink app entrypoint
-    commands/           # command implementations (planned)
+    commands/           # command implementations (init)
     components/         # Ink UI components (Logo, Help)
-    wizard/             # interactive wizard (planned)
+    wizard/             # interactive wizard (GroupSelect, ModuleSelect, Confirmation)
     lib/                # theme, types, runner, modules, platform detection
 assets/
   logo.svg              # brand mark (dark background)

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -10,7 +10,7 @@ import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { useApp } from "ink";
 import { Box, Text } from "ink";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import YAML from "yaml";
 
 import { Logo } from "../components/Logo.js";
@@ -116,14 +116,11 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
   const { exit } = useApp();
   const exitRef = useRef(exit);
 
-  // Derive a stable identity key from specs so state resets when the spec list changes
-  // (e.g. wizard transitions from [] to the real selection).
-  const specsKey = useMemo(() => specs.map((s) => s.key).join(","), [specs]);
-
   const [modules, setModules] = useState<ModuleRun[]>([]);
   const [done, setDone] = useState(false);
 
   // Re-initialize module state whenever specs change
+  // (wizard transitions from [] to the real selection).
   useEffect(() => {
     setModules(
       specs.map((s) => ({
@@ -135,7 +132,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
       })),
     );
     setDone(false);
-  }, [specsKey]);
+  }, [specs]);
 
   useEffect(() => {
     if (!autoStart || specs.length === 0) return;

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -10,7 +10,7 @@ import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { useApp } from "ink";
 import { Box, Text } from "ink";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import YAML from "yaml";
 
 import { Logo } from "../components/Logo.js";
@@ -116,16 +116,26 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
   const { exit } = useApp();
   const exitRef = useRef(exit);
 
-  const [modules, setModules] = useState<ModuleRun[]>(() =>
-    specs.map((s) => ({
-      key: s.key,
-      label: s.label,
-      status: "pending" as const,
-      detail: "",
-      progressMsg: "",
-    })),
-  );
+  // Derive a stable identity key from specs so state resets when the spec list changes
+  // (e.g. wizard transitions from [] to the real selection).
+  const specsKey = useMemo(() => specs.map((s) => s.key).join(","), [specs]);
+
+  const [modules, setModules] = useState<ModuleRun[]>([]);
   const [done, setDone] = useState(false);
+
+  // Re-initialize module state whenever specs change
+  useEffect(() => {
+    setModules(
+      specs.map((s) => ({
+        key: s.key,
+        label: s.label,
+        status: "pending" as const,
+        detail: "",
+        progressMsg: "",
+      })),
+    );
+    setDone(false);
+  }, [specsKey]);
 
   useEffect(() => {
     if (!autoStart || specs.length === 0) return;

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -1,8 +1,9 @@
 /**
- * devlair init — non-interactive machine provisioning.
+ * devlair init — machine provisioning with optional interactive wizard.
  *
- * Resolves module order from CLI flags, executes each module sequentially
- * via the shell runner, and renders live progress with Ink.
+ * When CLI flags are provided (--only, --group, --skip, --config),
+ * runs non-interactively. Otherwise launches the wizard:
+ * group select -> module select -> confirmation -> execution.
  */
 
 import { readFileSync } from "node:fs";
@@ -17,14 +18,18 @@ import { type ModuleRun, Progress } from "../components/Progress.js";
 import { OptionalHint, Summary } from "../components/Summary.js";
 import type { InitFlags } from "../lib/args.js";
 import { buildModuleContext } from "../lib/context.js";
+import type { Group, ModuleSpec } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
 import { runModule } from "../lib/runner.js";
 import { selectModules } from "../lib/selection.js";
 import { D_COMMENT, D_FG, D_PINK, D_PURPLE } from "../lib/theme.js";
-import type { Status } from "../lib/types.js";
+import type { ModuleContext, Status } from "../lib/types.js";
+import { Confirmation } from "../wizard/Confirmation.js";
+import { GroupSelect } from "../wizard/GroupSelect.js";
+import { ModuleSelect } from "../wizard/ModuleSelect.js";
 
-type Phase = "running" | "done";
+type Phase = "wizard-groups" | "wizard-modules" | "wizard-confirm" | "running" | "done";
 
 interface ProfileData {
   name?: string;
@@ -100,11 +105,85 @@ function PlatformSkipped({ names }: { names: string }) {
   );
 }
 
-export function InitView({ flags }: { flags: InitFlags }) {
-  const { exit } = useApp();
+/** Returns true when the user provided explicit selection flags. */
+function hasExplicitFlags(flags: InitFlags): boolean {
+  return flags.only !== null || flags.group !== null || flags.skip.size > 0 || flags.config !== null;
+}
 
-  // Compute platform, context, and selection exactly once (lazy init).
-  // These involve filesystem reads and process spawning — must not re-run on every render.
+// ── Execution engine (shared by wizard and non-interactive paths) ──────────
+
+function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoStart: boolean) {
+  const { exit } = useApp();
+  const exitRef = useRef(exit);
+
+  const [modules, setModules] = useState<ModuleRun[]>(() =>
+    specs.map((s) => ({
+      key: s.key,
+      label: s.label,
+      status: "pending" as const,
+      detail: "",
+      progressMsg: "",
+    })),
+  );
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (!autoStart || specs.length === 0) return;
+
+    const abortController = new AbortController();
+
+    async function run() {
+      for (let i = 0; i < specs.length; i++) {
+        if (abortController.signal.aborted) break;
+        const spec = specs[i];
+
+        setModules((prev) => prev.map((m, j) => (j === i ? { ...m, status: "running" } : m)));
+
+        let finalStatus: Status = "fail";
+        let finalDetail = "";
+
+        try {
+          const scriptPath = moduleScriptPath(spec.key);
+          const iter = runModule(scriptPath, context, "run", { signal: abortController.signal });
+
+          while (true) {
+            const { value, done: iterDone } = await iter.next();
+            if (iterDone) {
+              finalStatus = value.status;
+              break;
+            }
+            if (value.type === "progress") {
+              setModules((prev) => prev.map((m, j) => (j === i ? { ...m, progressMsg: value.message } : m)));
+            } else if (value.type === "result") {
+              finalDetail = value.detail;
+            }
+          }
+        } catch (err) {
+          finalStatus = "fail";
+          finalDetail = err instanceof Error ? err.message : String(err);
+        }
+
+        setModules((prev) =>
+          prev.map((m, j) => (j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "" } : m)),
+        );
+      }
+
+      setDone(true);
+      setTimeout(() => exitRef.current(), 0);
+    }
+
+    run();
+    return () => {
+      abortController.abort();
+    };
+  }, [specs, context, autoStart]);
+
+  return { modules, done };
+}
+
+// ── Non-interactive init (flags provided) ──────────────────────────────────
+
+function NonInteractiveInit({ flags }: { flags: InitFlags }) {
   const [initState] = useState(() => {
     const platform = detectPlatform();
     const wslVersion = detectWslVersion(platform);
@@ -117,83 +196,98 @@ export function InitView({ flags }: { flags: InitFlags }) {
   });
 
   const { platform, context, selected, optional, skippedNames, profile } = initState;
-
-  const exitRef = useRef(exit);
-
-  const [modules, setModules] = useState<ModuleRun[]>(() =>
-    selected.map((s) => ({
-      key: s.key,
-      label: s.label,
-      status: "pending" as const,
-      detail: "",
-      progressMsg: "",
-    })),
-  );
-  const [phase, setPhase] = useState<Phase>("running");
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    const specs = selected;
-    const ctx = context;
-
-    async function run() {
-      for (let i = 0; i < specs.length; i++) {
-        if (abortController.signal.aborted) break;
-        const spec = specs[i];
-
-        // Mark as running
-        setModules((prev) => prev.map((m, j) => (j === i ? { ...m, status: "running" } : m)));
-
-        let finalStatus: Status = "fail";
-        let finalDetail = "";
-
-        try {
-          const scriptPath = moduleScriptPath(spec.key);
-          const iter = runModule(scriptPath, ctx, "run", { signal: abortController.signal });
-
-          while (true) {
-            const { value, done } = await iter.next();
-            if (done) {
-              finalStatus = value.status;
-              break;
-            }
-            // Update progress message for the running module
-            if (value.type === "progress") {
-              setModules((prev) => prev.map((m, j) => (j === i ? { ...m, progressMsg: value.message } : m)));
-            } else if (value.type === "result") {
-              finalDetail = value.detail;
-            }
-          }
-        } catch (err) {
-          finalStatus = "fail";
-          finalDetail = err instanceof Error ? err.message : String(err);
-        }
-
-        // Mark with final status
-        setModules((prev) =>
-          prev.map((m, j) => (j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "" } : m)),
-        );
-      }
-
-      setPhase("done");
-      // Give Ink one more render cycle before exiting
-      setTimeout(() => exitRef.current(), 0);
-    }
-
-    run();
-    return () => {
-      abortController.abort();
-    };
-  }, [selected, context]);
+  const { modules, done } = useModuleExecution(selected, context, true);
 
   return (
     <Box flexDirection="column">
       <InitHeader username={context.username} host={hostname()} platform={platform} profileName={profile?.name} />
       <PlatformSkipped names={skippedNames} />
       <Progress modules={modules} total={selected.length} />
-      {phase === "done" && <Summary modules={modules} />}
-      {phase === "done" && <OptionalHint specs={optional} />}
+      {done && <Summary modules={modules} />}
+      {done && <OptionalHint specs={optional} />}
       <Text>{""}</Text>
     </Box>
   );
+}
+
+// ── Interactive wizard init (no flags) ─────────────────────────────────────
+
+function WizardInit() {
+  const { exit } = useApp();
+
+  const [envState] = useState(() => {
+    const platform = detectPlatform();
+    const wslVersion = detectWslVersion(platform);
+    const context = buildModuleContext(platform, wslVersion);
+    return { platform, wslVersion, context };
+  });
+
+  const { platform, context } = envState;
+
+  const [phase, setPhase] = useState<Phase>("wizard-groups");
+  const [selectedGroups, setSelectedGroups] = useState<Set<Group>>(new Set());
+  const [selectedModules, setSelectedModules] = useState<ModuleSpec[]>([]);
+
+  const cancel = () => {
+    exit();
+  };
+
+  // Execution state — only populated after wizard confirmation
+  const { modules, done } = useModuleExecution(selectedModules, context, phase === "running" || phase === "done");
+
+  return (
+    <Box flexDirection="column">
+      <InitHeader username={context.username} host={hostname()} platform={platform} />
+
+      {phase === "wizard-groups" && (
+        <GroupSelect
+          onConfirm={(groups) => {
+            setSelectedGroups(groups);
+            setPhase("wizard-modules");
+          }}
+          onCancel={cancel}
+        />
+      )}
+
+      {phase === "wizard-modules" && (
+        <ModuleSelect
+          groups={selectedGroups}
+          platform={platform}
+          onConfirm={(mods) => {
+            setSelectedModules(mods);
+            setPhase("wizard-confirm");
+          }}
+          onBack={() => setPhase("wizard-groups")}
+          onCancel={cancel}
+        />
+      )}
+
+      {phase === "wizard-confirm" && (
+        <Confirmation
+          modules={selectedModules}
+          onConfirm={() => setPhase("running")}
+          onBack={() => setPhase("wizard-modules")}
+          onCancel={cancel}
+        />
+      )}
+
+      {(phase === "running" || phase === "done") && (
+        <>
+          <Progress modules={modules} total={selectedModules.length} />
+          {done && <Summary modules={modules} />}
+        </>
+      )}
+
+      <Text>{""}</Text>
+    </Box>
+  );
+}
+
+// ── Exported view — decides wizard vs non-interactive ──────────────────────
+
+export function InitView({ flags }: { flags: InitFlags }) {
+  if (hasExplicitFlags(flags)) {
+    return <NonInteractiveInit flags={flags} />;
+  }
+  return <WizardInit />;
 }

--- a/cli/src/test/wizard.test.ts
+++ b/cli/src/test/wizard.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for wizard selection logic and helpers.
+ * Tests the pure logic used by wizard components without rendering Ink.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { GROUPS, MODULE_SPECS, type ModuleSpec, keysForGroups, resolveOrder } from "../lib/modules.js";
+
+// ── GroupSelect logic ──────────────────────────────────────────────────────
+
+describe("GroupSelect logic", () => {
+  test("all groups are defined", () => {
+    expect(GROUPS).toEqual(["core", "network", "coding", "cloud-sync", "ai", "desktop"]);
+  });
+
+  test("every module belongs to a known group", () => {
+    const groupSet = new Set<string>(GROUPS);
+    for (const spec of MODULE_SPECS) {
+      expect(groupSet.has(spec.group)).toBe(true);
+    }
+  });
+
+  test("core group always has modules", () => {
+    const coreKeys = keysForGroups(new Set(["core"]));
+    expect(coreKeys.size).toBeGreaterThan(0);
+    expect(coreKeys).toContain("system");
+    expect(coreKeys).toContain("zsh");
+    expect(coreKeys).toContain("shell");
+  });
+
+  test("keysForGroups returns correct module sets", () => {
+    const codingKeys = keysForGroups(new Set(["coding"]));
+    expect(codingKeys).toContain("tmux");
+    expect(codingKeys).toContain("devtools");
+    expect(codingKeys).toContain("github");
+    expect(codingKeys).not.toContain("system"); // system is core
+
+    const aiKeys = keysForGroups(new Set(["ai"]));
+    expect(aiKeys).toContain("claude");
+    expect(aiKeys.size).toBe(1);
+  });
+});
+
+// ── ModuleSelect logic (dependency expansion) ──────────────────────────────
+
+describe("ModuleSelect dependency expansion", () => {
+  test("selecting a module auto-expands its dependencies", () => {
+    const keys = new Set(["shell"]); // depends on zsh
+    const resolved = resolveOrder(keys);
+    const resolvedKeys = resolved.map((s) => s.key);
+    expect(resolvedKeys).toContain("zsh");
+    expect(resolvedKeys).toContain("shell");
+  });
+
+  test("deep dependency chain is fully expanded", () => {
+    const keys = new Set(["firewall"]); // firewall -> ssh -> tailscale
+    const resolved = resolveOrder(keys);
+    const resolvedKeys = resolved.map((s) => s.key);
+    expect(resolvedKeys).toContain("tailscale");
+    expect(resolvedKeys).toContain("ssh");
+    expect(resolvedKeys).toContain("firewall");
+    expect(resolvedKeys.indexOf("tailscale")).toBeLessThan(resolvedKeys.indexOf("ssh"));
+    expect(resolvedKeys.indexOf("ssh")).toBeLessThan(resolvedKeys.indexOf("firewall"));
+  });
+
+  test("claude depends on devtools", () => {
+    const keys = new Set(["claude"]);
+    const resolved = resolveOrder(keys);
+    const resolvedKeys = resolved.map((s) => s.key);
+    expect(resolvedKeys).toContain("devtools");
+    expect(resolvedKeys).toContain("claude");
+    expect(resolvedKeys.indexOf("devtools")).toBeLessThan(resolvedKeys.indexOf("claude"));
+  });
+
+  test("no duplicates when selecting module and its dependency", () => {
+    const keys = new Set(["zsh", "shell"]);
+    const resolved = resolveOrder(keys);
+    const resolvedKeys = resolved.map((s) => s.key);
+    const unique = new Set(resolvedKeys);
+    expect(resolvedKeys.length).toBe(unique.size);
+  });
+});
+
+// ── Platform filtering in module select ────────────────────────────────────
+
+describe("ModuleSelect platform filtering", () => {
+  test("linux-only modules are excluded on WSL", () => {
+    const allKeys = new Set(MODULE_SPECS.map((s) => s.key));
+    const resolved = resolveOrder(allKeys, "wsl");
+    const resolvedKeys = new Set(resolved.map((s) => s.key));
+    expect(resolvedKeys.has("timezone")).toBe(false);
+    expect(resolvedKeys.has("ssh")).toBe(false);
+    expect(resolvedKeys.has("firewall")).toBe(false);
+    expect(resolvedKeys.has("gnome_terminal")).toBe(false);
+  });
+
+  test("cross-platform modules are available on WSL", () => {
+    const allKeys = new Set(MODULE_SPECS.map((s) => s.key));
+    const resolved = resolveOrder(allKeys, "wsl");
+    const resolvedKeys = new Set(resolved.map((s) => s.key));
+    expect(resolvedKeys.has("system")).toBe(true);
+    expect(resolvedKeys.has("zsh")).toBe(true);
+    expect(resolvedKeys.has("tmux")).toBe(true);
+    expect(resolvedKeys.has("devtools")).toBe(true);
+  });
+
+  test("platform filter combined with key selection", () => {
+    // Select network group modules on WSL — only tailscale should survive
+    const networkKeys = keysForGroups(new Set(["network"]));
+    const resolved = resolveOrder(networkKeys, "wsl");
+    const resolvedKeys = resolved.map((s) => s.key);
+    expect(resolvedKeys).toContain("tailscale");
+    expect(resolvedKeys).not.toContain("ssh");
+    expect(resolvedKeys).not.toContain("firewall");
+  });
+});
+
+// ── Confirmation logic (module ordering) ────────────────────────────────────
+
+describe("Confirmation module ordering", () => {
+  test("modules are in dependency-safe order", () => {
+    const keys = new Set(["shell", "claude", "firewall"]);
+    const resolved = resolveOrder(keys, "linux");
+    const resolvedKeys = resolved.map((s) => s.key);
+
+    // Check all dependency constraints are met
+    for (const spec of resolved) {
+      const specIdx = resolvedKeys.indexOf(spec.key);
+      for (const dep of spec.deps) {
+        const depIdx = resolvedKeys.indexOf(dep);
+        if (depIdx >= 0) {
+          expect(depIdx).toBeLessThan(specIdx);
+        }
+      }
+    }
+  });
+
+  test("grouping by group preserves all modules", () => {
+    const keys = new Set(MODULE_SPECS.map((s) => s.key));
+    const resolved = resolveOrder(keys, "linux");
+
+    // Group by group (simulates Confirmation component logic)
+    const byGroup = new Map<string, ModuleSpec[]>();
+    for (const mod of resolved) {
+      const list = byGroup.get(mod.group) ?? [];
+      list.push(mod);
+      byGroup.set(mod.group, list);
+    }
+
+    // All resolved modules should appear in exactly one group
+    let total = 0;
+    for (const mods of byGroup.values()) {
+      total += mods.length;
+    }
+    expect(total).toBe(resolved.length);
+  });
+});
+
+// ── Wizard flow state transitions ──────────────────────────────────────────
+
+describe("wizard flow helpers", () => {
+  test("hasExplicitFlags detects no-flag state", () => {
+    // Simulates the logic in init.tsx
+    function hasExplicitFlags(flags: {
+      only: Set<string> | null;
+      skip: Set<string>;
+      group: Set<string> | null;
+      config: string | null;
+    }): boolean {
+      return flags.only !== null || flags.group !== null || flags.skip.size > 0 || flags.config !== null;
+    }
+
+    expect(hasExplicitFlags({ only: null, skip: new Set(), group: null, config: null })).toBe(false);
+    expect(hasExplicitFlags({ only: new Set(["zsh"]), skip: new Set(), group: null, config: null })).toBe(true);
+    expect(hasExplicitFlags({ only: null, skip: new Set(["tmux"]), group: null, config: null })).toBe(true);
+    expect(hasExplicitFlags({ only: null, skip: new Set(), group: new Set(["core"]), config: null })).toBe(true);
+    expect(hasExplicitFlags({ only: null, skip: new Set(), group: null, config: "setup.yaml" })).toBe(true);
+  });
+
+  test("findAutoExpanded detects new dependencies", () => {
+    // Simulates the logic in ModuleSelect
+    function findAutoExpanded(selectedKeys: Set<string>): string[] {
+      const resolved = resolveOrder(selectedKeys);
+      return resolved.map((s) => s.key).filter((k) => !selectedKeys.has(k));
+    }
+
+    // shell depends on zsh — selecting shell without zsh should auto-expand
+    expect(findAutoExpanded(new Set(["shell"]))).toContain("zsh");
+
+    // Selecting both should expand nothing
+    expect(findAutoExpanded(new Set(["shell", "zsh"]))).toEqual([]);
+
+    // firewall -> ssh -> tailscale
+    const expanded = findAutoExpanded(new Set(["firewall"]));
+    expect(expanded).toContain("ssh");
+    expect(expanded).toContain("tailscale");
+  });
+});

--- a/cli/src/wizard/Confirmation.tsx
+++ b/cli/src/wizard/Confirmation.tsx
@@ -4,8 +4,7 @@
  */
 
 import { Box, Text, useInput } from "ink";
-import type { Group } from "../lib/modules.js";
-import type { ModuleSpec } from "../lib/modules.js";
+import type { Group, ModuleSpec } from "../lib/modules.js";
 import { D_COMMENT, D_CYAN, D_GREEN, D_PINK, D_PURPLE } from "../lib/theme.js";
 
 export interface ConfirmationProps {

--- a/cli/src/wizard/Confirmation.tsx
+++ b/cli/src/wizard/Confirmation.tsx
@@ -1,0 +1,86 @@
+/**
+ * Wizard step 3 — summary table of selected modules.
+ * Press Enter to start execution, q to cancel.
+ */
+
+import { Box, Text, useInput } from "ink";
+import type { Group } from "../lib/modules.js";
+import type { ModuleSpec } from "../lib/modules.js";
+import { D_COMMENT, D_CYAN, D_GREEN, D_PINK, D_PURPLE } from "../lib/theme.js";
+
+export interface ConfirmationProps {
+  modules: ModuleSpec[];
+  onConfirm: () => void;
+  onBack: () => void;
+  onCancel: () => void;
+}
+
+export function Confirmation({ modules, onConfirm, onBack, onCancel }: ConfirmationProps) {
+  useInput((input, key) => {
+    if (key.return) {
+      onConfirm();
+    } else if (key.escape || key.backspace || key.delete) {
+      onBack();
+    } else if (input === "q") {
+      onCancel();
+    }
+  });
+
+  // Group modules by their group for display
+  const byGroup = new Map<Group, ModuleSpec[]>();
+  for (const mod of modules) {
+    const list = byGroup.get(mod.group) ?? [];
+    list.push(mod);
+    byGroup.set(mod.group, list);
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={D_PINK} bold>
+          {"  "}Ready to provision
+        </Text>
+        <Text color={D_COMMENT}>
+          {"  "}
+          {modules.length} modules selected
+        </Text>
+      </Box>
+
+      {[...byGroup.entries()].map(([group, specs]) => (
+        <Box key={group} flexDirection="column">
+          <Box>
+            <Text color={D_CYAN} bold>
+              {"    "}
+              {group}
+            </Text>
+          </Box>
+          {specs.map((spec, i) => (
+            <Box key={spec.key}>
+              <Text color={D_GREEN}>
+                {"      "}
+                {i === specs.length - 1 ? "└" : "├"}{" "}
+              </Text>
+              <Text>{spec.label}</Text>
+              <Text color={D_COMMENT}> ({spec.key})</Text>
+            </Box>
+          ))}
+        </Box>
+      ))}
+
+      <Box marginTop={1} flexDirection="column">
+        <Box>
+          <Text>{"  "}</Text>
+          <Text color={D_PURPLE}>Press </Text>
+          <Text color={D_GREEN} bold>
+            Enter
+          </Text>
+          <Text color={D_PURPLE}> to start provisioning</Text>
+        </Box>
+        <Box>
+          <Text>{"  "}</Text>
+          <Text color={D_COMMENT}>esc = back, q = cancel</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/cli/src/wizard/GroupSelect.tsx
+++ b/cli/src/wizard/GroupSelect.tsx
@@ -1,0 +1,91 @@
+/**
+ * Wizard step 1 — multi-select checkboxes for module groups.
+ * Core is always selected and cannot be deselected.
+ */
+
+import { Box, Text, useInput } from "ink";
+import { useState } from "react";
+import { GROUPS, type Group, MODULE_SPECS } from "../lib/modules.js";
+import { D_COMMENT, D_GREEN, D_PINK, D_PURPLE } from "../lib/theme.js";
+
+const GROUP_DESCRIPTIONS: Record<Group, string> = {
+  core: "System update, timezone, Zsh, shell aliases",
+  network: "Tailscale, SSH, firewall + Fail2Ban",
+  coding: "tmux, dev tools (Docker, Node, Python, etc.), GitHub SSH key",
+  "cloud-sync": "rclone cloud sync",
+  ai: "Claude Code AI assistant",
+  desktop: "Gnome Terminal Dracula theme",
+};
+
+function moduleCountForGroup(group: Group): number {
+  return MODULE_SPECS.filter((s) => s.group === group).length;
+}
+
+export interface GroupSelectProps {
+  onConfirm: (groups: Set<Group>) => void;
+  onCancel: () => void;
+}
+
+export function GroupSelect({ onConfirm, onCancel }: GroupSelectProps) {
+  const [cursor, setCursor] = useState(0);
+  const [selected, setSelected] = useState<Set<Group>>(() => new Set(GROUPS));
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setCursor((c) => (c > 0 ? c - 1 : GROUPS.length - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => (c < GROUPS.length - 1 ? c + 1 : 0));
+    } else if (input === " ") {
+      const group = GROUPS[cursor];
+      if (group === "core") return; // core cannot be deselected
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(group)) next.delete(group);
+        else next.add(group);
+        return next;
+      });
+    } else if (key.return) {
+      onConfirm(selected);
+    } else if (input === "q") {
+      onCancel();
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={D_PINK} bold>
+          {"  "}Select module groups
+        </Text>
+        <Text color={D_COMMENT}> (space = toggle, enter = next, q = cancel)</Text>
+      </Box>
+
+      {GROUPS.map((group, i) => {
+        const isCore = group === "core";
+        const isSelected = selected.has(group);
+        const isCursor = i === cursor;
+        const count = moduleCountForGroup(group);
+
+        const pointer = isCursor ? ">" : " ";
+        const checkbox = isSelected ? "[x]" : "[ ]";
+        const nameColor = isCore ? D_GREEN : isCursor ? D_PURPLE : undefined;
+
+        return (
+          <Box key={group}>
+            <Text color={D_PURPLE}>{`  ${pointer} `}</Text>
+            <Text color={isSelected ? D_GREEN : D_COMMENT}>{checkbox}</Text>
+            <Text> </Text>
+            <Text color={nameColor} bold={isCursor}>
+              {group.padEnd(12)}
+            </Text>
+            <Text color={D_COMMENT}>
+              {`(${count} modules) `}
+              {GROUP_DESCRIPTIONS[group]}
+            </Text>
+            {isCore && <Text color={D_COMMENT}> (required)</Text>}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/cli/src/wizard/ModuleSelect.tsx
+++ b/cli/src/wizard/ModuleSelect.tsx
@@ -1,0 +1,153 @@
+/**
+ * Wizard step 2 — per-module toggles within selected groups.
+ * Shows dependency auto-expansion warnings and platform compatibility.
+ */
+
+import { Box, Text, useInput } from "ink";
+import { useState } from "react";
+import { type Group, MODULE_SPECS, type ModuleSpec, resolveOrder } from "../lib/modules.js";
+import { D_COMMENT, D_CYAN, D_GREEN, D_ORANGE, D_PINK, D_PURPLE } from "../lib/theme.js";
+import type { Platform } from "../lib/types.js";
+
+export interface ModuleSelectProps {
+  groups: Set<Group>;
+  platform: Platform;
+  onConfirm: (modules: ModuleSpec[]) => void;
+  onBack: () => void;
+  onCancel: () => void;
+}
+
+interface ModuleRow {
+  spec: ModuleSpec;
+  platformOk: boolean;
+}
+
+/**
+ * Given a set of selected module keys, expand dependencies and return
+ * any keys that were auto-added (not in the original set).
+ */
+function findAutoExpanded(selectedKeys: Set<string>): string[] {
+  const resolved = resolveOrder(selectedKeys);
+  return resolved.map((s) => s.key).filter((k) => !selectedKeys.has(k));
+}
+
+export function ModuleSelect({ groups, platform, onConfirm, onBack, onCancel }: ModuleSelectProps) {
+  // Build the list of modules for the selected groups
+  const rows: ModuleRow[] = MODULE_SPECS.filter((s) => groups.has(s.group)).map((s) => ({
+    spec: s,
+    platformOk: s.platforms.has(platform),
+  }));
+
+  const [cursor, setCursor] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    // Default: select all platform-compatible modules in selected groups
+    return new Set(rows.filter((r) => r.platformOk).map((r) => r.spec.key));
+  });
+  const [depWarning, setDepWarning] = useState<string | null>(null);
+
+  useInput((input, key) => {
+    if (key.upArrow) {
+      setCursor((c) => (c > 0 ? c - 1 : rows.length - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => (c < rows.length - 1 ? c + 1 : 0));
+    } else if (input === " ") {
+      const row = rows[cursor];
+      if (!row.platformOk) return; // can't toggle platform-incompatible modules
+
+      setSelected((prev) => {
+        const next = new Set(prev);
+        if (next.has(row.spec.key)) {
+          next.delete(row.spec.key);
+          setDepWarning(null);
+        } else {
+          next.add(row.spec.key);
+          // Check if this triggers dependency auto-expansion
+          const autoExpanded = findAutoExpanded(next);
+          if (autoExpanded.length > 0) {
+            for (const k of autoExpanded) next.add(k);
+            setDepWarning(`Auto-added dependencies: ${autoExpanded.join(", ")}`);
+          } else {
+            setDepWarning(null);
+          }
+        }
+        return next;
+      });
+    } else if (key.return) {
+      const finalModules = resolveOrder(selected, platform);
+      onConfirm(finalModules);
+    } else if (key.escape || key.backspace || key.delete) {
+      onBack();
+    } else if (input === "q") {
+      onCancel();
+    }
+  });
+
+  // Group the rows visually by group
+  let lastGroup: Group | null = null;
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={D_PINK} bold>
+          {"  "}Select modules
+        </Text>
+        <Text color={D_COMMENT}> (space = toggle, enter = confirm, esc = back, q = cancel)</Text>
+      </Box>
+
+      {rows.map((row, i) => {
+        const showGroupHeader = row.spec.group !== lastGroup;
+        lastGroup = row.spec.group;
+
+        const isCursor = i === cursor;
+        const isSelected = selected.has(row.spec.key);
+        const pointer = isCursor ? ">" : " ";
+
+        let checkbox: string;
+        let checkColor: string;
+        if (!row.platformOk) {
+          checkbox = "[-]";
+          checkColor = D_COMMENT;
+        } else {
+          checkbox = isSelected ? "[x]" : "[ ]";
+          checkColor = isSelected ? D_GREEN : D_COMMENT;
+        }
+
+        const nameColor = !row.platformOk ? D_COMMENT : isCursor ? D_PURPLE : undefined;
+
+        return (
+          <Box key={row.spec.key} flexDirection="column">
+            {showGroupHeader && (
+              <Box marginTop={i > 0 ? 1 : 0}>
+                <Text color={D_CYAN} bold>
+                  {"    "}
+                  {row.spec.group}
+                </Text>
+              </Box>
+            )}
+            <Box>
+              <Text color={D_PURPLE}>{`  ${pointer} `}</Text>
+              <Text color={checkColor}>{checkbox}</Text>
+              <Text> </Text>
+              <Text color={nameColor} bold={isCursor}>
+                {row.spec.key.padEnd(16)}
+              </Text>
+              <Text color={row.platformOk ? undefined : D_COMMENT}>{row.spec.label}</Text>
+              {!row.platformOk && <Text color={D_COMMENT}> (not available on {platform})</Text>}
+              {row.spec.deps.length > 0 && row.platformOk && (
+                <Text color={D_COMMENT}> (requires: {row.spec.deps.join(", ")})</Text>
+              )}
+            </Box>
+          </Box>
+        );
+      })}
+
+      {depWarning && (
+        <Box marginTop={1}>
+          <Text color={D_ORANGE}>
+            {"  "}⚠ {depWarning}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/cli/src/wizard/ModuleSelect.tsx
+++ b/cli/src/wizard/ModuleSelect.tsx
@@ -32,11 +32,13 @@ function findAutoExpanded(selectedKeys: Set<string>): string[] {
 }
 
 export function ModuleSelect({ groups, platform, onConfirm, onBack, onCancel }: ModuleSelectProps) {
-  // Build the list of modules for the selected groups
-  const rows: ModuleRow[] = MODULE_SPECS.filter((s) => groups.has(s.group)).map((s) => ({
-    spec: s,
-    platformOk: s.platforms.has(platform),
-  }));
+  // Build the list of modules for the selected groups (once — groups/platform are stable)
+  const [rows] = useState<ModuleRow[]>(() =>
+    MODULE_SPECS.filter((s) => groups.has(s.group)).map((s) => ({
+      spec: s,
+      platformOk: s.platforms.has(platform),
+    })),
+  );
 
   const [cursor, setCursor] = useState(0);
   const [selected, setSelected] = useState<Set<string>>(() => {
@@ -82,9 +84,6 @@ export function ModuleSelect({ groups, platform, onConfirm, onBack, onCancel }: 
     }
   });
 
-  // Group the rows visually by group
-  let lastGroup: Group | null = null;
-
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
@@ -95,8 +94,7 @@ export function ModuleSelect({ groups, platform, onConfirm, onBack, onCancel }: 
       </Box>
 
       {rows.map((row, i) => {
-        const showGroupHeader = row.spec.group !== lastGroup;
-        lastGroup = row.spec.group;
+        const showGroupHeader = i === 0 || row.spec.group !== rows[i - 1].spec.group;
 
         const isCursor = i === cursor;
         const isSelected = selected.has(row.spec.key);


### PR DESCRIPTION
## Summary
- Add 3-step interactive wizard when `devlair init` is run without CLI flags: group selection → module selection → confirmation → execution
- `GroupSelect` — multi-select checkboxes for module groups (core always on, cannot deselect), with descriptions and module counts
- `ModuleSelect` — per-module toggles grouped by category, with dependency auto-expansion warnings and platform incompatibility markers
- `Confirmation` — summary tree of selected modules with Enter to start / Esc to go back / q to cancel
- Refactored init command: extracted `useModuleExecution` hook shared by wizard and non-interactive paths
- Non-interactive mode (--only, --group, --skip, --config) preserved with identical behavior

Closes #43

## Test plan
- [x] `sudo devlair init` (no flags) launches interactive wizard
- [x] Group selection shows all 6 groups with descriptions and module counts
- [x] Core group cannot be deselected
- [x] Module selection shows dependency info and auto-expands dependencies with warning
- [x] Platform-incompatible modules shown as disabled (e.g. timezone on WSL)
- [x] Confirmation screen shows module tree grouped by category
- [x] Enter on confirmation starts execution with Progress display
- [x] Esc navigates back through wizard steps, q cancels
- [x] `sudo devlair init --group core` bypasses wizard (non-interactive)
- [x] `bun test` passes (92 tests including new wizard tests)
- [x] `bun run typecheck` and `bun run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)