### PR TITLE
fix(skills): /pr assigns issue and PR to the developer running it

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,6 +7,8 @@ allowed-tools: Bash, Read, Grep, Glob
 
 You are creating a pull request that follows the devlair SDLC practices. Every PR must have a linked issue, be assigned, and be tracked on the project board.
 
+**Assignment rule:** the linked issue AND the PR must be assigned to the developer running this command. Always pass `--assignee @me` (gh resolves it to the authenticated user) — never hardcode a username. This applies whether the issue is newly created or already existed.
+
 ### Argument parsing
 
 Parse `$ARGUMENTS` for:
@@ -27,13 +29,14 @@ Run these in parallel:
 ### Step 2: Ensure an issue exists
 
 If an issue number was provided in `$ARGUMENTS`:
-1. Verify it exists: `gh issue view <number>`.
+1. Verify it exists: `gh issue view <number> --json number,assignees`.
 2. If it doesn't exist, stop and report the error.
+3. If the current user is not already among `assignees`, attach them: `gh issue edit <number> --add-assignee @me`. Never remove existing assignees.
 
 If no issue number was provided:
 1. Analyze the commits and diff to understand the scope of work.
 2. Draft an issue title and body describing the work.
-3. Create it: `gh issue create --title "..." --body "..." --assignee ettoreaquino`.
+3. Create it: `gh issue create --title "..." --body "..." --assignee @me`.
 4. Add the issue to the project board as **In Progress**:
    ```
    gh project item-add 2 --owner ettoreaquino --url <issue-url>
@@ -70,7 +73,7 @@ If no issue number was provided:
 
    🤖 Generated with [Claude Code](https://claude.com/claude-code)
    EOF
-   )" --assignee ettoreaquino
+   )" --assignee @me
    ```
 
 ### Step 5: Add PR to project board


### PR DESCRIPTION
## Summary
- `.claude/commands/pr.md` now uses `--assignee @me` for both `gh issue create` and `gh pr create` so the skill works for any developer (no hardcoded usernames).
- Existing-issue path reads `assignees` and runs `gh issue edit <N> --add-assignee @me` when the developer isn't already attached. Never removes existing assignees.
- Added an explicit "Assignment rule" near the top of the skill so the intent is documented.

Closes #61

## Test plan
- [ ] Run `/pr` against an existing unassigned issue → developer is added as assignee, existing assignees preserved.
- [ ] Run `/pr` with no args → newly created issue is assigned to the developer.
- [ ] Created PR is assigned to the developer in both flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)