### PR TITLE
fix(release): exclude cli/ from v1 Python release scope

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "exclude-paths": ["cli"],
       "extra-files": [
         "devlair/__init__.py"
       ]


### PR DESCRIPTION
## Summary

- Add `exclude-paths: ["cli"]` to the root package in `release-please-config.json` so v2 TypeScript commits no longer pollute v1 Python releases.
- Fixes the issue visible in PR #50 (release 1.7.0), which lists every `feat(cli):` commit in its v1 changelog.

Closes #64

## Test plan

- [ ] CI green
- [ ] After merge, release-please regenerates PR #50 with v1-only commits
- [ ] PR #63 (`devlair-cli` 2.1.0-alpha.1) remains unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)