### PR TITLE
feat(install): support v2 alpha channel via --pre

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ devlair init
 
 That's it. The installer downloads a prebuilt binary for your architecture and places it in `/usr/local/bin`. `devlair init` takes care of the rest.
 
+> [!NOTE]
+> **Preview the v2 alpha** with `curl ... | sudo bash -s -- --pre`. The v2 rewrite drops `sync`, `filesystem`, and `claw` — pin to v1 if you depend on them. See [v2 (TypeScript + Ink — alpha)](#v2-typescript--ink--alpha).
+
 ## Why devlair
 
 <table>
@@ -391,6 +394,24 @@ uv run ruff check devlair/ tests/
 > [!WARNING]
 > v2 is in early alpha. The TypeScript + Ink rewrite is under active development.
 > For the stable CLI, use the [v1.x releases](https://github.com/ettoreaquino/devlair/releases/latest).
+
+**Try the alpha:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash -s -- --pre
+```
+
+This downloads the latest `devlair-cli-v*` prerelease asset and installs it as `/usr/local/bin/devlair`, replacing v1. To roll back, re-run the installer without `--pre`.
+
+**Removed in v2** (vs. v1):
+
+| Command | Replacement |
+|---------|-------------|
+| `devlair sync` | Pin to v1 or run `rclone bisync` directly |
+| `devlair filesystem` | Removed — not ported |
+| `devlair claw` | Removed — not ported |
+
+**Develop locally:**
 
 ```bash
 cd cli

--- a/install.sh
+++ b/install.sh
@@ -1,53 +1,91 @@
 #!/usr/bin/env bash
 # devlair installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash -s -- --pre
+#
+# Channels:
+#   stable   Latest v1 release (Python). Default.
+#   --pre    Latest v2 alpha (TypeScript + Ink). Preview — see breaking changes below.
 set -euo pipefail
 
 REPO="ettoreaquino/devlair"
 BIN="devlair"
 INSTALL_DIR="/usr/local/bin"
+CHANNEL="stable"
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+for arg in "$@"; do
+  case "$arg" in
+    --pre)    CHANNEL="pre" ;;
+    --stable) CHANNEL="stable" ;;
+    -h|--help)
+      sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
 
 # ── Detect architecture ───────────────────────────────────────────────────────
 ARCH=$(uname -m)
 case "$ARCH" in
-  x86_64)          SUFFIX="linux-x86_64"  ;;
-  aarch64 | arm64) SUFFIX="linux-aarch64" ;;
+  x86_64)          ARCH_SUFFIX="x86_64"  ;;
+  aarch64 | arm64) ARCH_SUFFIX="aarch64" ;;
   *)
-    echo "Unsupported architecture: $ARCH"
+    echo "Unsupported architecture: $ARCH" >&2
     exit 1
     ;;
 esac
 
-# ── Fetch latest release tag ──────────────────────────────────────────────────
-echo "Fetching latest devlair release..."
-LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep -o '"tag_name": *"[^"]*"' | head -1 | grep -o '"v[^"]*"' | tr -d '"')
+# ── Channel configuration ─────────────────────────────────────────────────────
+if [[ "$CHANNEL" == "pre" ]]; then
+  ASSET_PREFIX="devlair-cli"
+  echo "Fetching latest devlair v2 alpha release..."
+  # GitHub's /releases/latest endpoint excludes prereleases, so list and filter.
+  LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
+    | grep -o '"tag_name": *"devlair-cli-v[^"]*"' \
+    | head -1 \
+    | sed -E 's/.*"(devlair-cli-v[^"]*)"/\1/')
+else
+  ASSET_PREFIX="devlair"
+  echo "Fetching latest devlair release..."
+  LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -o '"tag_name": *"[^"]*"' | head -1 \
+    | grep -o '"v[^"]*"' | tr -d '"')
+fi
 
-if [[ -z "$LATEST" ]]; then
-  echo "Could not determine latest version. Check your internet connection."
+if [[ -z "${LATEST:-}" ]]; then
+  echo "Could not determine latest version. Check your internet connection." >&2
   exit 1
 fi
 
-echo "Installing devlair ${LATEST} (${SUFFIX})..."
+ASSET="${ASSET_PREFIX}-linux-${ARCH_SUFFIX}"
+echo "Installing ${ASSET} from release ${LATEST}..."
 
 # ── Download binary + checksums ───────────────────────────────────────────────
 BASE_URL="https://github.com/${REPO}/releases/download/${LATEST}"
 TMP=$(mktemp)
 TMP_CHECKSUMS=$(mktemp)
-curl -fsSL "${BASE_URL}/${BIN}-${SUFFIX}" -o "$TMP"
+curl -fsSL "${BASE_URL}/${ASSET}" -o "$TMP"
 curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
 
 # ── Verify SHA-256 checksum ──────────────────────────────────────────────────
-EXPECTED=$(grep "${BIN}-${SUFFIX}" "$TMP_CHECKSUMS" | awk '{print $1}')
+EXPECTED=$(grep " ${ASSET}\$" "$TMP_CHECKSUMS" | awk '{print $1}')
 ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
 rm -f "$TMP_CHECKSUMS"
 
 if [[ -z "$EXPECTED" ]]; then
-  echo "WARNING: No checksum found for ${BIN}-${SUFFIX} — skipping verification."
+  echo "WARNING: No checksum found for ${ASSET} — skipping verification."
 elif [[ "$ACTUAL" != "$EXPECTED" ]]; then
-  echo "ERROR: Checksum mismatch!"
-  echo "  Expected: ${EXPECTED}"
-  echo "  Got:      ${ACTUAL}"
+  echo "ERROR: Checksum mismatch!" >&2
+  echo "  Expected: ${EXPECTED}" >&2
+  echo "  Got:      ${ACTUAL}" >&2
   rm -f "$TMP"
   exit 1
 else
@@ -62,13 +100,26 @@ if [[ -w "$INSTALL_DIR" ]]; then
 else
   sudo mv "$TMP" "${INSTALL_DIR}/${BIN}"
 fi
-
-# Ensure the installed binary is readable + executable by all
 chmod 755 "${INSTALL_DIR}/${BIN}" 2>/dev/null || sudo chmod 755 "${INSTALL_DIR}/${BIN}"
 
 echo ""
 echo "✓ devlair ${LATEST} installed to ${INSTALL_DIR}/${BIN}"
 echo ""
+
+# ── Channel-specific post-install notice ──────────────────────────────────────
+if [[ "$CHANNEL" == "pre" ]]; then
+  cat <<'NOTICE'
+⚠  You installed a v2 alpha. The following v1 commands have been REMOVED:
+
+    devlair sync         — pin to v1 or run `rclone bisync` directly
+    devlair filesystem   — not ported
+    devlair claw         — not ported
+
+Report issues: https://github.com/ettoreaquino/devlair/issues
+
+NOTICE
+fi
+
 echo "Next step:"
 echo "  devlair init"
 echo ""


### PR DESCRIPTION
## Summary

- Add `--pre` channel to `install.sh` that resolves the latest `devlair-cli-v*` prerelease and installs the matching Bun-compiled asset (`devlair-cli-linux-{x86_64,aarch64}`).
- Default channel keeps current behavior: latest stable v1 (`devlair-linux-{arch}`) via `releases/latest` (which excludes prereleases).
- Tighten the checksum match (`grep " <asset>$"`) so v1 and v2 entries with overlapping prefixes can't collide once both ship.
- Print a post-install notice on `--pre` listing the v1 commands that were dropped from v2: `sync`, `filesystem`, `claw`.
- Document the alpha install path and removed commands in the README quick-start callout and the v2 section.

Coexistence model during the transition:
- Both `devlair/` (Python) and `cli/` (TypeScript) build into separate release assets under the same repo.
- Only one binary is installed on a user's machine at a time as `/usr/local/bin/devlair`; channels are switched by re-running `install.sh` with or without `--pre`.
- Once v2 reaches beta, `devlair upgrade` will surface the deprecation notice and the default channel will flip to v2 (tracked in #48 follow-ups).

Closes #48

## Test plan

- [x] `bash install.sh --help` prints usage and exits 0
- [x] `bash install.sh --bogus` fails with a clear error
- [ ] After PR #63 merges, run `curl -fsSL .../install.sh | sudo bash -s -- --pre` in a clean WSL shell — confirm it pulls `devlair-cli-v2.1.0-alpha.1`, the SHA-256 verifies, and `devlair --version` reports v2. <!-- needs-manual: requires PR #63 merged + clean WSL -->
- [ ] In the same WSL shell, re-run without `--pre` — confirm it falls back to v1.6.1 and the binary works. <!-- needs-manual: requires clean WSL -->
- [ ] Confirm the breaking-changes notice prints on `--pre` and is absent on the stable path. <!-- needs-manual: tied to first WSL run -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)