### PR TITLE
fix(ci): use correct release-please output key for v1 builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.rp.outputs['.--release_created'] }}
-      tag_name: ${{ steps.rp.outputs['.--tag_name'] }}
+      release_created: ${{ steps.rp.outputs['devlair--release_created'] }}
+      tag_name: ${{ steps.rp.outputs['devlair--tag_name'] }}
       cli_release_created: ${{ steps.rp.outputs['cli--release_created'] }}
       cli_tag_name: ${{ steps.rp.outputs['cli--tag_name'] }}
     steps:


### PR DESCRIPTION
## Summary

- Fix release-please output key mapping from `.--release_created` to `devlair--release_created`
- release-please v4 keys outputs by **component name** (`package-name`), not by path — the root package uses `devlair` as its component, so the correct key prefix is `devlair--`, not `.--`
- This caused every v1 release build to be skipped since the multi-component config was introduced (v1.7.0 shipped with no binary assets)

Closes #70

## Test plan

- [ ] Merge this PR to main <!-- needs-manual: requires human approval and merge -->
- [ ] Manually trigger `Release Binaries` workflow with tag `v1.7.0` to backfill missing assets <!-- needs-manual: requires GitHub Actions UI -->
- [ ] Verify v1.7.0 release gets `devlair-linux-x86_64`, `devlair-linux-aarch64`, and `checksums.txt` <!-- needs-manual: verify release assets post-workflow -->
- [ ] On next v1 release, confirm `build` job runs automatically <!-- needs-manual: requires future release event -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)