### PR TITLE
feat(cli): port disable-password and claude commands (no dashboard)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // \"\"' | head -1 | grep -qE '^gh pr create\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A pull request was just created. You MUST now run the /review-pr skill to perform both a code review and a README review, then post structured findings as PR comments. Use the PR number from the gh pr create output.\"}}' || true",
+            "command": "jq -r '.tool_input.command // \"\"' | head -1 | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A pull request was just created. You MUST now run the /review-pr skill to perform both a code review and a README review, then post structured findings as PR comments. Use the PR number from the gh pr create output.\"}}' || true",
             "timeout": 5,
             "statusMessage": "Checking for PR review..."
           }

--- a/README.md
+++ b/README.md
@@ -410,6 +410,14 @@ This downloads the latest `devlair-cli-v*` prerelease asset and installs it as `
 | `devlair sync` | Pin to v1 or run `rclone bisync` directly |
 | `devlair filesystem` | Removed — not ported |
 | `devlair claw` | Removed — not ported |
+| `devlair claude` usage dashboard | Pin to v1 for the dashboard. v2 `devlair claude` prints a short status panel only (plan + model); `--plan`, `--1m on\|off`, and `--channels` still work for configuration. |
+
+**Ported in v2:**
+
+| Command | Notes |
+|---------|-------|
+| `devlair disable-password [--yes]` | Linux-only, auto-elevates via sudo. `--yes` skips the interactive confirmation. |
+| `devlair claude [--plan TIER\|--1m on\|off\|--channels]` | Configures the local Claude Code install. No dashboard (see above). |
 
 **Develop locally:**
 
@@ -439,10 +447,11 @@ devlair/                # v1 Python CLI (stable)
 cli/                    # v2 TypeScript CLI (alpha)
   src/
     index.tsx           # Ink app entrypoint
-    commands/           # command implementations (init, doctor, upgrade)
+    commands/           # init, doctor, upgrade, claude, disable-password
     components/         # Ink UI components (Logo, Help)
     wizard/             # interactive wizard (GroupSelect, ModuleSelect, Confirmation)
-    lib/                # theme, types, runner, modules, platform detection
+    lib/                # theme, types, runner, modules, platform detection,
+                        # args, selection, profiles, jsonConfig, elevate
 assets/
   logo.svg              # brand mark (dark background)
   logo-light.svg        # brand mark (light background variant)

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -9,6 +9,7 @@
         "ink-spinner": "^5.0.0",
         "react": "^18.3.1",
         "yaml": "^2.8.3",
+        "zod": "^3.24.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
@@ -17,7 +18,6 @@
         "@types/react": "^18.3.0",
         "react-devtools-core": "^7.0.1",
         "typescript": "^5.7.0",
-        "zod": "^3.24.0",
       },
     },
   },

--- a/cli/package.json
+++ b/cli/package.json
@@ -27,7 +27,8 @@
     "ink": "^5.2.0",
     "ink-spinner": "^5.0.0",
     "react": "^18.3.1",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
@@ -35,8 +36,7 @@
     "@types/node": "^25.5.2",
     "@types/react": "^18.3.0",
     "react-devtools-core": "^7.0.1",
-    "typescript": "^5.7.0",
-    "zod": "^3.24.0"
+    "typescript": "^5.7.0"
   },
   "engines": {
     "node": ">=20",

--- a/cli/src/commands/claude.tsx
+++ b/cli/src/commands/claude.tsx
@@ -1,0 +1,311 @@
+/**
+ * devlair claude — Claude Code config helpers.
+ *
+ * Implements --plan, --1m on|off, --channels, and a default short status.
+ * The v1 usage dashboard (transcript parsing, plan-budget bars) is
+ * intentionally not ported; v1 should be used for that view.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Box, Text, useApp } from "ink";
+import { useEffect, useState } from "react";
+import { type ClaudeFlags, VALID_CLAUDE_PLANS } from "../lib/args.js";
+import { readJson, updateJson } from "../lib/jsonConfig.js";
+import { D_COMMENT, D_FG, D_GREEN, D_ORANGE, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
+
+const SETTINGS_FILE = join(homedir(), ".claude", "settings.json");
+const DEVLAIR_CONFIG = join(homedir(), ".claude", "devlair-config.json");
+const TELEGRAM_WRAPPER = join(homedir(), ".devlair", "bin", "claude-telegram");
+const TELEGRAM_ENV = join(homedir(), ".claude", "channels", "telegram", ".env");
+
+const DEFAULT_PLAN = "max5x";
+
+interface AllowedPlugin {
+  plugin?: string;
+  marketplace?: string;
+}
+
+interface ChannelStatus {
+  channelsEnabled: boolean;
+  allowedPlugins: AllowedPlugin[];
+  pluginInstalled: boolean;
+  wrapperExists: boolean;
+  bunOk: boolean;
+  tokenConfigured: boolean;
+}
+
+interface StatusSnapshot {
+  plan: string;
+  model: string;
+}
+
+interface ClaudeViewState {
+  /** When set, render this message and exit successfully. */
+  applied?: AppliedAction;
+  channels?: ChannelStatus;
+  status?: StatusSnapshot;
+  error?: string;
+}
+
+type AppliedAction = { kind: "plan"; plan: string } | { kind: "1m-on" } | { kind: "1m-off" };
+
+function commandExists(cmd: string): boolean {
+  return spawnSync("command", ["-v", cmd], { shell: "/bin/bash", stdio: "ignore" }).status === 0;
+}
+
+function telegramPluginInstalled(): boolean {
+  if (!commandExists("claude")) return false;
+  const result = spawnSync("claude", ["plugin", "list", "--json"], { encoding: "utf8" });
+  if (result.status !== 0) return false;
+  try {
+    const plugins = JSON.parse(result.stdout) as Array<{ name?: string; marketplace?: string }>;
+    return plugins.some((p) => p.name === "telegram" && p.marketplace === "claude-plugins-official");
+  } catch {
+    return false;
+  }
+}
+
+function gatherChannelStatus(): ChannelStatus {
+  const settings = readJson(SETTINGS_FILE);
+  return {
+    channelsEnabled: settings.channelsEnabled === true,
+    allowedPlugins: Array.isArray(settings.allowedChannelPlugins)
+      ? (settings.allowedChannelPlugins as AllowedPlugin[])
+      : [],
+    pluginInstalled: telegramPluginInstalled(),
+    wrapperExists: existsSync(TELEGRAM_WRAPPER),
+    bunOk: existsSync(join(homedir(), ".bun", "bin", "bun")) || commandExists("bun"),
+    tokenConfigured: existsSync(TELEGRAM_ENV),
+  };
+}
+
+function readStatusSnapshot(): StatusSnapshot {
+  const planRaw = readJson(DEVLAIR_CONFIG).claude_plan;
+  const plan =
+    typeof planRaw === "string" && (VALID_CLAUDE_PLANS as readonly string[]).includes(planRaw) ? planRaw : DEFAULT_PLAN;
+  const modelRaw = readJson(SETTINGS_FILE).model;
+  return { plan, model: typeof modelRaw === "string" ? modelRaw : "(unset)" };
+}
+
+function runCommand(flags: ClaudeFlags): ClaudeViewState {
+  if (flags.error) return { error: flags.error };
+  if (flags.plan) {
+    updateJson(DEVLAIR_CONFIG, { claude_plan: flags.plan });
+    return { applied: { kind: "plan", plan: flags.plan } };
+  }
+  if (flags.toggle1m === "on") {
+    updateJson(SETTINGS_FILE, { model: "opus[1m]" });
+    return { applied: { kind: "1m-on" } };
+  }
+  if (flags.toggle1m === "off") {
+    updateJson(SETTINGS_FILE, { model: "sonnet" });
+    return { applied: { kind: "1m-off" } };
+  }
+  if (flags.channels) return { channels: gatherChannelStatus() };
+  return { status: readStatusSnapshot() };
+}
+
+export interface ClaudeViewProps {
+  flags: ClaudeFlags;
+}
+
+export function ClaudeView({ flags }: ClaudeViewProps) {
+  const { exit } = useApp();
+  const [state] = useState<ClaudeViewState>(() => runCommand(flags));
+
+  useEffect(() => {
+    if (state.error) process.exitCode = 1;
+    setTimeout(() => exit(), 0);
+  }, [state, exit]);
+
+  if (state.error) {
+    return (
+      <Box flexDirection="column">
+        <Text color={D_RED}>{`  ${state.error}`}</Text>
+      </Box>
+    );
+  }
+  if (state.applied) return <AppliedView action={state.applied} />;
+  if (state.channels) return <ChannelsPanel status={state.channels} />;
+  if (state.status) return <StatusPanel snapshot={state.status} />;
+  return null;
+}
+
+function AppliedView({ action }: { action: AppliedAction }) {
+  if (action.kind === "plan") {
+    return (
+      <Text>
+        {"  "}
+        <Text color={D_GREEN}>✓</Text>
+        <Text>{"  Plan set to "}</Text>
+        <Text bold>{action.plan}</Text>
+      </Text>
+    );
+  }
+  if (action.kind === "1m-on") {
+    return (
+      <Box flexDirection="column">
+        <Text>
+          {"  "}
+          <Text color={D_GREEN}>✓</Text>
+          <Text>{"  1M context enabled — model set to "}</Text>
+          <Text bold>opus[1m]</Text>
+        </Text>
+        <Text color={D_COMMENT}>{"  Revert with: devlair claude --1m off"}</Text>
+      </Box>
+    );
+  }
+  return (
+    <Text>
+      {"  "}
+      <Text color={D_GREEN}>✓</Text>
+      <Text>{"  1M context disabled — model reset to "}</Text>
+      <Text bold>sonnet</Text>
+    </Text>
+  );
+}
+
+function StatusPanel({ snapshot }: { snapshot: StatusSnapshot }) {
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={D_PURPLE} bold>
+          {"  devlair"}
+        </Text>
+        <Text color={D_PINK} bold>
+          {"  claude"}
+        </Text>
+        <Text color={D_COMMENT}>{`  ${snapshot.plan}`}</Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        <Row label="plan" value={snapshot.plan} />
+        <Row label="model" value={snapshot.model} />
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        <Text color={D_COMMENT}>{"  Usage dashboard is not available in v2. Run v1 devlair claude to see it."}</Text>
+        <Text color={D_COMMENT}>
+          {"  devlair claude --plan "}
+          <Text color={D_FG}>{VALID_CLAUDE_PLANS.join("|")}</Text>
+          {"   set subscription tier"}
+        </Text>
+        <Text color={D_COMMENT}>{"  devlair claude --1m on|off                   toggle 1M-token context"}</Text>
+        <Text color={D_COMMENT}>
+          {"  devlair claude --channels                    show channel configuration status"}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Text color={D_COMMENT}>{`  ${label.padEnd(8)}`}</Text>
+      <Text color={D_FG} bold>
+        {value}
+      </Text>
+    </Box>
+  );
+}
+
+function ChannelsPanel({ status }: { status: ChannelStatus }) {
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text color={D_PURPLE} bold>
+          {"  devlair"}
+        </Text>
+        <Text color={D_PINK} bold>
+          {"  channels"}
+        </Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        <StatusLine label="channelsEnabled" ok={status.channelsEnabled} fix="run sudo devlair init --only claude" />
+        {status.allowedPlugins.length > 0 ? (
+          <Box flexDirection="column">
+            <Text color={D_COMMENT}>{"  allowed plugins:"}</Text>
+            {status.allowedPlugins.map((p) => (
+              <Text key={`${p.marketplace ?? "?"}/${p.plugin ?? "?"}`}>
+                {"    "}
+                <Text color={D_FG}>{p.plugin ?? "?"}</Text>
+                <Text color={D_COMMENT}>{` @ ${p.marketplace ?? "?"}`}</Text>
+              </Text>
+            ))}
+          </Box>
+        ) : (
+          <StatusLine label="allowed plugins" ok={false} fix="run sudo devlair init --only claude" />
+        )}
+        <StatusLine label="telegram plugin" ok={status.pluginInstalled} fix="run sudo devlair init --only claude" />
+        <StatusLine
+          label="claude-telegram wrapper"
+          ok={status.wrapperExists}
+          fix="run sudo devlair init --only claude"
+        />
+        <StatusLine label="bun" ok={status.bunOk} fix="run sudo devlair init --only devtools" />
+        {status.tokenConfigured ? (
+          <StatusLine label="telegram token" ok={true} fix="" />
+        ) : (
+          <Box>
+            <Text color={D_ORANGE}>{"  ○"}</Text>
+            <Text>{"  telegram token  "}</Text>
+            <Text color={D_ORANGE}>not set</Text>
+            <Text color={D_COMMENT}>{"  — see step 1 below"}</Text>
+          </Box>
+        )}
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text color={D_COMMENT}>{"  Setup (one-time):"}</Text>
+        <Text color={D_COMMENT}>
+          {"    1. Create a bot: Telegram → "}
+          <Text color={D_FG}>@BotFather</Text>
+          {" → "}
+          <Text color={D_FG}>/newbot</Text>
+          {" → copy token"}
+        </Text>
+        <Text color={D_COMMENT}>{"    2. In any Claude Code session, configure your token:"}</Text>
+        <Text>
+          {"         "}
+          <Text color={D_FG}>/telegram:configure &lt;token&gt;</Text>
+        </Text>
+        <Text color={D_COMMENT}>{"    3. Launch with channels:"}</Text>
+        <Text>
+          {"         "}
+          <Text color={D_FG}>claude-telegram</Text>
+        </Text>
+        <Text color={D_COMMENT}>{"    4. Pair: message your bot → reply contains a code → in Claude Code:"}</Text>
+        <Text>
+          {"         "}
+          <Text color={D_FG}>/telegram:access pair &lt;code&gt;</Text>
+        </Text>
+        <Text>
+          {"         "}
+          <Text color={D_FG}>/telegram:access policy allowlist</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function StatusLine({ label, ok, fix }: { label: string; ok: boolean; fix: string }) {
+  if (ok) {
+    return (
+      <Box>
+        <Text color={D_GREEN}>{"  ●"}</Text>
+        <Text>{`  ${label}  `}</Text>
+        <Text color={D_GREEN}>ok</Text>
+      </Box>
+    );
+  }
+  return (
+    <Box>
+      <Text color={D_RED}>{"  ○"}</Text>
+      <Text>{`  ${label}  `}</Text>
+      <Text color={D_RED}>missing</Text>
+      {fix && <Text color={D_COMMENT}>{`  — ${fix}`}</Text>}
+    </Box>
+  );
+}

--- a/cli/src/commands/disable-password.tsx
+++ b/cli/src/commands/disable-password.tsx
@@ -9,10 +9,10 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, constants as fsConstants, openSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Box, Text, useApp, useInput } from "ink";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { DisablePasswordFlags } from "../lib/args.js";
 import { resolveInvokingUser } from "../lib/context.js";
 import { detectPlatform } from "../lib/platform.js";
@@ -43,7 +43,13 @@ function countAuthorizedKeys(path: string): number {
 function preflight(): Preflight {
   const [username, userHome] = resolveInvokingUser();
   const authKeysPath = join(userHome, ".ssh", "authorized_keys");
-  if (!existsSync(authKeysPath) || statSync(authKeysPath).size === 0) {
+  let size = 0;
+  try {
+    size = statSync(authKeysPath).size;
+  } catch {
+    size = 0;
+  }
+  if (size === 0) {
     return {
       ok: false,
       authKeysPath,
@@ -60,19 +66,36 @@ interface ApplyResult {
 }
 
 function applyHardening(): ApplyResult {
-  if (!existsSync(SSHD_CONF)) {
-    return {
-      ok: false,
-      error: `${SSHD_CONF} not found. Run 'sudo devlair init --only ssh' first.`,
-    };
+  // Open with O_NOFOLLOW so a swapped-in symlink (e.g. → /etc/sudoers) fails
+  // with ELOOP instead of redirecting our root-privileged write.
+  let fd: number;
+  try {
+    fd = openSync(SSHD_CONF, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return { ok: false, error: `${SSHD_CONF} not found. Run 'sudo devlair init --only ssh' first.` };
+    }
+    if (code === "ELOOP") {
+      return { ok: false, error: `${SSHD_CONF} is a symlink — refusing to write. Inspect the file manually.` };
+    }
+    return { ok: false, error: `Cannot read ${SSHD_CONF}: ${(err as Error).message}` };
   }
+  const current = readFileSync(fd, "utf8");
+  closeSync(fd);
 
-  const current = readFileSync(SSHD_CONF, "utf8");
-  let updated = current.replace("PasswordAuthentication yes", "PasswordAuthentication no");
-  if (!updated.includes("PasswordAuthentication no")) {
+  let updated = current.replace(/^[ \t]*PasswordAuthentication[ \t]+.*$/gm, "PasswordAuthentication no");
+  if (!/^[ \t]*PasswordAuthentication[ \t]+no\b/m.test(updated)) {
     updated += "\nPasswordAuthentication no\n";
   }
-  writeFileSync(SSHD_CONF, updated, "utf8");
+
+  try {
+    const writeFd = openSync(SSHD_CONF, fsConstants.O_WRONLY | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW);
+    writeFileSync(writeFd, updated, "utf8");
+    closeSync(writeFd);
+  } catch (err) {
+    return { ok: false, error: `Cannot write ${SSHD_CONF}: ${(err as Error).message}` };
+  }
 
   const restart = spawnSync("systemctl", ["restart", "ssh"], { stdio: "ignore" });
   if (restart.status !== 0) {
@@ -95,7 +118,14 @@ export function DisablePasswordView({ flags }: DisablePasswordViewProps) {
   const [result, setResult] = useState<ApplyResult | null>(null);
   const aborted = phase === "done" && result === null;
 
-  // Bail conditions: non-linux platform, preflight failure.
+  const runApply = useCallback(() => {
+    const res = applyHardening();
+    setResult(res);
+    if (!res.ok) process.exitCode = 1;
+    setPhase("done");
+    setTimeout(() => exit(), 0);
+  }, [exit]);
+
   useEffect(() => {
     if (platform !== "linux" || (check && !check.ok)) {
       process.exitCode = 1;
@@ -103,24 +133,14 @@ export function DisablePasswordView({ flags }: DisablePasswordViewProps) {
     }
   }, [platform, check, exit]);
 
-  // Auto-apply when --yes was passed.
   useEffect(() => {
-    if (!flags.yes || !check?.ok || phase !== "confirm") return;
-    const res = applyHardening();
-    setResult(res);
-    if (!res.ok) process.exitCode = 1;
-    setPhase("done");
-    setTimeout(() => exit(), 0);
-  }, [flags.yes, check, phase, exit]);
+    if (flags.yes && check?.ok && phase === "confirm") runApply();
+  }, [flags.yes, check, phase, runApply]);
 
   useInput(
     (input, key) => {
       if (key.return || input === "y" || input === "Y") {
-        const res = applyHardening();
-        setResult(res);
-        if (!res.ok) process.exitCode = 1;
-        setPhase("done");
-        setTimeout(() => exit(), 0);
+        runApply();
       } else if (key.escape || input === "n" || input === "N" || input === "q") {
         setPhase("done");
         setTimeout(() => exit(), 0);

--- a/cli/src/commands/disable-password.tsx
+++ b/cli/src/commands/disable-password.tsx
@@ -1,0 +1,211 @@
+/**
+ * devlair disable-password — flips SSH to key-only auth.
+ *
+ * Verifies the invoking user has at least one public key in
+ * ~/.ssh/authorized_keys, prompts for confirmation, then rewrites
+ * /etc/ssh/sshd_config.d/99-hardened.conf and restarts sshd.
+ *
+ * Linux-only: WSL has no systemctl-managed sshd; macOS uses launchd.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Box, Text, useApp, useInput } from "ink";
+import { useEffect, useState } from "react";
+import type { DisablePasswordFlags } from "../lib/args.js";
+import { resolveInvokingUser } from "../lib/context.js";
+import { detectPlatform } from "../lib/platform.js";
+import { D_COMMENT, D_FG, D_GREEN, D_ORANGE, D_PURPLE, D_RED } from "../lib/theme.js";
+
+const SSHD_CONF = "/etc/ssh/sshd_config.d/99-hardened.conf";
+
+interface Preflight {
+  ok: boolean;
+  /** Number of public keys in authorized_keys (only set when ok). */
+  keyCount?: number;
+  /** Path checked, surfaced in error messages. */
+  authKeysPath: string;
+  /** Reason for failure when ok=false. */
+  reason?: string;
+  username: string;
+}
+
+function countAuthorizedKeys(path: string): number {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed.length > 0 && !trimmed.startsWith("#");
+    }).length;
+}
+
+function preflight(): Preflight {
+  const [username, userHome] = resolveInvokingUser();
+  const authKeysPath = join(userHome, ".ssh", "authorized_keys");
+  if (!existsSync(authKeysPath) || statSync(authKeysPath).size === 0) {
+    return {
+      ok: false,
+      authKeysPath,
+      username,
+      reason: `No public key found. Add one to ${authKeysPath} before disabling password auth.`,
+    };
+  }
+  return { ok: true, authKeysPath, username, keyCount: countAuthorizedKeys(authKeysPath) };
+}
+
+interface ApplyResult {
+  ok: boolean;
+  error?: string;
+}
+
+function applyHardening(): ApplyResult {
+  if (!existsSync(SSHD_CONF)) {
+    return {
+      ok: false,
+      error: `${SSHD_CONF} not found. Run 'sudo devlair init --only ssh' first.`,
+    };
+  }
+
+  const current = readFileSync(SSHD_CONF, "utf8");
+  let updated = current.replace("PasswordAuthentication yes", "PasswordAuthentication no");
+  if (!updated.includes("PasswordAuthentication no")) {
+    updated += "\nPasswordAuthentication no\n";
+  }
+  writeFileSync(SSHD_CONF, updated, "utf8");
+
+  const restart = spawnSync("systemctl", ["restart", "ssh"], { stdio: "ignore" });
+  if (restart.status !== 0) {
+    return { ok: false, error: "systemctl restart ssh failed — file written but sshd may still accept passwords." };
+  }
+  return { ok: true };
+}
+
+type Phase = "confirm" | "done";
+
+export interface DisablePasswordViewProps {
+  flags: DisablePasswordFlags;
+}
+
+export function DisablePasswordView({ flags }: DisablePasswordViewProps) {
+  const { exit } = useApp();
+  const [platform] = useState(() => detectPlatform());
+  const [check] = useState(() => (platform === "linux" ? preflight() : null));
+  const [phase, setPhase] = useState<Phase>("confirm");
+  const [result, setResult] = useState<ApplyResult | null>(null);
+  const aborted = phase === "done" && result === null;
+
+  // Bail conditions: non-linux platform, preflight failure.
+  useEffect(() => {
+    if (platform !== "linux" || (check && !check.ok)) {
+      process.exitCode = 1;
+      setTimeout(() => exit(), 0);
+    }
+  }, [platform, check, exit]);
+
+  // Auto-apply when --yes was passed.
+  useEffect(() => {
+    if (!flags.yes || !check?.ok || phase !== "confirm") return;
+    const res = applyHardening();
+    setResult(res);
+    if (!res.ok) process.exitCode = 1;
+    setPhase("done");
+    setTimeout(() => exit(), 0);
+  }, [flags.yes, check, phase, exit]);
+
+  useInput(
+    (input, key) => {
+      if (key.return || input === "y" || input === "Y") {
+        const res = applyHardening();
+        setResult(res);
+        if (!res.ok) process.exitCode = 1;
+        setPhase("done");
+        setTimeout(() => exit(), 0);
+      } else if (key.escape || input === "n" || input === "N" || input === "q") {
+        setPhase("done");
+        setTimeout(() => exit(), 0);
+      }
+    },
+    { isActive: phase === "confirm" && check?.ok === true && !flags.yes },
+  );
+
+  if (platform !== "linux") {
+    return (
+      <Box flexDirection="column">
+        <Text color={D_RED}>{`  disable-password is Linux-only (current platform: ${platform}).`}</Text>
+        <Text color={D_COMMENT}>{"  WSL uses Windows SSH; macOS uses launchd."}</Text>
+      </Box>
+    );
+  }
+
+  if (!check || !check.ok) {
+    return (
+      <Box flexDirection="column">
+        <Header />
+        <Box marginTop={1}>
+          <Text color={D_RED}>{`  ${check?.reason ?? "Preflight failed."}`}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Header />
+      <Box marginTop={1} flexDirection="column">
+        <Text>
+          {"  "}
+          <Text color={D_GREEN}>{check.keyCount}</Text>
+          <Text color={D_COMMENT}>{" public key(s) found for "}</Text>
+          <Text color={D_FG} bold>
+            {check.username}
+          </Text>
+          <Text color={D_COMMENT}>{` at ${check.authKeysPath}`}</Text>
+        </Text>
+        <Text color={D_COMMENT}>{`  Updates ${SSHD_CONF} and sets PasswordAuthentication no.`}</Text>
+        <Text color={D_ORANGE}>{"  Make sure you can log in with your SSH key before continuing."}</Text>
+      </Box>
+
+      {phase === "confirm" && !flags.yes && (
+        <Box marginTop={1}>
+          <Text>{"  "}</Text>
+          <Text color={D_PURPLE}>Disable SSH password authentication? </Text>
+          <Text color={D_COMMENT}>(y/N)</Text>
+        </Box>
+      )}
+
+      {phase === "done" && result?.ok && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color={D_GREEN}>{"  ✓ Password authentication disabled."}</Text>
+          <Text color={D_COMMENT}>{"  SSH now requires a key to log in."}</Text>
+        </Box>
+      )}
+
+      {phase === "done" && result && !result.ok && (
+        <Box marginTop={1}>
+          <Text color={D_RED}>{`  ${result.error}`}</Text>
+        </Box>
+      )}
+
+      {aborted && (
+        <Box marginTop={1}>
+          <Text color={D_COMMENT}>{"  Aborted."}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function Header() {
+  return (
+    <Box>
+      <Text color={D_PURPLE} bold>
+        {"  devlair"}
+      </Text>
+      <Text bold color={D_FG}>
+        {"  disable-password"}
+      </Text>
+      <Text color={D_COMMENT}>{"  Hardening SSH authentication"}</Text>
+    </Box>
+  );
+}

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -6,12 +6,10 @@
  * group select -> module select -> confirmation -> execution.
  */
 
-import { readFileSync } from "node:fs";
 import { hostname } from "node:os";
 import { useApp } from "ink";
 import { Box, Text } from "ink";
 import { useEffect, useRef, useState } from "react";
-import YAML from "yaml";
 
 import { Logo } from "../components/Logo.js";
 import { type ModuleRun, Progress } from "../components/Progress.js";
@@ -21,34 +19,16 @@ import { buildModuleContext } from "../lib/context.js";
 import type { Group, ModuleSpec } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
+import { type Profile, ProfileError, loadProfile, resolveProfileKeys } from "../lib/profiles.js";
 import { runModule } from "../lib/runner.js";
 import { selectModules } from "../lib/selection.js";
-import { D_COMMENT, D_FG, D_PINK, D_PURPLE } from "../lib/theme.js";
+import { D_COMMENT, D_FG, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
 import type { ModuleContext, Status } from "../lib/types.js";
 import { Confirmation } from "../wizard/Confirmation.js";
 import { GroupSelect } from "../wizard/GroupSelect.js";
 import { ModuleSelect } from "../wizard/ModuleSelect.js";
 
 type Phase = "wizard-groups" | "wizard-modules" | "wizard-confirm" | "running" | "done";
-
-interface ProfileData {
-  name?: string;
-  config?: Record<string, unknown>;
-}
-
-function loadProfile(path: string): ProfileData {
-  try {
-    const raw = readFileSync(path, "utf8");
-    const data = YAML.parse(raw) as Record<string, unknown>;
-    return {
-      name: typeof data.name === "string" ? data.name : undefined,
-      config: typeof data.config === "object" && data.config !== null ? (data.config as Record<string, unknown>) : {},
-    };
-  } catch (err) {
-    process.stderr.write(`Profile error: ${err instanceof Error ? err.message : err}\n`);
-    process.exit(1);
-  }
-}
 
 function InitHeader({
   username,
@@ -190,19 +170,78 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
 
 // ── Non-interactive init (flags provided) ──────────────────────────────────
 
-function NonInteractiveInit({ flags }: { flags: InitFlags }) {
-  const [initState] = useState(() => {
-    const platform = detectPlatform();
-    const wslVersion = detectWslVersion(platform);
-    const profile = flags.config ? loadProfile(flags.config) : undefined;
-    const config = profile?.config ?? {};
-    const context = buildModuleContext(platform, wslVersion, config);
-    const { selected, optional, platformSkipped } = selectModules(flags, platform);
-    const skippedNames = platformSkipped.map((s) => s.key).join(", ");
-    return { platform, context, selected, optional, platformSkipped, skippedNames, profile };
-  });
+interface InitState {
+  platform: ReturnType<typeof detectPlatform>;
+  context: ModuleContext;
+  selected: ModuleSpec[];
+  optional: ModuleSpec[];
+  skippedNames: string;
+  profile: Profile | null;
+}
 
-  const { platform, context, selected, optional, skippedNames, profile } = initState;
+function buildInitState(flags: InitFlags, profile: Profile | null): InitState {
+  const platform = detectPlatform();
+  const wslVersion = detectWslVersion(platform);
+  const config = (profile?.config ?? {}) as Record<string, unknown>;
+  const context = buildModuleContext(platform, wslVersion, config);
+  const profileSelection = profile ? resolveProfileKeys(profile) : undefined;
+  const { selected, optional, platformSkipped } = selectModules(flags, platform, profileSelection);
+  return {
+    platform,
+    context,
+    selected,
+    optional,
+    skippedNames: platformSkipped.map((s) => s.key).join(", "),
+    profile,
+  };
+}
+
+function NonInteractiveInit({ flags }: { flags: InitFlags }) {
+  const { exit } = useApp();
+  const [initState, setInitState] = useState<InitState | null>(() =>
+    flags.config ? null : buildInitState(flags, null),
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initState !== null || error !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const profile = flags.config ? await loadProfile(flags.config) : null;
+        if (!cancelled) setInitState(buildInitState(flags, profile));
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof ProfileError ? err.message : err instanceof Error ? err.message : String(err);
+        setError(msg);
+        process.exitCode = 1;
+        setTimeout(() => exit(), 0);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [flags, initState, error, exit]);
+
+  if (error !== null) {
+    return (
+      <Box flexDirection="column">
+        <Text color={D_RED}>{`  Profile error: ${error}`}</Text>
+      </Box>
+    );
+  }
+  if (initState === null) {
+    return (
+      <Box flexDirection="column">
+        <Text color={D_COMMENT}>{"  Loading profile..."}</Text>
+      </Box>
+    );
+  }
+  return <NonInteractiveInitView state={initState} />;
+}
+
+function NonInteractiveInitView({ state }: { state: InitState }) {
+  const { platform, context, selected, optional, skippedNames, profile } = state;
   const { modules, done } = useModuleExecution(selected, context, true);
 
   return (

--- a/cli/src/components/Help.tsx
+++ b/cli/src/components/Help.tsx
@@ -19,19 +19,14 @@ const HELP_SECTIONS: HelpSection[] = [
       { cmd: "init [--only MOD] [--skip MOD] [--group GRP] [--config FILE]", desc: "Set up this machine from scratch" },
       { cmd: "doctor [--fix]", desc: "Check system health & fix drift" },
       { cmd: "upgrade [--no-self]", desc: "Upgrade tools & re-apply configs" },
-      { cmd: "disable-password", desc: "Lock SSH to key-only auth" },
-    ],
-  },
-  {
-    title: "Cloud & Filesystem",
-    entries: [
-      { cmd: "sync [--add|--remove|--now]", desc: "Manage rclone folder syncs" },
-      { cmd: "filesystem", desc: "AI-guided folder structure design" },
+      { cmd: "disable-password [--yes]", desc: "Lock SSH to key-only auth" },
     ],
   },
   {
     title: "AI Agents & Channels",
-    entries: [{ cmd: "claude [--plan TIER] [--1m on|off]", desc: "Usage dashboard & config" }],
+    entries: [
+      { cmd: "claude [--plan TIER] [--1m on|off] [--channels]", desc: "Status & config (dashboard moved to v1)" },
+    ],
   },
   {
     title: "tmux Sessions",

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -1,14 +1,20 @@
 #!/usr/bin/env bun
 import { Text, render } from "ink";
 import pkg from "../package.json" with { type: "json" };
+import { ClaudeView } from "./commands/claude.js";
+import { DisablePasswordView } from "./commands/disable-password.js";
 import { DoctorView } from "./commands/doctor.js";
 import { InitView } from "./commands/init.js";
 import { UpgradeView } from "./commands/upgrade.js";
 import { Help } from "./components/Help.js";
 import {
+  type ClaudeFlags,
+  type DisablePasswordFlags,
   type DoctorFlags,
   type InitFlags,
   type UpgradeFlags,
+  parseClaudeFlags,
+  parseDisablePasswordFlags,
   parseDoctorFlags,
   parseInitFlags,
   parseUpgradeFlags,
@@ -23,7 +29,9 @@ type Command =
   | { type: "help" }
   | { type: "init"; flags: InitFlags }
   | { type: "doctor"; flags: DoctorFlags }
-  | { type: "upgrade"; flags: UpgradeFlags };
+  | { type: "upgrade"; flags: UpgradeFlags }
+  | { type: "claude"; flags: ClaudeFlags }
+  | { type: "disable-password"; flags: DisablePasswordFlags };
 
 function parseCommand(args: string[]): Command {
   if (args.includes("--version") || args.includes("-V")) {
@@ -38,6 +46,12 @@ function parseCommand(args: string[]): Command {
   }
   if (firstArg === "upgrade") {
     return { type: "upgrade", flags: parseUpgradeFlags(args.slice(1)) };
+  }
+  if (firstArg === "claude") {
+    return { type: "claude", flags: parseClaudeFlags(args.slice(1)) };
+  }
+  if (firstArg === "disable-password") {
+    return { type: "disable-password", flags: parseDisablePasswordFlags(args.slice(1)) };
   }
   return { type: "help" };
 }
@@ -55,19 +69,30 @@ function App({ command }: { command: Command }) {
   if (command.type === "upgrade") {
     return <UpgradeView flags={command.flags} version={VERSION} />;
   }
+  if (command.type === "claude") {
+    return <ClaudeView flags={command.flags} />;
+  }
+  if (command.type === "disable-password") {
+    return <DisablePasswordView flags={command.flags} />;
+  }
   return <Help version={VERSION} />;
 }
+
+const ELEVATED_COMMANDS = new Set(["init", "doctor", "upgrade", "disable-password"]);
 
 async function main() {
   const command = parseCommand(process.argv.slice(2));
 
-  if (command.type === "init" || command.type === "doctor" || command.type === "upgrade") {
+  if (ELEVATED_COMMANDS.has(command.type)) {
     elevateIfNeeded();
-    const { waitUntilExit } = render(<App command={command} />);
-    await waitUntilExit();
-  } else {
+  }
+
+  if (command.type === "help" || command.type === "version") {
     const { unmount } = render(<App command={command} />);
     unmount();
+  } else {
+    const { waitUntilExit } = render(<App command={command} />);
+    await waitUntilExit();
   }
 }
 

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -1,4 +1,4 @@
-/** CLI flag parsing for init, doctor, and upgrade commands. */
+/** CLI flag parsing for all devlair v2 subcommands. */
 
 export interface InitFlags {
   only: Set<string> | null;

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -59,3 +59,53 @@ export function parseDoctorFlags(args: readonly string[]): DoctorFlags {
 export function parseUpgradeFlags(args: readonly string[]): UpgradeFlags {
   return { noSelf: args.includes("--no-self") };
 }
+
+export const VALID_CLAUDE_PLANS = ["pro", "max5x", "max20x"] as const;
+export type ClaudePlan = (typeof VALID_CLAUDE_PLANS)[number];
+export type ToggleValue = "on" | "off";
+
+export interface ClaudeFlags {
+  plan: ClaudePlan | null;
+  toggle1m: ToggleValue | null;
+  channels: boolean;
+  error: string | null;
+}
+
+/** Parse claude-specific flags from argv (after the "claude" command). */
+export function parseClaudeFlags(args: readonly string[]): ClaudeFlags {
+  const flags: ClaudeFlags = { plan: null, toggle1m: null, channels: false, error: null };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--channels") {
+      flags.channels = true;
+    } else if (arg === "--plan") {
+      const value = args[++i];
+      if (!value || value.startsWith("--")) {
+        flags.error = "Missing value for --plan";
+        continue;
+      }
+      if (!(VALID_CLAUDE_PLANS as readonly string[]).includes(value)) {
+        flags.error = `Unknown plan '${value}' — use one of: ${VALID_CLAUDE_PLANS.join(", ")}`;
+        continue;
+      }
+      flags.plan = value as ClaudePlan;
+    } else if (arg === "--1m") {
+      const value = args[++i];
+      if (value !== "on" && value !== "off") {
+        flags.error = `--1m requires 'on' or 'off' (got ${value ?? "nothing"})`;
+        continue;
+      }
+      flags.toggle1m = value;
+    }
+  }
+  return flags;
+}
+
+export interface DisablePasswordFlags {
+  /** Skip the interactive confirmation (CI / scripts). */
+  yes: boolean;
+}
+
+export function parseDisablePasswordFlags(args: readonly string[]): DisablePasswordFlags {
+  return { yes: args.includes("--yes") || args.includes("-y") };
+}

--- a/cli/src/lib/context.ts
+++ b/cli/src/lib/context.ts
@@ -5,12 +5,19 @@ import type { ModuleContext, Platform } from "./types.js";
  * Resolve the real user behind sudo. Returns [username, homeDir].
  * Falls back to the current OS user when not running under sudo.
  */
+const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/;
+
+function isSafeHome(path: string, username: string): boolean {
+  return path === `/home/${username}` || path === `/Users/${username}`;
+}
+
 export function resolveInvokingUser(): [username: string, homeDir: string] {
   const sudoUser = process.env.SUDO_USER;
-  if (sudoUser && sudoUser !== "root") {
-    // Under sudo HOME points to root's home. SUDO_HOME is non-standard but
-    // set by some wrappers; fall back to /home/<user> which covers Linux.
-    const home = process.env.SUDO_HOME ?? `/home/${sudoUser}`;
+  if (sudoUser && sudoUser !== "root" && VALID_USERNAME_RE.test(sudoUser)) {
+    // SUDO_HOME is non-standard; only honor it when it points to a conventional
+    // user home for the same name. Otherwise derive /home/<user>.
+    const claimed = process.env.SUDO_HOME;
+    const home = claimed && isSafeHome(claimed, sudoUser) ? claimed : `/home/${sudoUser}`;
     return [sudoUser, home];
   }
   const info = userInfo({ encoding: "utf8" });

--- a/cli/src/lib/elevate.ts
+++ b/cli/src/lib/elevate.ts
@@ -11,7 +11,7 @@ export function elevateIfNeeded(): void {
 
   // Preserve only the env vars we need — blanket -E would forward secrets
   // like AWS_SECRET_ACCESS_KEY to every child module running as root.
-  const preserve = ["TERM", "COLORTERM", "LANG", "LC_ALL", "ANTHROPIC_API_KEY"].join(",");
+  const preserve = ["TERM", "COLORTERM", "LANG", "LC_ALL"].join(",");
   const result = spawnSync("sudo", [`--preserve-env=${preserve}`, "--", ...process.argv], {
     stdio: "inherit",
   });

--- a/cli/src/lib/jsonConfig.ts
+++ b/cli/src/lib/jsonConfig.ts
@@ -1,0 +1,25 @@
+/**
+ * Read/merge helpers for the JSON config files used by the claude command
+ * (~/.claude/settings.json, ~/.claude/devlair-config.json).
+ *
+ * Missing or corrupt files read as `{}`; writes always create parent dirs and
+ * preserve existing keys via a shallow merge.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export function readJson(path: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function updateJson(path: string, updates: Record<string, unknown>): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const data = { ...readJson(path), ...updates };
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}

--- a/cli/src/lib/profiles.ts
+++ b/cli/src/lib/profiles.ts
@@ -1,0 +1,245 @@
+/**
+ * Setup profile loading, Zod validation, and remote fetching.
+ *
+ * Profiles are YAML documents (schema version 1) that declare which module
+ * groups or modules to install, what to skip, and per-module config. They
+ * can live on disk, at an HTTPS URL, or in a GitHub repo using the shorthand
+ * `org/repo[@ref]:path/to/profile.yaml`.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import { z } from "zod";
+import { GROUPS, MODULE_SPECS, keysForGroups } from "./modules.js";
+
+const MODULE_KEYS = MODULE_SPECS.map((s) => s.key) as [string, ...string[]];
+const MODULE_KEY_SET = new Set<string>(MODULE_KEYS);
+const GROUP_SET = new Set<string>(GROUPS);
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const GITHUB_SHORTHAND_RE = /^([\w.-]+)\/([\w.-]+)(?:@([\w./-]+))?:(.+)$/;
+
+export class ProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProfileError";
+  }
+}
+
+const moduleKeySchema = z.string().superRefine((k, ctx) => {
+  if (!MODULE_KEY_SET.has(k)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Unknown module '${k}'` });
+  }
+});
+
+const groupSchema = z.string().superRefine((g, ctx) => {
+  if (!GROUP_SET.has(g)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Unknown group '${g}'` });
+  }
+});
+
+const profileSchema = z
+  .object({
+    version: z.literal(1, { errorMap: () => ({ message: "Unsupported profile version (expected 1)" }) }),
+    name: z.string().optional(),
+    groups: z.array(groupSchema).optional(),
+    modules: z.array(moduleKeySchema).optional(),
+    skip: z.array(moduleKeySchema).optional(),
+    config: z.record(z.string(), z.record(z.string(), z.unknown())).optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.modules !== undefined && data.groups !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "'modules' and 'groups' are mutually exclusive — use one or the other",
+        path: ["modules"],
+      });
+    }
+    if (data.config) {
+      for (const key of Object.keys(data.config)) {
+        if (!MODULE_KEY_SET.has(key)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Unknown module '${key}' in config section`,
+            path: ["config", key],
+          });
+        }
+      }
+    }
+  });
+
+export type Profile = z.infer<typeof profileSchema>;
+
+export interface ProfileSelection {
+  /** Explicit module set declared by the profile, or null if it specified neither modules nor groups. */
+  want: Set<string> | null;
+  /** Modules the profile asks to skip. Always defined (empty when absent). */
+  skip: Set<string>;
+}
+
+/** Parse + validate a YAML string. Throws ProfileError with a readable message. */
+export function parseProfile(text: string, sourceLabel = "profile"): Profile {
+  let raw: unknown;
+  try {
+    raw = YAML.parse(text);
+  } catch (err) {
+    throw new ProfileError(`Invalid YAML in ${sourceLabel}: ${err instanceof Error ? err.message : err}`);
+  }
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new ProfileError(`${sourceLabel} must be a YAML mapping, got ${describe(raw)}`);
+  }
+  const result = profileSchema.safeParse(raw);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `${i.path.length ? `${i.path.join(".")}: ` : ""}${i.message}`)
+      .join("; ");
+    throw new ProfileError(`Invalid ${sourceLabel}: ${issues}`);
+  }
+  return result.data;
+}
+
+/** Derive (want, skip) from a validated profile. Mirrors Python's resolve_profile_keys. */
+export function resolveProfileKeys(profile: Profile): ProfileSelection {
+  let want: Set<string> | null = null;
+  if (profile.modules) {
+    want = new Set(profile.modules);
+  } else if (profile.groups) {
+    want = keysForGroups(new Set(profile.groups));
+  }
+  return { want, skip: new Set(profile.skip ?? []) };
+}
+
+export interface SourceClassification {
+  kind: "file" | "url" | "github";
+  /** Canonical URL for url/github sources. */
+  url?: string;
+  /** Local filesystem path for file sources. */
+  path?: string;
+}
+
+/** Classify a --config argument as a local file, HTTPS URL, or GitHub shorthand. */
+export function classifySource(source: string): SourceClassification {
+  if (source.startsWith("http://") || source.startsWith("https://")) {
+    return { kind: "url", url: source };
+  }
+  const match = GITHUB_SHORTHAND_RE.exec(source);
+  if (match) {
+    const [, org, repo, ref, path] = match;
+    const url = `https://raw.githubusercontent.com/${org}/${repo}/${ref ?? "HEAD"}/${path}`;
+    return { kind: "github", url };
+  }
+  return { kind: "file", path: source };
+}
+
+function cacheDir(): string {
+  return join(homedir(), ".devlair", "profiles");
+}
+
+function cachePath(url: string): string {
+  const hash = createHash("sha256").update(url).digest("hex").slice(0, 16);
+  return join(cacheDir(), `${hash}.yaml`);
+}
+
+function cacheIsFresh(path: string, now: number): boolean {
+  try {
+    const stat = statSync(path);
+    return now - stat.mtimeMs < CACHE_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+function readCached(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function writeCached(path: string, text: string): void {
+  try {
+    mkdirSync(cacheDir(), { recursive: true });
+    writeFileSync(path, text, "utf8");
+  } catch {
+    // Cache writes are best-effort.
+  }
+}
+
+export type FetchLike = (input: string | URL | Request) => Promise<Response>;
+
+export interface FetchOptions {
+  /** Override fetch (mainly for tests). */
+  fetchImpl?: FetchLike;
+  /** Skip cache reads/writes (mainly for tests). */
+  noCache?: boolean;
+  /** Override clock (mainly for tests). */
+  now?: () => number;
+}
+
+async function fetchRemote(url: string, opts: FetchOptions): Promise<string> {
+  const fetchFn = opts.fetchImpl ?? globalThis.fetch;
+  const now = opts.now ?? Date.now;
+  const cache = cachePath(url);
+
+  if (!opts.noCache && cacheIsFresh(cache, now())) {
+    const cached = readCached(cache);
+    if (cached !== null) return cached;
+  }
+
+  try {
+    const response = await fetchFn(url);
+    if (!response.ok) {
+      throw new ProfileError(`Failed to fetch profile (${response.status} ${response.statusText}): ${url}`);
+    }
+    const text = await response.text();
+    if (!opts.noCache) writeCached(cache, text);
+    return text;
+  } catch (err) {
+    if (err instanceof ProfileError) {
+      // On HTTP error, fall back to stale cache if available.
+      const stale = opts.noCache ? null : readCached(cache);
+      if (stale !== null) return stale;
+      throw err;
+    }
+    const stale = opts.noCache ? null : readCached(cache);
+    if (stale !== null) return stale;
+    throw new ProfileError(`Failed to fetch profile ${url}: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+/**
+ * Load and validate a profile from any source — local path, HTTPS URL, or
+ * GitHub shorthand `org/repo[@ref]:path`.
+ */
+export async function loadProfile(source: string, opts: FetchOptions = {}): Promise<Profile> {
+  const classified = classifySource(source);
+  let text: string;
+  let label: string;
+
+  if (classified.kind === "file") {
+    label = classified.path as string;
+    try {
+      text = readFileSync(label, "utf8");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const tag = (err as NodeJS.ErrnoException).code === "ENOENT" ? "not found" : "cannot read";
+      throw new ProfileError(`Profile ${tag}: ${label}${tag === "cannot read" ? ` (${msg})` : ""}`);
+    }
+  } else {
+    label = classified.url as string;
+    text = await fetchRemote(label, opts);
+  }
+
+  return parseProfile(text, label);
+}
+
+function describe(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "list";
+  return typeof value;
+}

--- a/cli/src/lib/profiles.ts
+++ b/cli/src/lib/profiles.ts
@@ -20,7 +20,7 @@ const MODULE_KEY_SET = new Set<string>(MODULE_KEYS);
 const GROUP_SET = new Set<string>(GROUPS);
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
-const GITHUB_SHORTHAND_RE = /^([\w.-]+)\/([\w.-]+)(?:@([\w./-]+))?:(.+)$/;
+const GITHUB_SHORTHAND_RE = /^([\w.-]+)\/([\w.-]+)(?:@([\w./-]+))?:([\w./-]+)$/;
 
 export class ProfileError extends Error {
   constructor(message: string) {
@@ -123,12 +123,18 @@ export interface SourceClassification {
 
 /** Classify a --config argument as a local file, HTTPS URL, or GitHub shorthand. */
 export function classifySource(source: string): SourceClassification {
-  if (source.startsWith("http://") || source.startsWith("https://")) {
+  if (source.startsWith("http://")) {
+    throw new ProfileError(`Refusing to load profile over plaintext http:// — use https:// (${source})`);
+  }
+  if (source.startsWith("https://")) {
     return { kind: "url", url: source };
   }
   const match = GITHUB_SHORTHAND_RE.exec(source);
   if (match) {
     const [, org, repo, ref, path] = match;
+    if (path.split("/").some((seg) => seg === "..")) {
+      throw new ProfileError(`GitHub shorthand path may not contain '..' segments: ${source}`);
+    }
     const url = `https://raw.githubusercontent.com/${org}/${repo}/${ref ?? "HEAD"}/${path}`;
     return { kind: "github", url };
   }

--- a/cli/src/lib/selection.ts
+++ b/cli/src/lib/selection.ts
@@ -5,6 +5,7 @@
 
 import type { InitFlags } from "./args.js";
 import { type ModuleSpec, keysForGroups, resolveOrder } from "./modules.js";
+import type { ProfileSelection } from "./profiles.js";
 import type { Platform } from "./types.js";
 
 export interface SelectionResult {
@@ -16,8 +17,9 @@ export interface SelectionResult {
   platformSkipped: ModuleSpec[];
 }
 
-export function selectModules(flags: InitFlags, platform: Platform): SelectionResult {
-  // Build the set of explicitly requested keys (null = "all")
+export function selectModules(flags: InitFlags, platform: Platform, profile?: ProfileSelection): SelectionResult {
+  // Build the set of explicitly requested keys (null = "all").
+  // CLI --only/--group override the profile; otherwise fall back to profile selection.
   let want: Set<string> | null = null;
 
   if (flags.only || flags.group) {
@@ -28,14 +30,20 @@ export function selectModules(flags: InitFlags, platform: Platform): SelectionRe
       const only = flags.only;
       want = want !== null ? new Set([...want].filter((k) => only.has(k))) : only;
     }
+  } else if (profile?.want) {
+    want = profile.want;
   }
+
+  // --skip is always additive with profile skip.
+  const skipSet = new Set<string>(profile?.skip ?? []);
+  for (const k of flags.skip) skipSet.add(k);
 
   // Resolve full order with dependency expansion
   const allSpecs = resolveOrder(want ?? undefined);
 
   // Separate platform-incompatible modules
   const platformSkipped = allSpecs.filter((s) => !s.platforms.has(platform));
-  let selected = allSpecs.filter((s) => s.platforms.has(platform) && !flags.skip.has(s.key));
+  let selected = allSpecs.filter((s) => s.platforms.has(platform) && !skipSet.has(s.key));
 
   // When no explicit selection, filter out modules not default for this platform
   let optional: ModuleSpec[] = [];

--- a/cli/src/test/claude-args.test.ts
+++ b/cli/src/test/claude-args.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { parseClaudeFlags, parseDisablePasswordFlags } from "../lib/args.js";
+
+describe("parseClaudeFlags", () => {
+  test("no args -> defaults", () => {
+    const f = parseClaudeFlags([]);
+    expect(f.plan).toBeNull();
+    expect(f.toggle1m).toBeNull();
+    expect(f.channels).toBe(false);
+    expect(f.error).toBeNull();
+  });
+
+  test("--channels", () => {
+    expect(parseClaudeFlags(["--channels"]).channels).toBe(true);
+  });
+
+  test("--plan valid", () => {
+    const f = parseClaudeFlags(["--plan", "max20x"]);
+    expect(f.plan).toBe("max20x");
+    expect(f.error).toBeNull();
+  });
+
+  test("--plan invalid value", () => {
+    const f = parseClaudeFlags(["--plan", "starter"]);
+    expect(f.plan).toBeNull();
+    expect(f.error).toMatch(/Unknown plan 'starter'/);
+  });
+
+  test("--plan missing value", () => {
+    const f = parseClaudeFlags(["--plan"]);
+    expect(f.error).toMatch(/Missing value for --plan/);
+  });
+
+  test("--1m on", () => {
+    expect(parseClaudeFlags(["--1m", "on"]).toggle1m).toBe("on");
+  });
+
+  test("--1m off", () => {
+    expect(parseClaudeFlags(["--1m", "off"]).toggle1m).toBe("off");
+  });
+
+  test("--1m invalid value", () => {
+    const f = parseClaudeFlags(["--1m", "maybe"]);
+    expect(f.toggle1m).toBeNull();
+    expect(f.error).toMatch(/--1m requires 'on' or 'off'/);
+  });
+});
+
+describe("parseDisablePasswordFlags", () => {
+  test("no args", () => {
+    expect(parseDisablePasswordFlags([]).yes).toBe(false);
+  });
+
+  test("--yes", () => {
+    expect(parseDisablePasswordFlags(["--yes"]).yes).toBe(true);
+  });
+
+  test("-y short form", () => {
+    expect(parseDisablePasswordFlags(["-y"]).yes).toBe(true);
+  });
+});

--- a/cli/src/test/jsonConfig.test.ts
+++ b/cli/src/test/jsonConfig.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readJson, updateJson } from "../lib/jsonConfig.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "devlair-jsonconfig-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("readJson", () => {
+  test("returns {} for missing file", () => {
+    expect(readJson(join(tmpDir, "missing.json"))).toEqual({});
+  });
+
+  test("returns parsed contents", () => {
+    const path = join(tmpDir, "ok.json");
+    writeFileSync(path, JSON.stringify({ a: 1, b: "two" }));
+    expect(readJson(path)).toEqual({ a: 1, b: "two" });
+  });
+
+  test("returns {} for corrupt JSON", () => {
+    const path = join(tmpDir, "bad.json");
+    writeFileSync(path, "{ this is not json");
+    expect(readJson(path)).toEqual({});
+  });
+
+  test("returns {} for non-object JSON", () => {
+    const path = join(tmpDir, "list.json");
+    writeFileSync(path, "[1, 2, 3]");
+    expect(readJson(path)).toEqual({});
+  });
+});
+
+describe("updateJson", () => {
+  test("creates file with parent dir", () => {
+    const path = join(tmpDir, "nested", "deep", "config.json");
+    updateJson(path, { model: "sonnet" });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ model: "sonnet" });
+  });
+
+  test("merges with existing keys", () => {
+    const path = join(tmpDir, "merge.json");
+    writeFileSync(path, JSON.stringify({ a: 1, model: "old" }));
+    updateJson(path, { model: "opus[1m]", b: 2 });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ a: 1, model: "opus[1m]", b: 2 });
+  });
+
+  test("overwrites corrupt files cleanly", () => {
+    const path = join(tmpDir, "broken.json");
+    writeFileSync(path, "garbage");
+    updateJson(path, { model: "sonnet" });
+    expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({ model: "sonnet" });
+  });
+
+  test("writes trailing newline", () => {
+    const path = join(tmpDir, "newline.json");
+    updateJson(path, { x: 1 });
+    expect(readFileSync(path, "utf8").endsWith("\n")).toBe(true);
+  });
+});

--- a/cli/src/test/profiles.test.ts
+++ b/cli/src/test/profiles.test.ts
@@ -114,8 +114,12 @@ describe("classifySource", () => {
     expect(c.url).toBe("https://example.com/p.yaml");
   });
 
-  test("http URL", () => {
-    expect(classifySource("http://example.com/p.yaml").kind).toBe("url");
+  test("rejects plaintext http URL", () => {
+    expect(() => classifySource("http://example.com/p.yaml")).toThrow(ProfileError);
+  });
+
+  test("rejects GitHub shorthand with .. segments", () => {
+    expect(() => classifySource("acme/profiles:../etc/passwd")).toThrow(ProfileError);
   });
 
   test("GitHub shorthand with default ref", () => {

--- a/cli/src/test/profiles.test.ts
+++ b/cli/src/test/profiles.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProfileError, classifySource, loadProfile, parseProfile, resolveProfileKeys } from "../lib/profiles.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "devlair-profiles-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeProfile(filename: string, body: string): string {
+  const path = join(tmpDir, filename);
+  writeFileSync(path, body);
+  return path;
+}
+
+describe("parseProfile", () => {
+  test("accepts minimal valid profile", () => {
+    expect(parseProfile("version: 1\n")).toEqual({ version: 1 });
+  });
+
+  test("accepts full profile", () => {
+    const body = `
+version: 1
+name: full
+groups: [core, coding]
+skip: [system]
+config:
+  github:
+    email: a@b.com
+`;
+    const data = parseProfile(body);
+    expect(data.name).toBe("full");
+    expect(data.groups).toEqual(["core", "coding"]);
+    expect(data.skip).toEqual(["system"]);
+    expect(data.config?.github).toEqual({ email: "a@b.com" });
+  });
+
+  test("rejects missing version", () => {
+    expect(() => parseProfile("name: x\n")).toThrow(/Unsupported profile version/);
+  });
+
+  test("rejects wrong version", () => {
+    expect(() => parseProfile("version: 2\n")).toThrow(/expected 1/);
+  });
+
+  test("rejects unknown group", () => {
+    expect(() => parseProfile("version: 1\ngroups: [core, bogus]\n")).toThrow(/Unknown group 'bogus'/);
+  });
+
+  test("rejects unknown module", () => {
+    expect(() => parseProfile("version: 1\nmodules: [system, bogus]\n")).toThrow(/Unknown module 'bogus'/);
+  });
+
+  test("rejects unknown module in skip", () => {
+    expect(() => parseProfile("version: 1\nskip: [bogus]\n")).toThrow(/Unknown module 'bogus'/);
+  });
+
+  test("rejects unknown module in config", () => {
+    expect(() => parseProfile("version: 1\nconfig:\n  bogus: {}\n")).toThrow(/Unknown module 'bogus' in config/);
+  });
+
+  test("rejects modules + groups together", () => {
+    expect(() => parseProfile("version: 1\nmodules: [system]\ngroups: [core]\n")).toThrow(/mutually exclusive/);
+  });
+
+  test("rejects non-mapping YAML", () => {
+    expect(() => parseProfile("- a\n- b\n")).toThrow(/must be a YAML mapping/);
+  });
+
+  test("rejects invalid YAML", () => {
+    expect(() => parseProfile(":\n  - :\n  invalid: [\n")).toThrow(/Invalid YAML/);
+  });
+
+  test("rejects name as non-string", () => {
+    expect(() => parseProfile("version: 1\nname: 123\n")).toThrow();
+  });
+});
+
+describe("resolveProfileKeys", () => {
+  test("modules become explicit want set", () => {
+    const { want, skip } = resolveProfileKeys(parseProfile("version: 1\nmodules: [system, zsh]\n"));
+    expect(want).toEqual(new Set(["system", "zsh"]));
+    expect(skip).toEqual(new Set());
+  });
+
+  test("groups expand to module keys", () => {
+    const { want } = resolveProfileKeys(parseProfile("version: 1\ngroups: [core]\n"));
+    expect(want).toEqual(new Set(["system", "timezone", "zsh", "shell"]));
+  });
+
+  test("no selection returns null want", () => {
+    const { want, skip } = resolveProfileKeys(parseProfile("version: 1\n"));
+    expect(want).toBeNull();
+    expect(skip).toEqual(new Set());
+  });
+
+  test("skip is preserved", () => {
+    const { skip } = resolveProfileKeys(parseProfile("version: 1\nskip: [system, tmux]\n"));
+    expect(skip).toEqual(new Set(["system", "tmux"]));
+  });
+});
+
+describe("classifySource", () => {
+  test("https URL", () => {
+    const c = classifySource("https://example.com/p.yaml");
+    expect(c.kind).toBe("url");
+    expect(c.url).toBe("https://example.com/p.yaml");
+  });
+
+  test("http URL", () => {
+    expect(classifySource("http://example.com/p.yaml").kind).toBe("url");
+  });
+
+  test("GitHub shorthand with default ref", () => {
+    const c = classifySource("acme/profiles:dev.yaml");
+    expect(c.kind).toBe("github");
+    expect(c.url).toBe("https://raw.githubusercontent.com/acme/profiles/HEAD/dev.yaml");
+  });
+
+  test("GitHub shorthand with explicit ref", () => {
+    const c = classifySource("acme/profiles@v1.2.0:nested/dev.yaml");
+    expect(c.kind).toBe("github");
+    expect(c.url).toBe("https://raw.githubusercontent.com/acme/profiles/v1.2.0/nested/dev.yaml");
+  });
+
+  test("local relative path", () => {
+    const c = classifySource("./setup.yaml");
+    expect(c.kind).toBe("file");
+    expect(c.path).toBe("./setup.yaml");
+  });
+
+  test("local absolute path", () => {
+    const c = classifySource("/tmp/setup.yaml");
+    expect(c.kind).toBe("file");
+  });
+});
+
+describe("loadProfile", () => {
+  test("reads local file", async () => {
+    const path = writeProfile("p.yaml", "version: 1\nname: local\n");
+    const profile = await loadProfile(path);
+    expect(profile.name).toBe("local");
+  });
+
+  test("missing local file raises ProfileError", async () => {
+    await expect(loadProfile(join(tmpDir, "missing.yaml"))).rejects.toBeInstanceOf(ProfileError);
+  });
+
+  test("fetches via HTTPS URL using injected fetch", async () => {
+    const fakeFetch = async () => new Response("version: 1\nname: remote\n", { status: 200, statusText: "OK" });
+    const profile = await loadProfile("https://example.test/p.yaml", { fetchImpl: fakeFetch, noCache: true });
+    expect(profile.name).toBe("remote");
+  });
+
+  test("resolves GitHub shorthand to raw.githubusercontent URL", async () => {
+    let requested = "";
+    const fakeFetch = async (input: RequestInfo | URL) => {
+      requested = typeof input === "string" ? input : input.toString();
+      return new Response("version: 1\n", { status: 200 });
+    };
+    await loadProfile("acme/profiles:dev.yaml", { fetchImpl: fakeFetch, noCache: true });
+    expect(requested).toBe("https://raw.githubusercontent.com/acme/profiles/HEAD/dev.yaml");
+  });
+
+  test("non-2xx response raises ProfileError", async () => {
+    const fakeFetch = async () => new Response("nope", { status: 404, statusText: "Not Found" });
+    await expect(
+      loadProfile("https://example.test/missing.yaml", { fetchImpl: fakeFetch, noCache: true }),
+    ).rejects.toThrow(/404/);
+  });
+
+  test("invalid remote YAML raises ProfileError", async () => {
+    const fakeFetch = async () => new Response("version: 99\n", { status: 200 });
+    await expect(loadProfile("https://example.test/bad.yaml", { fetchImpl: fakeFetch, noCache: true })).rejects.toThrow(
+      /Unsupported profile version/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Ports the last two v2 feature commands as Ink views:

- **`disable-password`** (linux-only)
  - Verifies the invoking user's `authorized_keys` is non-empty before doing anything destructive.
  - Prompts `y/N` for confirmation (or `--yes`/`-y` to skip for scripts).
  - Patches `/etc/ssh/sshd_config.d/99-hardened.conf` and restarts sshd via `systemctl`.
  - Bails cleanly on macOS/WSL with an explanatory message instead of half-applying changes.

- **`claude --plan TIER`** — writes `~/.claude/devlair-config.json` (`pro` / `max5x` / `max20x`).
- **`claude --1m on|off`** — toggles `~/.claude/settings.json` model between `opus[1m]` and `sonnet`.
- **`claude --channels`** — diagnoses the telegram channel setup (settings flags, plugin install, wrapper, bun, token) and prints the one-time setup guide.
- **`claude`** (no args) — short status panel (plan, model) and a note that the usage dashboard is v1-only.

### Out of scope

The v1 transcript-parsing usage dashboard (`_dashboard_panel`, `_parse_transcript`, `PLAN_BUDGETS` in `devlair/features/claude.py`) is **intentionally not ported** — those numbers depend on reverse-engineered Anthropic budgets that drift quickly. Users who want the dashboard should pin to v1.

### Plumbing

- New `readJson` / `updateJson` helpers (shallow merge, missing/corrupt files read as `{}`).
- New argument parsers: `parseClaudeFlags`, `parseDisablePasswordFlags`.
- `disable-password` joins the elevated-command set (`init`, `doctor`, `upgrade`); `claude` runs unprivileged.
- `Help.tsx` drops the Sync & Filesystem section (those commands aren't in v2) and updates the `claude` entry to reflect the v2 surface.

### Hook fix bundled in

`fix(hooks): match gh pr create when prefixed with cd, &&, ;, or pipe` — the `/review-pr` trigger hook was anchored at the start of the bash command, so `cd /repo && gh pr create ...` (which happens when the Bash tool's cwd drifts into a subdir) silently skipped review. That's why PR #73 didn't get an auto-review. Regex now matches `gh pr create` after `&&`, `;`, `|`, or whitespace, still constrained to line 1 (so heredoc commit bodies don't false-fire).

Closes #45

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (biome)
- [x] `bun test` — 153 pass / 0 fail (19 new tests for flag parsing + jsonConfig)
- [ ] Smoke test: `devlair claude` shows status panel
- [ ] Smoke test: `devlair claude --plan max20x` then `devlair claude` shows updated plan
- [ ] Smoke test: `devlair claude --1m on` then verify `~/.claude/settings.json`
- [ ] Smoke test: `devlair claude --channels` on a configured machine
- [ ] Smoke test: `sudo devlair disable-password` (run on a throwaway VM with key access verified first!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)