### PR TITLE
fix(cli): re-exec with execPath under sudo to fix WSL elevation

### DIFF
--- a/cli/src/lib/elevate.ts
+++ b/cli/src/lib/elevate.ts
@@ -12,7 +12,11 @@ export function elevateIfNeeded(): void {
   // Preserve only the env vars we need — blanket -E would forward secrets
   // like AWS_SECRET_ACCESS_KEY to every child module running as root.
   const preserve = ["TERM", "COLORTERM", "LANG", "LC_ALL"].join(",");
-  const result = spawnSync("sudo", [`--preserve-env=${preserve}`, "--", ...process.argv], {
+  // In a bun-compiled binary, process.argv[0] is the literal "bun" and
+  // argv[1] is a /$bunfs/... internal path — neither resolves under sudo.
+  // Re-exec the real binary (process.execPath) with the user-facing args only.
+  const userArgs = process.argv.slice(2);
+  const result = spawnSync("sudo", [`--preserve-env=${preserve}`, "--", process.execPath, ...userArgs], {
     stdio: "inherit",
   });
 


### PR DESCRIPTION
## Summary

- `devlair init` on a fresh WSL Ubuntu after `--pre` install was failing with `sudo: bun: command not found`.
- In a `bun build --compile` binary, `process.argv[0]` is the literal string `"bun"` and `argv[1]` is an internal `/$bunfs/...` path — so `elevateIfNeeded` was telling sudo to exec `bun`, which is not on the user's PATH.
- Fix: re-exec with `process.execPath` (the real binary) and the user-facing args only (`argv.slice(2)`).

Verified locally with a `bun build --compile` binary and a fake `sudo` on PATH — sudo is now invoked with `/.../dist/devlair init` instead of `bun /$bunfs/... init`.

Closes #81

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (154 pass)
- [x] Manual: compiled binary + fake `sudo` shim shows `execPath` is passed
- [ ] Manual smoke test on a fresh WSL Ubuntu following the repro in #81 <!-- needs-manual: environment-specific -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
