### PR TITLE
fix(v2/install): ship modules tarball alongside binary

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -144,25 +144,53 @@ jobs:
           name: devlair-cli-linux-${{ matrix.arch }}
           path: cli/dist/devlair-cli-linux-${{ matrix.arch }}
 
-  checksums-cli:
-    needs: [release-please, build-cli]
+  package-cli-modules:
+    needs: release-please
     if: needs.release-please.outputs.cli_release_created == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Download all binaries
+      - uses: actions/checkout@v4
+
+      - name: Package modules
+        run: tar -czf modules.tar.gz modules
+
+      - name: Upload tarball to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-please.outputs.cli_tag_name }}
+          files: modules.tar.gz
+
+      - name: Upload tarball as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: modules-tarball
+          path: modules.tar.gz
+
+  checksums-cli:
+    needs: [release-please, build-cli, package-cli-modules]
+    if: needs.release-please.outputs.cli_release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binaries
         uses: actions/download-artifact@v4
         with:
-          path: binaries
+          path: assets
           pattern: devlair-cli-linux-*
           merge-multiple: true
 
+      - name: Download modules tarball
+        uses: actions/download-artifact@v4
+        with:
+          path: assets
+          name: modules-tarball
+
       - name: Generate checksums
         run: |
-          cd binaries
-          sha256sum devlair-cli-linux-* | tee checksums.txt
+          cd assets
+          sha256sum devlair-cli-linux-* modules.tar.gz | tee checksums.txt
 
       - name: Upload checksums to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.release-please.outputs.cli_tag_name }}
-          files: binaries/checksums.txt
+          files: assets/checksums.txt

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ uv run ruff check devlair/ tests/
 curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash -s -- --pre
 ```
 
-This downloads the latest `devlair-cli-v*` prerelease asset and installs it as `/usr/local/bin/devlair`, replacing v1. To roll back, re-run the installer without `--pre`.
+This downloads the latest `devlair-cli-v*` prerelease asset and installs it as `/usr/local/bin/devlair`, replacing v1. The companion `modules.tar.gz` (shell scripts invoked by the wizard) is verified against the same `checksums.txt` and extracted to `/usr/local/share/devlair/modules/`. To roll back, re-run the installer without `--pre`.
 
 **Removed in v2** (vs. v1):
 

--- a/cli/src/lib/paths.ts
+++ b/cli/src/lib/paths.ts
@@ -5,31 +5,34 @@ import { join, resolve } from "node:path";
 
 let _modulesDir: string | undefined;
 
+const INSTALL_MODULES_DIR = "/usr/local/share/devlair/modules";
+
 /**
  * Return the absolute path to the modules/ directory.
  *
- * In development: cli/src/lib/paths.ts → ../../../modules/
- * In compiled binary: dist/cli.js → ../modules/
+ * Production: install.sh extracts modules.tar.gz to /usr/local/share/devlair/modules/.
+ * Development: cli/src/lib/paths.ts → ../../../modules/ in the repo.
+ *
+ * The compiled-binary path can't be derived from process.argv[0] (which is the
+ * literal string "bun" in bun-compiled binaries) or from import.meta.dir (which
+ * points into the internal /$bunfs/... virtual FS), so we pin the install path
+ * instead and fall back to the dev layout.
  */
 export function modulesDir(): string {
   if (_modulesDir) return _modulesDir;
 
-  // Try relative to this source file first (development layout)
+  if (existsSync(join(INSTALL_MODULES_DIR, "_lib.sh"))) {
+    _modulesDir = INSTALL_MODULES_DIR;
+    return _modulesDir;
+  }
+
   const devPath = resolve(import.meta.dir, "../../../modules");
   if (existsSync(join(devPath, "_lib.sh"))) {
     _modulesDir = devPath;
     return _modulesDir;
   }
 
-  // Try relative to the binary (compiled layout: dist/devlair → ../modules/)
-  const binDir = resolve(process.argv[0], "..");
-  const binPath = resolve(binDir, "../modules");
-  if (existsSync(join(binPath, "_lib.sh"))) {
-    _modulesDir = binPath;
-    return _modulesDir;
-  }
-
-  throw new Error(`Cannot find modules/ directory (tried ${devPath} and ${binPath})`);
+  throw new Error(`Cannot find modules/ directory (tried ${INSTALL_MODULES_DIR} and ${devPath})`);
 }
 
 /**

--- a/install.sh
+++ b/install.sh
@@ -113,8 +113,13 @@ if [[ "$CHANNEL" == "pre" ]]; then
   EXPECTED_MODULES=$(grep " modules.tar.gz\$" "$TMP_CHECKSUMS" | awk '{print $1}')
   ACTUAL_MODULES=$(sha256sum "$TMP_MODULES" | awk '{print $1}')
 
+  # Modules ship a fresh tree on every release — a missing checksum entry
+  # means CI is misconfigured, not a soft warning. Hard-fail rather than
+  # extract an unverified archive and execute its scripts as root.
   if [[ -z "$EXPECTED_MODULES" ]]; then
-    echo "WARNING: No checksum found for modules.tar.gz — skipping verification."
+    echo "ERROR: No checksum entry for modules.tar.gz in checksums.txt — aborting." >&2
+    rm -f "$TMP_MODULES"
+    exit 1
   elif [[ "$ACTUAL_MODULES" != "$EXPECTED_MODULES" ]]; then
     echo "ERROR: Checksum mismatch for modules.tar.gz!" >&2
     echo "  Expected: ${EXPECTED_MODULES}" >&2
@@ -126,24 +131,25 @@ if [[ "$CHANNEL" == "pre" ]]; then
   fi
 
   # Replace the modules dir atomically: extract to a staging path, then swap.
+  # --no-same-owner / --no-same-permissions ignore uid/gid/mode bits from the
+  # archive so a future tampered tarball can't plant setuid bits or odd owners
+  # under sudo; chmod immediately after pins a known-safe mode regardless of
+  # the installer's umask.
   STAGE_DIR=$(mktemp -d)
-  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR"
+  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR" --no-same-owner --no-same-permissions
+  chmod -R u=rwX,go=rX "$STAGE_DIR/modules"
   rm -f "$TMP_MODULES"
 
-  if [[ -w "$(dirname "$SHARE_DIR")" ]]; then
-    rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
-    [[ -d "$SHARE_DIR" ]] && mv "$SHARE_DIR" "${SHARE_DIR}.old"
-    mkdir -p "$SHARE_DIR"
-    mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
-    rm -rf "${SHARE_DIR}.old" "$STAGE_DIR"
-  else
-    sudo rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
-    [[ -d "$SHARE_DIR" ]] && sudo mv "$SHARE_DIR" "${SHARE_DIR}.old"
-    sudo mkdir -p "$SHARE_DIR"
-    sudo mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
-    sudo rm -rf "${SHARE_DIR}.old"
-    rm -rf "$STAGE_DIR"
-  fi
+  MAYBE_SUDO=""
+  [[ ! -w "$(dirname "$SHARE_DIR")" ]] && MAYBE_SUDO="sudo"
+
+  $MAYBE_SUDO rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
+  [[ -d "$SHARE_DIR" ]] && $MAYBE_SUDO mv "$SHARE_DIR" "${SHARE_DIR}.old"
+  $MAYBE_SUDO mkdir -m 755 -p "$SHARE_DIR"
+  $MAYBE_SUDO mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
+  $MAYBE_SUDO chmod 755 "${SHARE_DIR}/modules"
+  $MAYBE_SUDO rm -rf "${SHARE_DIR}.old"
+  rm -rf "$STAGE_DIR"
 
   echo "✓ modules installed to ${SHARE_DIR}/modules"
 fi

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 REPO="ettoreaquino/devlair"
 BIN="devlair"
 INSTALL_DIR="/usr/local/bin"
+SHARE_DIR="/usr/local/share/devlair"
 CHANNEL="stable"
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
@@ -78,7 +79,6 @@ curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
 # ── Verify SHA-256 checksum ──────────────────────────────────────────────────
 EXPECTED=$(grep " ${ASSET}\$" "$TMP_CHECKSUMS" | awk '{print $1}')
 ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
-rm -f "$TMP_CHECKSUMS"
 
 if [[ -z "$EXPECTED" ]]; then
   echo "WARNING: No checksum found for ${ASSET} — skipping verification."
@@ -101,6 +101,54 @@ else
   sudo mv "$TMP" "${INSTALL_DIR}/${BIN}"
 fi
 chmod 755 "${INSTALL_DIR}/${BIN}" 2>/dev/null || sudo chmod 755 "${INSTALL_DIR}/${BIN}"
+
+# ── Pre-release: fetch modules tarball ────────────────────────────────────────
+# v2 shell modules live outside the compiled binary and ship as a separate
+# tarball. v1 (stable) is self-contained and does not need this step.
+if [[ "$CHANNEL" == "pre" ]]; then
+  TMP_MODULES=$(mktemp)
+  echo "Fetching modules tarball..."
+  curl -fsSL "${BASE_URL}/modules.tar.gz" -o "$TMP_MODULES"
+
+  EXPECTED_MODULES=$(grep " modules.tar.gz\$" "$TMP_CHECKSUMS" | awk '{print $1}')
+  ACTUAL_MODULES=$(sha256sum "$TMP_MODULES" | awk '{print $1}')
+
+  if [[ -z "$EXPECTED_MODULES" ]]; then
+    echo "WARNING: No checksum found for modules.tar.gz — skipping verification."
+  elif [[ "$ACTUAL_MODULES" != "$EXPECTED_MODULES" ]]; then
+    echo "ERROR: Checksum mismatch for modules.tar.gz!" >&2
+    echo "  Expected: ${EXPECTED_MODULES}" >&2
+    echo "  Got:      ${ACTUAL_MODULES}" >&2
+    rm -f "$TMP_MODULES"
+    exit 1
+  else
+    echo "✓ modules.tar.gz SHA-256 verified"
+  fi
+
+  # Replace the modules dir atomically: extract to a staging path, then swap.
+  STAGE_DIR=$(mktemp -d)
+  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR"
+  rm -f "$TMP_MODULES"
+
+  if [[ -w "$(dirname "$SHARE_DIR")" ]]; then
+    rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
+    [[ -d "$SHARE_DIR" ]] && mv "$SHARE_DIR" "${SHARE_DIR}.old"
+    mkdir -p "$SHARE_DIR"
+    mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
+    rm -rf "${SHARE_DIR}.old" "$STAGE_DIR"
+  else
+    sudo rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
+    [[ -d "$SHARE_DIR" ]] && sudo mv "$SHARE_DIR" "${SHARE_DIR}.old"
+    sudo mkdir -p "$SHARE_DIR"
+    sudo mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
+    sudo rm -rf "${SHARE_DIR}.old"
+    rm -rf "$STAGE_DIR"
+  fi
+
+  echo "✓ modules installed to ${SHARE_DIR}/modules"
+fi
+
+rm -f "$TMP_CHECKSUMS"
 
 echo ""
 echo "✓ devlair ${LATEST} installed to ${INSTALL_DIR}/${BIN}"


### PR DESCRIPTION
## Summary

- Ship the `modules/` shell scripts to `--pre` users so `devlair init` can actually run them.
- Compiled v2 binary calls external scripts in `modules/`, but `install.sh` only downloaded the binary — on a fresh WSL the wizard reached module execution and then failed with `Cannot find modules/ directory`.
- Path resolver was also broken: `process.argv[0]` is the literal string `"bun"` in bun-compiled binaries, so `resolve(process.argv[0], "..")` collapsed to cwd and produced the misleading `/modules` / `/mnt/c/Users/modules` paths.

## Changes

- `.github/workflows/release-please.yml` — new `package-cli-modules` job tars `modules/` into `modules.tar.gz`, uploads as a release asset alongside the binary; `checksums-cli` now covers both.
- `install.sh` — on `--pre`, download `modules.tar.gz`, verify SHA-256 against the same `checksums.txt`, atomically install to `/usr/local/share/devlair/modules/` (stage dir + swap via `.old`, `MAYBE_SUDO`-collapsed branches). Hardened: `tar --no-same-owner --no-same-permissions` + `chmod -R` on staging, `mkdir -m 755`, `chmod 755` on target, hard-fail when the modules checksum entry is missing.
- `cli/src/lib/paths.ts` — try `/usr/local/share/devlair/modules` first (production), fall back to the repo's `modules/` (dev). Drop the broken `process.argv[0]` branch.
- `README.md` — note that the `--pre` installer also extracts `modules.tar.gz` to `/usr/local/share/devlair/modules/`.

Closes #84

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (154 pass)
- [x] `bash -n install.sh`
- [x] Local simulation: tar repo `modules/` → extract to staging with `--no-same-owner --no-same-permissions` + `chmod -R` → swap into fake `SHARE_DIR` → `_lib.sh` present at mode 755
- [x] Dev mode: resolver returns repo's in-tree `modules/`
- [ ] End-to-end: merge → release-please cuts a new alpha → `curl … | sudo bash -s -- --pre` on fresh WSL → `devlair init` finds modules and runs each step <!-- needs-manual: full release cycle -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
