### PR TITLE
fix(v2): bootstrap jq + surface stderr in init UI

### DIFF
--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -137,6 +137,18 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
             const { value, done: iterDone } = await iter.next();
             if (iterDone) {
               finalStatus = value.status;
+              // A module that exits non-zero without emitting a `result` event
+              // (e.g. a missing runtime dep aborting _lib.sh early) leaves the
+              // UI showing a bare ✗. Fall back to the last non-empty stderr
+              // line so the user sees what actually happened.
+              if (!finalDetail && finalStatus !== "ok") {
+                const lastErr = value.stderr
+                  .split("\n")
+                  .map((s) => s.trim())
+                  .filter(Boolean)
+                  .pop();
+                if (lastErr) finalDetail = lastErr;
+              }
               break;
             }
             if (value.type === "progress") {

--- a/install.sh
+++ b/install.sh
@@ -152,6 +152,22 @@ if [[ "$CHANNEL" == "pre" ]]; then
   rm -rf "$STAGE_DIR"
 
   echo "✓ modules installed to ${SHARE_DIR}/modules"
+
+  # ── Pre-release: bootstrap runtime deps ────────────────────────────────────
+  # modules/_lib.sh hard-requires jq for context parsing; on a fresh Ubuntu
+  # the binary installs cleanly but every `devlair init` step exits 1 before
+  # emitting any output. Install jq up-front so the first wizard run works.
+  if ! command -v jq >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+      echo "Installing runtime dep: jq..."
+      $MAYBE_SUDO apt-get update -qq >/dev/null
+      $MAYBE_SUDO apt-get install -y -qq jq >/dev/null
+      echo "✓ jq installed"
+    else
+      echo "WARNING: jq is required by devlair modules but apt-get is not available." >&2
+      echo "Install jq manually before running 'devlair init'." >&2
+    fi
+  fi
 fi
 
 rm -f "$TMP_CHECKSUMS"


### PR DESCRIPTION
## Summary

After #82 + #85 landed, `v2.2.2-alpha.1` smoke-tested on a fresh WSL Ubuntu 24.04 produced a bare `✗` for every `devlair init` step — silent failure.

Two compounding bugs:

1. **`modules/_lib.sh` hard-requires `jq`.** Every module's first line is `read_context`, which aborts with `exit 1` if `jq` isn't on PATH. Ubuntu 24.04 doesn't preinstall jq, so every module exited 1 *before* emitting any JSON event on stdout.
2. **`cli/src/commands/init.tsx` ignored `RunResult.stderr`.** When a module exits non-zero without a `result` event, `finalDetail` stayed empty and the UI showed a bare `✗`. `runner.ts` already captures stderr into `RunResult.stderr` — the UI just dropped it. That's why bug #1 took two rounds to diagnose.

## Changes

- `install.sh` — on `--pre`, after placing the binary + modules, `apt-get install -y jq` if missing (`apt-get update -qq` first; clear warning on non-Debian systems).
- `cli/src/commands/init.tsx` — when `finalDetail` is empty after a non-ok exit, fall back to the last non-empty stderr line.

Closes #88

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (154 pass)
- [x] `bash -n install.sh`
- [ ] Manual: fresh Ubuntu 24.04, `curl … | sudo bash -s -- --pre` shows `Installing runtime dep: jq...`, then `devlair init` runs modules and surfaces real error text on any remaining failures <!-- needs-manual: full release cycle -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
