### PR TITLE
fix(modules): split system.sh essentials by platform to unblock WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
 
-Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `htop`, `tmux`, `zsh`, `bat`, `fzf`, `build-essential`, `ufw`, `fail2ban`, and more.
+Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `htop`, `tmux`, `zsh`, `bat`, `fzf`, `build-essential`, and more. On bare Linux it also installs `openssh-server`, `ufw`, `fail2ban`, and `avahi-daemon`; these are skipped on WSL because they ship systemd-managed postinst scripts that don't work under WSL's systemd-less default (the dedicated `ssh` and `firewall` modules are also Linux-only).
 
 </details>
 

--- a/modules/system.sh
+++ b/modules/system.sh
@@ -52,7 +52,11 @@ do_run() {
 }
 
 do_check() {
-  for pair in "git:git" "curl:curl" "tmux:tmux" "zsh:zsh" "ufw:ufw" "fail2ban:fail2ban-client"; do
+  local checks=( "git:git" "curl:curl" "tmux:tmux" "zsh:zsh" )
+  if [[ "$PLATFORM" == "linux" ]]; then
+    checks+=( "ufw:ufw" "fail2ban:fail2ban-client" )
+  fi
+  for pair in "${checks[@]}"; do
     label="${pair%%:*}"
     cmd="${pair##*:}"
     if cmd_exists "$cmd"; then

--- a/modules/system.sh
+++ b/modules/system.sh
@@ -14,10 +14,19 @@ PLATFORM=$(ctx_get platform)
 MODE=${1:-run}
 
 ESSENTIALS=(
-  openssh-server ufw fail2ban curl wget git vim htop tmux unzip
-  net-tools avahi-daemon build-essential ca-certificates gnupg jq
+  curl wget git vim htop tmux unzip
+  net-tools build-essential ca-certificates gnupg jq
   tree rsync zsh bat fzf locales
 )
+
+# Linux-only essentials. These packages either ship systemd-managed
+# postinst scripts (openssh-server, fail2ban) or require kernel features
+# (ufw needs netfilter, avahi-daemon is mDNS) that don't apply under
+# WSL's systemd-less default. Installing them on WSL leaves dpkg in a
+# broken state, poisoning every later apt-get install. The dedicated
+# ssh and firewall modules — both platforms={"linux"} — cover these on
+# bare Linux already.
+LINUX_ESSENTIALS=( openssh-server ufw fail2ban avahi-daemon )
 
 do_run() {
   json_progress "updating package lists"
@@ -25,6 +34,10 @@ do_run() {
   json_progress "upgrading packages"
   apt-get upgrade -y -qq >&2
   apt_install "${ESSENTIALS[@]}"
+
+  if [[ "$PLATFORM" == "linux" ]]; then
+    apt_install "${LINUX_ESSENTIALS[@]}"
+  fi
 
   # WSL extras: wslu provides wslview for opening URLs in the Windows browser
   if [[ "$PLATFORM" == "wsl" ]]; then


### PR DESCRIPTION
## Summary

`modules/system.sh` installed `openssh-server`, `ufw`, `fail2ban`, and `avahi-daemon` unconditionally on every platform. On WSL (systemd-less by default), `openssh-server`'s postinst fails (`systemctl restart ssh`), leaving dpkg half-configured and poisoning every subsequent `apt-get install` — which is why the `tmux` and `Dev tools` modules cascade-fail with the misleading trailing `E: Sub-process /usr/bin/dpkg returned an error code (1)`.

These are exactly the packages the dedicated `ssh` and `firewall` modules (both `platforms={"linux"}`) already cover on bare Linux. So on WSL they were both redundant and actively breaking the install.

PR #93 added an installer-side preflight that repairs *pre-existing* half-config. This PR is the missing other half: stop `system` from recreating the problem on every run.

## Changes

- `modules/system.sh` — split `ESSENTIALS` into two arrays:
  - `ESSENTIALS` (platform-agnostic): curl, git, vim, tmux, build-essential, jq, zsh, etc.
  - `LINUX_ESSENTIALS` (Linux-only): openssh-server, ufw, fail2ban, avahi-daemon
- Installed conditionally based on `PLATFORM`.

Closes #94

## Test plan

- [x] `bash -n modules/system.sh`
- [ ] Manual: fresh Ubuntu 24.04 WSL → `curl … \| sudo bash -s -- --pre` → `devlair init` completes System update, tmux, Dev tools without dpkg errors <!-- needs-manual: full release cycle -->
- [ ] Manual: bare Linux → `devlair init` still installs openssh-server/ufw/fail2ban via the system module path <!-- needs-manual: requires non-WSL test host -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)