### PR TITLE
fix(cli): trigger v2.2.4-alpha.1 release with WSL bootstrap fixes

### DIFF
--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# modules/system.sh — System update
+# cli/modules/system.sh — System update
 # devlair module: system
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Triggers a v2 release-please PR so the WSL bootstrap fixes — already merged to main but invisible to release-please's path filter — get packaged into a new alpha.

The WSL fixes (PRs #93, #95) touched \`install.sh\` (excluded from the \`cli\` component) and the pre-relocation \`modules/\` tree (untracked by either component at the time). Without a tracked-path commit, release-please can't open a release PR. This commit adds a one-line path comment in \`cli/modules/system.sh\` and uses the \`Release-As: 2.2.4-alpha.1\` footer to force the version.

After PR #98 moved \`modules/\` under \`cli/\`, future module fixes will trigger release-please automatically without this workaround.

## Test plan

- [ ] release-please opens a v2 release PR after merge
- [ ] Merging the release PR builds binary + \`modules.tar.gz\` and publishes \`devlair-cli v2.2.4-alpha.1\`
- [ ] Fresh WSL Ubuntu 24.04: \`curl … | sudo bash -s -- --pre\` succeeds without dpkg cascade failures
- [ ] \`devlair init\` completes with no failed modules on WSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)