### PR TITLE
feat(install): match devlair Dracula style and clarify WSL cleanup message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,29 @@ INSTALL_DIR="/usr/local/bin"
 SHARE_DIR="/usr/local/share/devlair"
 CHANNEL="stable"
 
+# ── Dracula-styled output ─────────────────────────────────────────────────────
+# Match cli/src/lib/theme.ts (and devlair/console.py). Auto-disable on non-TTY
+# or when NO_COLOR is set so piped/CI output stays clean.
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  C_PURPLE=$'\033[38;2;189;147;249m'
+  C_PINK=$'\033[38;2;255;121;198m'
+  C_GREEN=$'\033[38;2;80;250;123m'
+  C_ORANGE=$'\033[38;2;255;184;108m'
+  C_RED=$'\033[38;2;255;85;85m'
+  C_CYAN=$'\033[38;2;139;233;253m'
+  C_COMMENT=$'\033[38;2;98;114;164m'
+  C_BOLD=$'\033[1m'
+  C_RESET=$'\033[0m'
+else
+  C_PURPLE="" C_PINK="" C_GREEN="" C_ORANGE="" C_RED="" C_CYAN="" C_COMMENT="" C_BOLD="" C_RESET=""
+fi
+
+section() { printf "%s▸%s %s%s%s\n" "$C_PURPLE" "$C_RESET" "$C_BOLD" "$1" "$C_RESET"; }
+ok()      { printf "  %s✓%s %s\n" "$C_GREEN" "$C_RESET" "$1"; }
+warn()    { printf "  %s!%s %s\n" "$C_ORANGE" "$C_RESET" "$1"; }
+err()     { printf "  %s✗%s %s\n" "$C_RED" "$C_RESET" "$1" >&2; }
+meta()    { printf "    %s%s%s\n" "$C_COMMENT" "$1" "$C_RESET"; }
+
 # ── Parse flags ───────────────────────────────────────────────────────────────
 for arg in "$@"; do
   case "$arg" in
@@ -26,8 +49,8 @@ for arg in "$@"; do
       exit 0
       ;;
     *)
-      echo "Unknown option: $arg" >&2
-      echo "Run with --help for usage." >&2
+      err "Unknown option: $arg"
+      err "Run with --help for usage."
       exit 1
       ;;
   esac
@@ -39,15 +62,18 @@ case "$ARCH" in
   x86_64)          ARCH_SUFFIX="x86_64"  ;;
   aarch64 | arm64) ARCH_SUFFIX="aarch64" ;;
   *)
-    echo "Unsupported architecture: $ARCH" >&2
+    err "Unsupported architecture: $ARCH"
     exit 1
     ;;
 esac
 
+printf "\n%s%s devlair installer%s  %s· channel: %s · arch: %s%s\n\n" \
+  "$C_BOLD" "$C_PINK" "$C_RESET" "$C_COMMENT" "$CHANNEL" "$ARCH_SUFFIX" "$C_RESET"
+
 # ── Channel configuration ─────────────────────────────────────────────────────
+section "Resolving release"
 if [[ "$CHANNEL" == "pre" ]]; then
   ASSET_PREFIX="devlair-cli"
-  echo "Fetching latest devlair v2 alpha release..."
   # GitHub's /releases/latest endpoint excludes prereleases, so list and filter.
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
     | grep -o '"tag_name": *"devlair-cli-v[^"]*"' \
@@ -55,59 +81,63 @@ if [[ "$CHANNEL" == "pre" ]]; then
     | sed -E 's/.*"(devlair-cli-v[^"]*)"/\1/')
 else
   ASSET_PREFIX="devlair"
-  echo "Fetching latest devlair release..."
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
     | grep -o '"tag_name": *"[^"]*"' | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"')
 fi
 
 if [[ -z "${LATEST:-}" ]]; then
-  echo "Could not determine latest version. Check your internet connection." >&2
+  err "Could not determine latest version. Check your internet connection."
   exit 1
 fi
 
 ASSET="${ASSET_PREFIX}-linux-${ARCH_SUFFIX}"
-echo "Installing ${ASSET} from release ${LATEST}..."
+ok "release ${LATEST}"
+meta "asset: ${ASSET}"
 
 # ── Download binary + checksums ───────────────────────────────────────────────
+section "Downloading binary"
 BASE_URL="https://github.com/${REPO}/releases/download/${LATEST}"
 TMP=$(mktemp)
 TMP_CHECKSUMS=$(mktemp)
 curl -fsSL "${BASE_URL}/${ASSET}" -o "$TMP"
 curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
+ok "downloaded ${ASSET}"
 
 # ── Verify SHA-256 checksum ──────────────────────────────────────────────────
 EXPECTED=$(grep " ${ASSET}\$" "$TMP_CHECKSUMS" | awk '{print $1}')
 ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
 
 if [[ -z "$EXPECTED" ]]; then
-  echo "WARNING: No checksum found for ${ASSET} — skipping verification."
+  warn "no checksum found for ${ASSET} — skipping verification"
 elif [[ "$ACTUAL" != "$EXPECTED" ]]; then
-  echo "ERROR: Checksum mismatch!" >&2
-  echo "  Expected: ${EXPECTED}" >&2
-  echo "  Got:      ${ACTUAL}" >&2
+  err "checksum mismatch!"
+  meta "expected: ${EXPECTED}"
+  meta "got:      ${ACTUAL}"
   rm -f "$TMP"
   exit 1
 else
-  echo "✓ SHA-256 verified"
+  ok "SHA-256 verified"
 fi
 
 chmod 755 "$TMP"
 
 # ── Install (sudo if needed) ──────────────────────────────────────────────────
+section "Installing binary"
 if [[ -w "$INSTALL_DIR" ]]; then
   mv "$TMP" "${INSTALL_DIR}/${BIN}"
 else
   sudo mv "$TMP" "${INSTALL_DIR}/${BIN}"
 fi
 chmod 755 "${INSTALL_DIR}/${BIN}" 2>/dev/null || sudo chmod 755 "${INSTALL_DIR}/${BIN}"
+ok "${INSTALL_DIR}/${BIN}"
 
 # ── Pre-release: fetch modules tarball ────────────────────────────────────────
 # v2 shell modules live outside the compiled binary and ship as a separate
 # tarball. v1 (stable) is self-contained and does not need this step.
 if [[ "$CHANNEL" == "pre" ]]; then
+  section "Fetching v2 modules"
   TMP_MODULES=$(mktemp)
-  echo "Fetching modules tarball..."
   curl -fsSL "${BASE_URL}/modules.tar.gz" -o "$TMP_MODULES"
 
   EXPECTED_MODULES=$(grep " modules.tar.gz\$" "$TMP_CHECKSUMS" | awk '{print $1}')
@@ -117,17 +147,17 @@ if [[ "$CHANNEL" == "pre" ]]; then
   # means CI is misconfigured, not a soft warning. Hard-fail rather than
   # extract an unverified archive and execute its scripts as root.
   if [[ -z "$EXPECTED_MODULES" ]]; then
-    echo "ERROR: No checksum entry for modules.tar.gz in checksums.txt — aborting." >&2
+    err "no checksum entry for modules.tar.gz in checksums.txt — aborting"
     rm -f "$TMP_MODULES"
     exit 1
   elif [[ "$ACTUAL_MODULES" != "$EXPECTED_MODULES" ]]; then
-    echo "ERROR: Checksum mismatch for modules.tar.gz!" >&2
-    echo "  Expected: ${EXPECTED_MODULES}" >&2
-    echo "  Got:      ${ACTUAL_MODULES}" >&2
+    err "checksum mismatch for modules.tar.gz!"
+    meta "expected: ${EXPECTED_MODULES}"
+    meta "got:      ${ACTUAL_MODULES}"
     rm -f "$TMP_MODULES"
     exit 1
   else
-    echo "✓ modules.tar.gz SHA-256 verified"
+    ok "SHA-256 verified"
   fi
 
   # Replace the modules dir atomically: extract to a staging path, then swap.
@@ -150,23 +180,25 @@ if [[ "$CHANNEL" == "pre" ]]; then
   $MAYBE_SUDO chmod 755 "${SHARE_DIR}/modules"
   $MAYBE_SUDO rm -rf "${SHARE_DIR}.old"
   rm -rf "$STAGE_DIR"
+  ok "modules installed to ${SHARE_DIR}/modules"
 
-  echo "✓ modules installed to ${SHARE_DIR}/modules"
-
-  # ── Pre-release: repair WSL-specific broken dpkg state (Debian-like) ──────
-  # Ubuntu 24.04 WSL ships with openssh-server half-configured: its postinst
-  # calls `systemctl restart ssh`, but systemd isn't running by default on
-  # WSL, so the postinst exits 1 and dpkg leaves the package broken. After
-  # that, every `apt-get install` fails with a misleading trailing
-  # `E: Sub-process /usr/bin/dpkg returned an error code (1)` regardless of
+  # ── Pre-release: WSL-specific dpkg state cleanup ──────────────────────────
+  # Ubuntu 24.04 WSL ships with openssh-server in a half-configured state:
+  # its postinst calls `systemctl restart ssh`, but systemd isn't running by
+  # default on WSL, so the postinst exits 1 and dpkg leaves the package in
+  # `iU` (unpacked, not configured). After that, every subsequent apt-get
+  # install fails with a misleading trailing
+  # `E: Sub-process /usr/bin/dpkg returned an error code (1)`, regardless of
   # what package is being installed — poisoning devlair's apt-using modules.
   # Scoped to WSL so we don't purge a legitimately-running openssh-server
   # on a bare Linux server (which would lock out remote operators).
   if grep -qi microsoft /proc/version 2>/dev/null && command -v dpkg-query >/dev/null 2>&1; then
     ssh_status=$(dpkg-query -W -f='${Status}' openssh-server 2>/dev/null || true)
     if [[ -n "$ssh_status" && "$ssh_status" != "install ok installed" ]]; then
-      echo "Repairing pre-existing openssh-server half-config..."
+      section "Cleaning up Ubuntu WSL dpkg state"
+      warn "Ubuntu's openssh-server postinst failed under WSL (no systemd) — removing it so later apt installs succeed"
       $MAYBE_SUDO apt-get purge -y -qq openssh-server >/dev/null 2>&1 || true
+      ok "openssh-server cleared"
     fi
     $MAYBE_SUDO dpkg --configure -a >/dev/null 2>&1 || true
   fi
@@ -176,38 +208,32 @@ if [[ "$CHANNEL" == "pre" ]]; then
   # the binary installs cleanly but every `devlair init` step exits 1 before
   # emitting any output. Install jq up-front so the first wizard run works.
   if ! command -v jq >/dev/null 2>&1; then
+    section "Bootstrapping runtime deps"
     if command -v apt-get >/dev/null 2>&1; then
-      echo "Installing runtime dep: jq..."
       $MAYBE_SUDO apt-get update -qq >/dev/null
       $MAYBE_SUDO apt-get install -y -qq jq >/dev/null
-      echo "✓ jq installed"
+      ok "jq installed"
     else
-      echo "WARNING: jq is required by devlair modules but apt-get is not available." >&2
-      echo "Install jq manually before running 'devlair init'." >&2
+      warn "jq is required by devlair modules but apt-get is not available"
+      meta "install jq manually before running 'devlair init'"
     fi
   fi
 fi
 
 rm -f "$TMP_CHECKSUMS"
 
-echo ""
-echo "✓ devlair ${LATEST} installed to ${INSTALL_DIR}/${BIN}"
-echo ""
+printf "\n%s✓%s %sdevlair %s installed%s\n" "$C_GREEN" "$C_RESET" "$C_BOLD" "$LATEST" "$C_RESET"
+printf "  %s%s%s\n\n" "$C_COMMENT" "${INSTALL_DIR}/${BIN}" "$C_RESET"
 
 # ── Channel-specific post-install notice ──────────────────────────────────────
 if [[ "$CHANNEL" == "pre" ]]; then
-  cat <<'NOTICE'
-⚠  You installed a v2 alpha. The following v1 commands have been REMOVED:
-
-    devlair sync         — pin to v1 or run `rclone bisync` directly
-    devlair filesystem   — not ported
-    devlair claw         — not ported
-
-Report issues: https://github.com/ettoreaquino/devlair/issues
-
-NOTICE
+  printf "%s!%s %sv2 alpha%s — the following v1 commands have been REMOVED:\n\n" \
+    "$C_ORANGE" "$C_RESET" "$C_BOLD" "$C_RESET"
+  printf "  %sdevlair sync%s         pin to v1 or run 'rclone bisync' directly\n" "$C_PINK" "$C_RESET"
+  printf "  %sdevlair filesystem%s   not ported\n" "$C_PINK" "$C_RESET"
+  printf "  %sdevlair claw%s         not ported\n\n" "$C_PINK" "$C_RESET"
+  printf "  %sReport issues: https://github.com/ettoreaquino/devlair/issues%s\n\n" "$C_COMMENT" "$C_RESET"
 fi
 
-echo "Next step:"
-echo "  devlair init"
-echo ""
+printf "%sNext step:%s\n" "$C_BOLD" "$C_RESET"
+printf "  %sdevlair init%s\n\n" "$C_PURPLE" "$C_RESET"

--- a/install.sh
+++ b/install.sh
@@ -16,9 +16,15 @@ INSTALL_DIR="/usr/local/bin"
 SHARE_DIR="/usr/local/share/devlair"
 CHANNEL="stable"
 
+# Computed after we know INSTALL_DIR — reused for binary install, modules
+# install, and any apt-get fallbacks below so the sudo decision is made once.
+MAYBE_SUDO=""
+[[ ! -w "$INSTALL_DIR" ]] && MAYBE_SUDO="sudo"
+
 # ── Dracula-styled output ─────────────────────────────────────────────────────
-# Match cli/src/lib/theme.ts (and devlair/console.py). Auto-disable on non-TTY
-# or when NO_COLOR is set so piped/CI output stays clean.
+# Keep in sync with Dracula palette (cli/src/lib/theme.ts) — drift produces
+# off-brand output. Auto-disable on non-TTY or when NO_COLOR is set so
+# piped/CI output stays clean.
 if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
   C_PURPLE=$'\033[38;2;189;147;249m'
   C_PINK=$'\033[38;2;255;121;198m'
@@ -38,6 +44,37 @@ ok()      { printf "  %s✓%s %s\n" "$C_GREEN" "$C_RESET" "$1"; }
 warn()    { printf "  %s!%s %s\n" "$C_ORANGE" "$C_RESET" "$1"; }
 err()     { printf "  %s✗%s %s\n" "$C_RED" "$C_RESET" "$1" >&2; }
 meta()    { printf "    %s%s%s\n" "$C_COMMENT" "$1" "$C_RESET"; }
+
+# verify_checksum <file> <asset_name> <checksums_file> <hard_fail_on_missing>
+# Compares sha256 of <file> against the entry for <asset_name> in <checksums_file>.
+# When <hard_fail_on_missing> is "1", a missing entry aborts; otherwise it warns
+# and continues. Mismatches always abort. Removes <file> on failure.
+verify_checksum() {
+  local file="$1" asset="$2" sums="$3" hard_fail="$4"
+  local expected actual
+  expected=$(grep " ${asset}\$" "$sums" | awk '{print $1}')
+  actual=$(sha256sum "$file" | awk '{print $1}')
+
+  if [[ -z "$expected" ]]; then
+    if [[ "$hard_fail" == "1" ]]; then
+      err "no checksum entry for ${asset} in checksums.txt — aborting"
+      rm -f "$file"
+      exit 1
+    fi
+    warn "no checksum found for ${asset} — skipping verification"
+    return 0
+  fi
+
+  if [[ "$actual" != "$expected" ]]; then
+    err "checksum mismatch for ${asset}!"
+    meta "expected: ${expected}"
+    meta "got:      ${actual}"
+    rm -f "$file"
+    exit 1
+  fi
+
+  ok "SHA-256 verified"
+}
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
 for arg in "$@"; do
@@ -105,31 +142,16 @@ curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
 ok "downloaded ${ASSET}"
 
 # ── Verify SHA-256 checksum ──────────────────────────────────────────────────
-EXPECTED=$(grep " ${ASSET}\$" "$TMP_CHECKSUMS" | awk '{print $1}')
-ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
-
-if [[ -z "$EXPECTED" ]]; then
-  warn "no checksum found for ${ASSET} — skipping verification"
-elif [[ "$ACTUAL" != "$EXPECTED" ]]; then
-  err "checksum mismatch!"
-  meta "expected: ${EXPECTED}"
-  meta "got:      ${ACTUAL}"
-  rm -f "$TMP"
-  exit 1
-else
-  ok "SHA-256 verified"
-fi
+# Stable channel: soft-warn on missing entry (pre-existing behavior; tracked
+# separately). Mismatches still hard-fail inside verify_checksum.
+verify_checksum "$TMP" "$ASSET" "$TMP_CHECKSUMS" 0
 
 chmod 755 "$TMP"
 
 # ── Install (sudo if needed) ──────────────────────────────────────────────────
 section "Installing binary"
-if [[ -w "$INSTALL_DIR" ]]; then
-  mv "$TMP" "${INSTALL_DIR}/${BIN}"
-else
-  sudo mv "$TMP" "${INSTALL_DIR}/${BIN}"
-fi
-chmod 755 "${INSTALL_DIR}/${BIN}" 2>/dev/null || sudo chmod 755 "${INSTALL_DIR}/${BIN}"
+$MAYBE_SUDO mv "$TMP" "${INSTALL_DIR}/${BIN}"
+$MAYBE_SUDO chmod 755 "${INSTALL_DIR}/${BIN}"
 ok "${INSTALL_DIR}/${BIN}"
 
 # ── Pre-release: fetch modules tarball ────────────────────────────────────────
@@ -140,25 +162,10 @@ if [[ "$CHANNEL" == "pre" ]]; then
   TMP_MODULES=$(mktemp)
   curl -fsSL "${BASE_URL}/modules.tar.gz" -o "$TMP_MODULES"
 
-  EXPECTED_MODULES=$(grep " modules.tar.gz\$" "$TMP_CHECKSUMS" | awk '{print $1}')
-  ACTUAL_MODULES=$(sha256sum "$TMP_MODULES" | awk '{print $1}')
-
   # Modules ship a fresh tree on every release — a missing checksum entry
   # means CI is misconfigured, not a soft warning. Hard-fail rather than
   # extract an unverified archive and execute its scripts as root.
-  if [[ -z "$EXPECTED_MODULES" ]]; then
-    err "no checksum entry for modules.tar.gz in checksums.txt — aborting"
-    rm -f "$TMP_MODULES"
-    exit 1
-  elif [[ "$ACTUAL_MODULES" != "$EXPECTED_MODULES" ]]; then
-    err "checksum mismatch for modules.tar.gz!"
-    meta "expected: ${EXPECTED_MODULES}"
-    meta "got:      ${ACTUAL_MODULES}"
-    rm -f "$TMP_MODULES"
-    exit 1
-  else
-    ok "SHA-256 verified"
-  fi
+  verify_checksum "$TMP_MODULES" "modules.tar.gz" "$TMP_CHECKSUMS" 1
 
   # Replace the modules dir atomically: extract to a staging path, then swap.
   # --no-same-owner / --no-same-permissions ignore uid/gid/mode bits from the
@@ -169,9 +176,6 @@ if [[ "$CHANNEL" == "pre" ]]; then
   tar -xzf "$TMP_MODULES" -C "$STAGE_DIR" --no-same-owner --no-same-permissions
   chmod -R u=rwX,go=rX "$STAGE_DIR/modules"
   rm -f "$TMP_MODULES"
-
-  MAYBE_SUDO=""
-  [[ ! -w "$(dirname "$SHARE_DIR")" ]] && MAYBE_SUDO="sudo"
 
   $MAYBE_SUDO rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
   [[ -d "$SHARE_DIR" ]] && $MAYBE_SUDO mv "$SHARE_DIR" "${SHARE_DIR}.old"


### PR DESCRIPTION
Closes #101

## Summary

- Style \`install.sh\` output using the Dracula palette (matches \`cli/src/lib/theme.ts\` and \`devlair/console.py\`): \`▸\` section markers, green ✓, orange !, red ✗, comment-gray meta. Auto-disables on non-TTY or when \`NO_COLOR\` is set.
- Reword the WSL openssh-server cleanup message — "Repairing pre-existing openssh-server half-config…" read like a prior devlair install was being repaired. New message attributes the broken state to Ubuntu's postinst failing under WSL's systemd-less default.

## Test plan

- [ ] \`bash -n install.sh\` passes
- [ ] Fresh WSL Ubuntu 24.04: \`curl … | sudo bash -s -- --pre\` renders the styled output
- [ ] \`curl … | sudo NO_COLOR=1 bash -s -- --pre\` renders plain text
- [ ] WSL cleanup message clearly identifies Ubuntu's openssh-server postinst as the cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)