### PR TITLE
fix(modules/tailscale): never block on interactive browser auth

### DIFF
--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -10,16 +10,10 @@ read_context
 
 MODE=${1:-run}
 
-# Connect tailscale without ever blocking on browser auth.
-#
-# - With TS_AUTHKEY (env var) or config.tailscale_authkey set, we hand the key
-#   to `tailscale up --authkey=…` and bring the node up unattended.
-# - Without a key, `tailscale up` prints an auth URL on stderr and blocks until
-#   the user opens it. We can't drive that from a wizard, so we run it in the
-#   background, capture the URL it prints within a few seconds, kill the
-#   process, and surface the URL via a `warn` result. The user finishes auth
-#   out-of-band by running `sudo tailscale up` themselves.
+# tailscale up blocks on browser auth and cannot be driven interactively from
+# the wizard; this function surfaces the URL without blocking.
 ts_connect() {
+  local url_wait_secs=10
   local authkey="${TS_AUTHKEY:-}"
   if [[ -z "$authkey" ]]; then
     authkey=$(ctx_get_config tailscale_authkey)
@@ -27,7 +21,7 @@ ts_connect() {
 
   if [[ -n "$authkey" ]]; then
     json_progress "connecting with authkey"
-    tailscale up --authkey="$authkey" --reset >&2 || true
+    TS_AUTHKEY="$authkey" tailscale up --reset >&2 || true
     return
   fi
 
@@ -37,9 +31,7 @@ ts_connect() {
   # --timeout=0s makes `tailscale up` print the auth URL and return without
   # waiting for the user to open it on tailscaled versions that support it;
   # on older versions we fall back to a background process + sleep + kill.
-  if tailscale up --timeout=0s >"$log" 2>&1; then
-    : # already connected
-  fi
+  tailscale up --timeout=0s >"$log" 2>&1 || true
   local url
   url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
   rm -f "$log"
@@ -51,7 +43,7 @@ ts_connect() {
     tailscale up >"$log" 2>&1 &
     local pid=$!
     local waited=0
-    while (( waited < 10 )); do
+    while (( waited < url_wait_secs )); do
       sleep 1
       ((waited++))
       url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# modules/tailscale.sh — Tailscale
+# cli/modules/tailscale.sh — Tailscale
 # devlair module: tailscale
 set -euo pipefail
 
@@ -9,6 +9,63 @@ source "$SCRIPT_DIR/_lib.sh"
 read_context
 
 MODE=${1:-run}
+
+# Connect tailscale without ever blocking on browser auth.
+#
+# - With TS_AUTHKEY (env var) or config.tailscale_authkey set, we hand the key
+#   to `tailscale up --authkey=…` and bring the node up unattended.
+# - Without a key, `tailscale up` prints an auth URL on stderr and blocks until
+#   the user opens it. We can't drive that from a wizard, so we run it in the
+#   background, capture the URL it prints within a few seconds, kill the
+#   process, and surface the URL via a `warn` result. The user finishes auth
+#   out-of-band by running `sudo tailscale up` themselves.
+ts_connect() {
+  local authkey="${TS_AUTHKEY:-}"
+  if [[ -z "$authkey" ]]; then
+    authkey=$(ctx_get_config tailscale_authkey)
+  fi
+
+  if [[ -n "$authkey" ]]; then
+    json_progress "connecting with authkey"
+    tailscale up --authkey="$authkey" --reset >&2 || true
+    return
+  fi
+
+  json_progress "starting tailscale (non-interactive)"
+  local log
+  log=$(mktemp)
+  # --timeout=0s makes `tailscale up` print the auth URL and return without
+  # waiting for the user to open it on tailscaled versions that support it;
+  # on older versions we fall back to a background process + sleep + kill.
+  if tailscale up --timeout=0s >"$log" 2>&1; then
+    : # already connected
+  fi
+  local url
+  url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
+  rm -f "$log"
+
+  if [[ -z "$url" ]]; then
+    # --timeout=0s unsupported — run the blocking form in background and
+    # scrape the URL it prints, then stop the orphan.
+    log=$(mktemp)
+    tailscale up >"$log" 2>&1 &
+    local pid=$!
+    local waited=0
+    while (( waited < 10 )); do
+      sleep 1
+      ((waited++))
+      url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
+      [[ -n "$url" ]] && break
+    done
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    rm -f "$log"
+  fi
+
+  if [[ -n "$url" ]]; then
+    TS_AUTH_URL="$url"
+  fi
+}
 
 do_run() {
   if ! cmd_exists tailscale; then
@@ -20,17 +77,19 @@ do_run() {
     json_install "tailscale" "tailscale.com" false
   fi
 
+  TS_AUTH_URL=""
   if ! tailscale status >/dev/null 2>&1; then
-    json_progress "connecting to tailscale"
-    tailscale up >&2 || true
+    ts_connect
   fi
 
   local ip
   ip=$(tailscale ip -4 2>/dev/null || true)
   if [[ -n "$ip" ]]; then
     json_result "ok" "$ip"
+  elif [[ -n "$TS_AUTH_URL" ]]; then
+    json_result "warn" "needs auth — open $TS_AUTH_URL or run 'sudo tailscale up'"
   else
-    json_result "warn" "connected but no IP yet — run 'tailscale status'"
+    json_result "warn" "not connected — run 'sudo tailscale up' to authenticate"
   fi
 }
 


### PR DESCRIPTION
Closes #102

## Summary

\`tailscale up\` with no auth key prints a login URL on stderr and blocks indefinitely. From inside the Ink wizard the spinner hides the URL, so the user sees an apparent freeze:

\`\`\`
[2/8] Tailscale ⠦ connecting to tailscale   ← hangs forever
\`\`\`

Now the module never blocks:

- **With an auth key** (\`TS_AUTHKEY\` env var or \`config.tailscale_authkey\`) → \`tailscale up --authkey=… --reset\` (unattended).
- **Without** → try \`tailscale up --timeout=0s\` (newer tailscaled prints the URL and returns immediately); fall back to background-process + URL-scrape + kill within 10s.
- Surface the captured auth URL via \`json_result "warn" "needs auth — open <url> or run 'sudo tailscale up'"\` so the wizard advances and the user finishes auth out-of-band.

## Test plan

- [ ] \`bash -n cli/modules/tailscale.sh\` passes
- [ ] \`bun test\` (cli) passes
- [ ] Fresh WSL box without auth key: module returns within ~10s with a \`warn\` result containing the auth URL
- [ ] With \`TS_AUTHKEY\` env var set: module connects non-interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)