### PR TITLE
feat(modules/tailscale): drive interactive auth and wait until connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ cli/                    # v2 TypeScript CLI (alpha)
   src/
     index.tsx           # Ink app entrypoint
     commands/           # init, doctor, upgrade, claude, disable-password
-    components/         # Ink UI components (Logo, Help)
+    components/         # Ink UI components (Logo, Help, Progress, Summary)
     wizard/             # interactive wizard (GroupSelect, ModuleSelect, Confirmation)
     lib/                # theme, types, runner, modules, platform detection,
                         # args, selection, profiles, jsonConfig, elevate

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -54,6 +54,15 @@ json_install() {
     "$(json_escape "$tool")" "$(json_escape "$source")" "$verified"
 }
 
+# json_auth_url URL MESSAGE -- surface an out-of-band authentication URL the
+# user must open in a browser. Unlike `progress`, the wizard renders this
+# persistently so the URL stays visible while the module polls for completion.
+json_auth_url() {
+  local url=$1 message=${2:-}
+  printf '{"type":"auth_url","url":%s,"message":%s}\n' \
+    "$(json_escape "$url")" "$(json_escape "$message")"
+}
+
 # read_context -- consume all of stdin into the CONTEXT global.
 # Must be called before ctx_get. Aborts with an error if jq is unavailable,
 # since the whole protocol (ctx_get and json_escape) depends on it; silently

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -55,8 +55,8 @@ json_install() {
 }
 
 # json_auth_url URL MESSAGE -- surface an out-of-band authentication URL the
-# user must open in a browser. Unlike `progress`, the wizard renders this
-# persistently so the URL stays visible while the module polls for completion.
+# user must open in a browser. Unlike `progress`, this event is sticky in the
+# UI and is not cleared by subsequent progress events.
 json_auth_url() {
   local url=$1 message=${2:-}
   printf '{"type":"auth_url","url":%s,"message":%s}\n' \

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -10,10 +10,18 @@ read_context
 
 MODE=${1:-run}
 
-# tailscale up blocks on browser auth and cannot be driven interactively from
-# the wizard; this function surfaces the URL without blocking.
+# `tailscale up` without an auth key blocks until the user completes browser
+# auth. We background it, scrape the URL it prints, surface the URL through
+# the protocol, and poll `tailscale status` until the node connects.
+#
+# The backgrounded `tailscale up` keeps running for the duration of the poll;
+# once the user authenticates in their browser it completes on its own. If the
+# poll deadline expires first, we kill it.
 ts_connect() {
   local url_wait_secs=10
+  local poll_timeout_secs=${TS_AUTH_POLL_TIMEOUT_SECS:-300}
+  local poll_interval_secs=2
+
   local authkey="${TS_AUTHKEY:-}"
   if [[ -z "$authkey" ]]; then
     authkey=$(ctx_get_config tailscale_authkey)
@@ -25,37 +33,50 @@ ts_connect() {
     return
   fi
 
-  json_progress "starting tailscale (non-interactive)"
+  json_progress "starting tailscale"
   local log
   log=$(mktemp)
-  # --timeout=0s makes `tailscale up` print the auth URL and return without
-  # waiting for the user to open it on tailscaled versions that support it;
-  # on older versions we fall back to a background process + sleep + kill.
-  tailscale up --timeout=0s >"$log" 2>&1 || true
-  local url
-  url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
-  rm -f "$log"
+  tailscale up >"$log" 2>&1 &
+  local pid=$!
+
+  local url=""
+  local waited=0
+  while (( waited < url_wait_secs )); do
+    sleep 1
+    ((waited++))
+    url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
+    [[ -n "$url" ]] && break
+  done
 
   if [[ -z "$url" ]]; then
-    # --timeout=0s unsupported — run the blocking form in background and
-    # scrape the URL it prints, then stop the orphan.
-    log=$(mktemp)
-    tailscale up >"$log" 2>&1 &
-    local pid=$!
-    local waited=0
-    while (( waited < url_wait_secs )); do
-      sleep 1
-      ((waited++))
-      url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
-      [[ -n "$url" ]] && break
-    done
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     rm -f "$log"
+    return
   fi
 
-  if [[ -n "$url" ]]; then
-    TS_AUTH_URL="$url"
+  json_auth_url "$url" "Open this URL in your browser to authenticate Tailscale"
+
+  # Poll until the node connects. tailscaled writes its `Running` state into
+  # `tailscale status` as soon as auth completes, even before this orphan
+  # `tailscale up` returns.
+  local elapsed=0
+  while (( elapsed < poll_timeout_secs )); do
+    if tailscale status >/dev/null 2>&1; then
+      break
+    fi
+    sleep "$poll_interval_secs"
+    elapsed=$((elapsed + poll_interval_secs))
+  done
+
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  rm -f "$log"
+
+  TS_AUTH_URL="$url"
+  TS_AUTH_TIMED_OUT="false"
+  if (( elapsed >= poll_timeout_secs )) && ! tailscale status >/dev/null 2>&1; then
+    TS_AUTH_TIMED_OUT="true"
   fi
 }
 
@@ -70,6 +91,7 @@ do_run() {
   fi
 
   TS_AUTH_URL=""
+  TS_AUTH_TIMED_OUT="false"
   if ! tailscale status >/dev/null 2>&1; then
     ts_connect
   fi
@@ -78,10 +100,12 @@ do_run() {
   ip=$(tailscale ip -4 2>/dev/null || true)
   if [[ -n "$ip" ]]; then
     json_result "ok" "$ip"
+  elif [[ "$TS_AUTH_TIMED_OUT" == "true" ]]; then
+    json_result "fail" "auth not completed within 5 minutes — open $TS_AUTH_URL or run 'sudo tailscale up'"
   elif [[ -n "$TS_AUTH_URL" ]]; then
-    json_result "warn" "needs auth — open $TS_AUTH_URL or run 'sudo tailscale up'"
+    json_result "fail" "tailscale did not connect — open $TS_AUTH_URL or run 'sudo tailscale up'"
   else
-    json_result "warn" "not connected — run 'sudo tailscale up' to authenticate"
+    json_result "fail" "could not obtain tailscale auth URL — run 'sudo tailscale up' manually"
   fi
 }
 

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -19,7 +19,12 @@ MODE=${1:-run}
 # poll deadline expires first, we kill it.
 ts_connect() {
   local url_wait_secs=10
-  local poll_timeout_secs=${TS_AUTH_POLL_TIMEOUT_SECS:-300}
+  local poll_timeout_secs
+  if [[ "${TS_AUTH_POLL_TIMEOUT_SECS:-}" =~ ^[0-9]+$ ]]; then
+    poll_timeout_secs=$TS_AUTH_POLL_TIMEOUT_SECS
+  else
+    poll_timeout_secs=300
+  fi
   local poll_interval_secs=2
 
   local authkey="${TS_AUTHKEY:-}"
@@ -36,6 +41,9 @@ ts_connect() {
   json_progress "starting tailscale"
   local log
   log=$(mktemp)
+  # Ensure the backgrounded process and temp file are cleaned up on any exit.
+  # shellcheck disable=SC2064
+  trap "kill \$pid 2>/dev/null || true; wait \$pid 2>/dev/null || true; rm -f \"\$log\"" EXIT INT TERM
   tailscale up >"$log" 2>&1 &
   local pid=$!
 
@@ -61,6 +69,7 @@ ts_connect() {
   # `tailscale status` as soon as auth completes, even before this orphan
   # `tailscale up` returns.
   local elapsed=0
+  local timed_out=false
   while (( elapsed < poll_timeout_secs )); do
     if tailscale status >/dev/null 2>&1; then
       break
@@ -68,16 +77,17 @@ ts_connect() {
     sleep "$poll_interval_secs"
     elapsed=$((elapsed + poll_interval_secs))
   done
+  (( elapsed >= poll_timeout_secs )) && timed_out=true
 
+  # trap handles kill + wait + rm -f on EXIT; explicit cleanup here so the
+  # trap becomes a no-op for the normal path.
+  trap - EXIT INT TERM
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
   rm -f "$log"
 
   TS_AUTH_URL="$url"
-  TS_AUTH_TIMED_OUT="false"
-  if (( elapsed >= poll_timeout_secs )) && ! tailscale status >/dev/null 2>&1; then
-    TS_AUTH_TIMED_OUT="true"
-  fi
+  TS_AUTH_TIMED_OUT="$timed_out"
 }
 
 do_run() {
@@ -91,17 +101,18 @@ do_run() {
   fi
 
   TS_AUTH_URL=""
-  TS_AUTH_TIMED_OUT="false"
+  TS_AUTH_TIMED_OUT=""
   if ! tailscale status >/dev/null 2>&1; then
     ts_connect
   fi
 
   local ip
   ip=$(tailscale ip -4 2>/dev/null || true)
+  local poll_mins=$(( ${TS_AUTH_POLL_TIMEOUT_SECS:-300} / 60 ))
   if [[ -n "$ip" ]]; then
     json_result "ok" "$ip"
   elif [[ "$TS_AUTH_TIMED_OUT" == "true" ]]; then
-    json_result "fail" "auth not completed within 5 minutes — open $TS_AUTH_URL or run 'sudo tailscale up'"
+    json_result "fail" "auth not completed within ${poll_mins} minutes — open $TS_AUTH_URL or run 'sudo tailscale up'"
   elif [[ -n "$TS_AUTH_URL" ]]; then
     json_result "fail" "tailscale did not connect — open $TS_AUTH_URL or run 'sudo tailscale up'"
   else

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -109,7 +109,6 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
         status: "pending" as const,
         detail: "",
         progressMsg: "",
-        authUrl: undefined,
       })),
     );
     setDone(false);

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -109,6 +109,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
         status: "pending" as const,
         detail: "",
         progressMsg: "",
+        authUrl: undefined,
       })),
     );
     setDone(false);
@@ -155,6 +156,9 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
               setModules((prev) => prev.map((m, j) => (j === i ? { ...m, progressMsg: value.message } : m)));
             } else if (value.type === "result") {
               finalDetail = value.detail;
+            } else if (value.type === "auth_url") {
+              const authUrl = { url: value.url, message: value.message };
+              setModules((prev) => prev.map((m, j) => (j === i ? { ...m, authUrl } : m)));
             }
           }
         } catch (err) {
@@ -163,7 +167,9 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
         }
 
         setModules((prev) =>
-          prev.map((m, j) => (j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "" } : m)),
+          prev.map((m, j) =>
+            j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "", authUrl: undefined } : m,
+          ),
         );
       }
 

--- a/cli/src/components/Progress.tsx
+++ b/cli/src/components/Progress.tsx
@@ -18,15 +18,7 @@ export interface ModuleRun {
 
 function AuthPanel({ url, message }: { url: string; message: string }) {
   return (
-    <Box
-      flexDirection="column"
-      marginLeft={4}
-      marginY={1}
-      paddingX={2}
-      paddingY={0}
-      borderStyle="round"
-      borderColor={D_PURPLE}
-    >
+    <Box flexDirection="column" marginLeft={4} marginY={1} paddingX={2} borderStyle="round" borderColor={D_PURPLE}>
       <Text color={D_PINK}>{message}</Text>
       <Text color={D_CYAN}>{url}</Text>
       <Text color={D_COMMENT}>Waiting for authentication…</Text>

--- a/cli/src/components/Progress.tsx
+++ b/cli/src/components/Progress.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
-import { D_COMMENT, D_GREEN, D_ORANGE, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
+import { D_COMMENT, D_CYAN, D_GREEN, D_ORANGE, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
 import type { Status } from "../lib/types.js";
 
 export type ModuleRunStatus = Status | "pending" | "running";
@@ -13,6 +13,25 @@ export interface ModuleRun {
   status: ModuleRunStatus;
   detail: string;
   progressMsg: string;
+  authUrl?: { url: string; message: string };
+}
+
+function AuthPanel({ url, message }: { url: string; message: string }) {
+  return (
+    <Box
+      flexDirection="column"
+      marginLeft={4}
+      marginY={1}
+      paddingX={2}
+      paddingY={0}
+      borderStyle="round"
+      borderColor={D_PURPLE}
+    >
+      <Text color={D_PINK}>{message}</Text>
+      <Text color={D_CYAN}>{url}</Text>
+      <Text color={D_COMMENT}>Waiting for authentication…</Text>
+    </Box>
+  );
 }
 
 const STATUS_ICON: Record<string, { char: string; color: string }> = {
@@ -27,16 +46,19 @@ function ModuleLine({ mod, index, total }: { mod: ModuleRun; index: number; tota
 
   if (mod.status === "running") {
     return (
-      <Box>
-        <Text>{"  "}</Text>
-        <Text color={D_COMMENT}>{counter}</Text>
-        <Text> </Text>
-        <Text color={D_PINK}>{mod.label}</Text>
-        <Text> </Text>
-        <Text color={D_PURPLE}>
-          <Spinner type="dots" />
-        </Text>
-        {mod.progressMsg ? <Text color={D_COMMENT}> {mod.progressMsg}</Text> : null}
+      <Box flexDirection="column">
+        <Box>
+          <Text>{"  "}</Text>
+          <Text color={D_COMMENT}>{counter}</Text>
+          <Text> </Text>
+          <Text color={D_PINK}>{mod.label}</Text>
+          <Text> </Text>
+          <Text color={D_PURPLE}>
+            <Spinner type="dots" />
+          </Text>
+          {mod.progressMsg ? <Text color={D_COMMENT}> {mod.progressMsg}</Text> : null}
+        </Box>
+        {mod.authUrl ? <AuthPanel url={mod.authUrl.url} message={mod.authUrl.message} /> : null}
       </Box>
     );
   }

--- a/cli/src/lib/runner.ts
+++ b/cli/src/lib/runner.ts
@@ -54,6 +54,8 @@ function isModuleEvent(value: unknown): value is ModuleEvent {
       );
     case "install":
       return typeof v.tool === "string" && typeof v.source === "string" && typeof v.verified === "boolean";
+    case "auth_url":
+      return typeof v.url === "string" && typeof v.message === "string";
     default:
       return false;
   }

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -14,7 +14,8 @@ export type ModuleEvent =
   | { type: "progress"; message: string; percent?: number }
   | { type: "result"; status: Status; detail: string }
   | { type: "check"; label: string; status: Status; detail?: string }
-  | { type: "install"; tool: string; source: string; verified: boolean };
+  | { type: "install"; tool: string; source: string; verified: boolean }
+  | { type: "auth_url"; url: string; message: string };
 
 export interface ModuleResult {
   status: Status;

--- a/cli/src/test/runner.test.ts
+++ b/cli/src/test/runner.test.ts
@@ -140,6 +140,23 @@ exit 0`,
     });
   });
 
+  test("parses auth_url events", async () => {
+    const script = writeScript(
+      "auth.sh",
+      `source "${LIB_PATH}"
+read_context
+json_auth_url "https://login.tailscale.com/a/xyz" "Open in browser"
+json_result "ok" "connected"
+exit 0`,
+    );
+    const { events } = await collect(script);
+    expect(events).toContainEqual({
+      type: "auth_url",
+      url: "https://login.tailscale.com/a/xyz",
+      message: "Open in browser",
+    });
+  });
+
   test("drops malformed JSON lines without failing", async () => {
     const script = writeScript(
       "noisy.sh",
@@ -285,6 +302,15 @@ json_install "awscli" "aws.amazon.com" true`);
       .map((l) => JSON.parse(l));
     expect(lines[0]).toEqual({ type: "install", tool: "uv", source: "astral.sh", verified: false });
     expect(lines[1]).toEqual({ type: "install", tool: "awscli", source: "aws.amazon.com", verified: true });
+  });
+
+  test("json_auth_url emits url + message", () => {
+    const { stdout } = runLibScript(`json_auth_url "https://login.tailscale.com/a/abc123" "Open in browser"`);
+    expect(JSON.parse(stdout.trim())).toEqual({
+      type: "auth_url",
+      url: "https://login.tailscale.com/a/abc123",
+      message: "Open in browser",
+    });
   });
 
   test("ctx_get reads top-level keys from context", () => {


### PR DESCRIPTION
## Summary

- New `auth_url` protocol event so modules can surface a URL the user must open in a browser; the wizard renders it as a sticky panel above the spinner.
- Rewrites `ts_connect` to background `tailscale up`, scrape the login URL, emit `auth_url`, then poll `tailscale status` every 2s for up to 5 min until the node is connected.
- Result is now `ok` with the tailnet IP once the user authenticates in the browser, or `fail` with a clear message on poll timeout / missing URL. No more `warn` that left init exiting with Tailscale half-configured.
- Auth-key path (`TS_AUTHKEY` env / `tailscale_authkey` config) unchanged.

Fixes the regression where `tailscale up --timeout=0s` in PR #104 hung indefinitely (in the Tailscale CLI `--timeout=0` means "no timeout / wait forever", not "return immediately").

Closes #106

## Test plan

- [x] `bun test` — 156 pass (new test: `runner.test.ts > parses auth_url events`; new helper test: `json_auth_url emits url + message`)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] Manual on fresh WSL: `sudo devlair init` → step 2 shows sticky URL panel; browser auth → step turns ✓ with tailnet IP; init proceeds
- [ ] Manual with `TS_AUTHKEY=tskey-…` set: connects unattended, no panel rendered
- [ ] Manual without tailscaled: step fails within ~10s with "could not obtain auth URL"

🤖 Generated with [Claude Code](https://claude.com/claude-code)