### PR TITLE
fix(modules): clear tailscale trap on no-URL path; pin pyenv Python to 3.12

### DIFF
--- a/cli/modules/devtools.sh
+++ b/cli/modules/devtools.sh
@@ -47,12 +47,14 @@ do_run() {
     run_shell_as "$USERNAME" "bash \"$script\"" >&2
     rm -f "$script"
     json_progress "installing Python via pyenv"
+    # Pinning to a stable major.minor avoids 404s when `pyenv latest 3`
+    # resolves to a version python-build's recipe can no longer fetch.
     run_shell_as "$USERNAME" "
       export PYENV_ROOT=\"$USER_HOME/.pyenv\"
       export PATH=\"\$PYENV_ROOT/bin:\$PATH\"
       eval \"\$(pyenv init -)\"
-      pyenv install -s 3
-      pyenv global \"\$(pyenv latest 3)\"
+      pyenv install -s 3.12
+      pyenv global 3.12
     " >&2
     json_install "pyenv" "pyenv.run" false
     installed+=(pyenv)

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -39,13 +39,15 @@ ts_connect() {
   fi
 
   json_progress "starting tailscale"
-  local log
+  # Initialise pid/log before the trap is armed so a signal that arrives
+  # between `trap` and `pid=$!` does not hit `set -u` "unbound variable".
+  local pid=""
+  local log=""
   log=$(mktemp)
-  # Ensure the backgrounded process and temp file are cleaned up on any exit.
   # shellcheck disable=SC2064
-  trap "kill \$pid 2>/dev/null || true; wait \$pid 2>/dev/null || true; rm -f \"\$log\"" EXIT INT TERM
+  trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; rm -f "$log"' EXIT INT TERM
   tailscale up >"$log" 2>&1 &
-  local pid=$!
+  pid=$!
 
   local url=""
   local waited=0
@@ -57,6 +59,7 @@ ts_connect() {
   done
 
   if [[ -z "$url" ]]; then
+    trap - EXIT INT TERM
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     rm -f "$log"


### PR DESCRIPTION
## Summary

Two regressions surfaced on a fresh WSL install of `devlair-cli 2.3.0-alpha.1`:

- **tailscale** — the EXIT trap from #107 referenced `\$pid` (function-local) without clearing the trap on the no-URL early-return path. When `tailscale up` failed to emit a login URL within 10s, the function returned without `trap -`, the script exited, the EXIT trap fired with `pid` out of scope, and `set -u` aborted with `pid: unbound variable`. Initialise `pid`/`log` up-front, switch the trap body to single-quoted form (deferred eval was correct, but the prior escaped form was hard to audit), and clear the trap on the no-URL early-return path.
- **devtools** — `pyenv install -s 3` + `pyenv global "\$(pyenv latest 3)"` resolves to whatever pyenv considers the newest Python 3.x. When `python-build`'s recipe for that version can't fetch the source archive (curl 404 from `python.org/ftp`), the whole devtools step fails non-recoverably. Pin to `3.12` — pyenv resolves to the latest 3.12 patch and the 3.12 recipe is stable.

Closes #109
Closes #110

## Test plan

- [x] `bun test` — 156 pass
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] Manual on fresh WSL: tailscale step fails cleanly (no \`pid: unbound variable\`) when no auth URL is captured
- [ ] Manual on fresh WSL: dev tools installs Python 3.12.x via pyenv without 404
- [ ] Re-run on a machine that already has pyenv: skipped install path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)