### PR TITLE
feat(init): persist module stderr to per-run log files

### DIFF
--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -16,7 +16,7 @@ import { type ModuleRun, Progress } from "../components/Progress.js";
 import { OptionalHint, Summary } from "../components/Summary.js";
 import type { InitFlags } from "../lib/args.js";
 import { buildModuleContext } from "../lib/context.js";
-import { createInitLogDir, moduleLogPath } from "../lib/logs.js";
+import { createInitLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
 import type { Group, ModuleSpec } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
@@ -120,8 +120,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
     if (!autoStart || specs.length === 0) return;
 
     const abortController = new AbortController();
-    // Lazily create the log directory the first time we actually run modules,
-    // so the wizard's cancel-without-running path doesn't leave empty dirs.
+    // Avoid creating empty dirs when the wizard is cancelled before running.
     let runLogDir: string | null = null;
     try {
       runLogDir = createInitLogDir(context.userHome);
@@ -142,9 +141,11 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
 
         try {
           const scriptPath = moduleScriptPath(spec.key);
+          const ownership = invokerOwnership();
           const iter = runModule(scriptPath, context, "run", {
             signal: abortController.signal,
             logFile: runLogDir ? moduleLogPath(runLogDir, spec.key) : undefined,
+            chownUidGid: ownership ?? undefined,
           });
 
           while (true) {

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -16,6 +16,7 @@ import { type ModuleRun, Progress } from "../components/Progress.js";
 import { OptionalHint, Summary } from "../components/Summary.js";
 import type { InitFlags } from "../lib/args.js";
 import { buildModuleContext } from "../lib/context.js";
+import { createInitLogDir, moduleLogPath } from "../lib/logs.js";
 import type { Group, ModuleSpec } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
@@ -98,6 +99,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
 
   const [modules, setModules] = useState<ModuleRun[]>([]);
   const [done, setDone] = useState(false);
+  const [logDir, setLogDir] = useState<string | null>(null);
 
   // Re-initialize module state whenever specs change
   // (wizard transitions from [] to the real selection).
@@ -118,6 +120,15 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
     if (!autoStart || specs.length === 0) return;
 
     const abortController = new AbortController();
+    // Lazily create the log directory the first time we actually run modules,
+    // so the wizard's cancel-without-running path doesn't leave empty dirs.
+    let runLogDir: string | null = null;
+    try {
+      runLogDir = createInitLogDir(context.userHome);
+      setLogDir(runLogDir);
+    } catch {
+      // Logging is best-effort — never block a run because we couldn't mkdir.
+    }
 
     async function run() {
       for (let i = 0; i < specs.length; i++) {
@@ -131,7 +142,10 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
 
         try {
           const scriptPath = moduleScriptPath(spec.key);
-          const iter = runModule(scriptPath, context, "run", { signal: abortController.signal });
+          const iter = runModule(scriptPath, context, "run", {
+            signal: abortController.signal,
+            logFile: runLogDir ? moduleLogPath(runLogDir, spec.key) : undefined,
+          });
 
           while (true) {
             const { value, done: iterDone } = await iter.next();
@@ -182,7 +196,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
     };
   }, [specs, context, autoStart]);
 
-  return { modules, done };
+  return { modules, done, logDir };
 }
 
 // ── Non-interactive init (flags provided) ──────────────────────────────────
@@ -259,14 +273,14 @@ function NonInteractiveInit({ flags }: { flags: InitFlags }) {
 
 function NonInteractiveInitView({ state }: { state: InitState }) {
   const { platform, context, selected, optional, skippedNames, profile } = state;
-  const { modules, done } = useModuleExecution(selected, context, true);
+  const { modules, done, logDir } = useModuleExecution(selected, context, true);
 
   return (
     <Box flexDirection="column">
       <InitHeader username={context.username} host={hostname()} platform={platform} profileName={profile?.name} />
       <PlatformSkipped names={skippedNames} />
       <Progress modules={modules} total={selected.length} />
-      {done && <Summary modules={modules} />}
+      {done && <Summary modules={modules} logDir={logDir} />}
       {done && <OptionalHint specs={optional} />}
       <Text>{""}</Text>
     </Box>
@@ -296,7 +310,11 @@ function WizardInit() {
   };
 
   // Execution state — only populated after wizard confirmation
-  const { modules, done } = useModuleExecution(selectedModules, context, phase === "running" || phase === "done");
+  const { modules, done, logDir } = useModuleExecution(
+    selectedModules,
+    context,
+    phase === "running" || phase === "done",
+  );
 
   return (
     <Box flexDirection="column">
@@ -337,7 +355,7 @@ function WizardInit() {
       {(phase === "running" || phase === "done") && (
         <>
           <Progress modules={modules} total={selectedModules.length} />
-          {done && <Summary modules={modules} />}
+          {done && <Summary modules={modules} logDir={logDir} />}
         </>
       )}
 

--- a/cli/src/components/Summary.tsx
+++ b/cli/src/components/Summary.tsx
@@ -19,7 +19,7 @@ function countByStatus(modules: ModuleRun[]) {
   return { ok, warn, fail, skip };
 }
 
-export function Summary({ modules }: { modules: ModuleRun[] }) {
+export function Summary({ modules, logDir }: { modules: ModuleRun[]; logDir?: string | null }) {
   const { ok, warn, fail, skip } = countByStatus(modules);
   const borderColor = fail === 0 ? D_GREEN : D_RED;
 
@@ -53,6 +53,16 @@ export function Summary({ modules }: { modules: ModuleRun[] }) {
           </Text>
         )}
       </Box>
+
+      {fail > 0 && logDir && (
+        <Box marginTop={1}>
+          <Text>
+            {"  "}
+            <Text color={D_COMMENT}>Logs: </Text>
+            <Text color={D_CYAN}>{logDir}</Text>
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/cli/src/lib/logs.ts
+++ b/cli/src/lib/logs.ts
@@ -1,0 +1,74 @@
+// Per-run log directory for `devlair init`. Each module's stderr is streamed
+// to its own file so failures can be diagnosed without re-running with extra
+// flags.
+
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const KEEP_RUNS = 10;
+const LOG_DIR_PREFIX = "init-";
+
+/** Format Date as `init-YYYY-MM-DDTHH-MM-SSZ` (filesystem-safe ISO). */
+function runDirName(now: Date): string {
+  const iso = now
+    .toISOString()
+    .replace(/[:.]/g, "-")
+    .replace(/-\d{3}Z$/, "Z");
+  return `${LOG_DIR_PREFIX}${iso}`;
+}
+
+/**
+ * Create `<userHome>/.devlair/logs/init-<ts>/` (mode 0700) and prune older
+ * `init-*` directories to the most recent KEEP_RUNS, including the new one.
+ *
+ * Returns the absolute path to the new directory.
+ */
+export function createInitLogDir(userHome: string, now: Date = new Date()): string {
+  const logsRoot = join(userHome, ".devlair", "logs");
+  mkdirSync(logsRoot, { recursive: true, mode: 0o700 });
+
+  const runDir = join(logsRoot, runDirName(now));
+  mkdirSync(runDir, { recursive: true, mode: 0o700 });
+
+  pruneOldRuns(logsRoot, KEEP_RUNS);
+  return runDir;
+}
+
+function pruneOldRuns(logsRoot: string, keep: number): void {
+  let entries: { name: string; mtimeMs: number }[];
+  try {
+    entries = readdirSync(logsRoot)
+      .filter((name) => name.startsWith(LOG_DIR_PREFIX))
+      .map((name) => {
+        const full = join(logsRoot, name);
+        try {
+          return { name, mtimeMs: statSync(full).mtimeMs };
+        } catch {
+          return null;
+        }
+      })
+      .filter((e): e is { name: string; mtimeMs: number } => e !== null);
+  } catch {
+    return;
+  }
+  if (entries.length <= keep) return;
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const stale of entries.slice(keep)) {
+    const path = join(logsRoot, stale.name);
+    try {
+      rmSync(path, { recursive: true, force: true });
+    } catch {
+      // Best-effort prune; never fail the run because of a stale log.
+    }
+  }
+}
+
+/** Resolve `<runDir>/<moduleKey>.log` — caller owns existence. */
+export function moduleLogPath(runDir: string, moduleKey: string): string {
+  return join(runDir, `${moduleKey}.log`);
+}
+
+/** Test helper. */
+export function _logDirExists(runDir: string): boolean {
+  return existsSync(runDir);
+}

--- a/cli/src/lib/logs.ts
+++ b/cli/src/lib/logs.ts
@@ -2,13 +2,12 @@
 // to its own file so failures can be diagnosed without re-running with extra
 // flags.
 
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, chownSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 const KEEP_RUNS = 10;
 const LOG_DIR_PREFIX = "init-";
 
-/** Format Date as `init-YYYY-MM-DDTHH-MM-SSZ` (filesystem-safe ISO). */
 function runDirName(now: Date): string {
   const iso = now
     .toISOString()
@@ -18,17 +17,59 @@ function runDirName(now: Date): string {
 }
 
 /**
+ * Return [uid, gid] of the invoking user when running under sudo, or null.
+ * Only returns a value when both SUDO_UID and SUDO_GID are set, non-zero, and
+ * parseable as integers — covers the common `sudo devlair init` case.
+ */
+export function invokerOwnership(): [number, number] | null {
+  const uid = Number.parseInt(process.env.SUDO_UID ?? "", 10);
+  const gid = Number.parseInt(process.env.SUDO_GID ?? "", 10);
+  if (!Number.isFinite(uid) || !Number.isFinite(gid) || uid === 0 || gid === 0) return null;
+  return [uid, gid];
+}
+
+/** Throw if path exists as a symlink — guards against pre-planted symlink attacks under sudo. */
+function rejectSymlink(path: string): void {
+  try {
+    if (lstatSync(path).isSymbolicLink()) {
+      throw new Error(`Refusing to create log directory: ${path} is a symlink`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return; // does not exist yet — fine
+    throw err;
+  }
+}
+
+/**
  * Create `<userHome>/.devlair/logs/init-<ts>/` (mode 0700) and prune older
  * `init-*` directories to the most recent KEEP_RUNS, including the new one.
  *
  * Returns the absolute path to the new directory.
  */
 export function createInitLogDir(userHome: string, now: Date = new Date()): string {
-  const logsRoot = join(userHome, ".devlair", "logs");
+  const devlairDir = join(userHome, ".devlair");
+  const logsRoot = join(devlairDir, "logs");
+
+  // Reject symlinks on each path component before creating children.
+  // Under sudo, a user-planted symlink at ~/.devlair or ~/.devlair/logs would
+  // otherwise redirect root-owned mkdir/rmSync into an attacker-chosen target.
+  rejectSymlink(devlairDir);
+  rejectSymlink(logsRoot);
+
   mkdirSync(logsRoot, { recursive: true, mode: 0o700 });
+  // Explicitly tighten permissions — mkdirSync mode is only applied to newly
+  // created dirs; an existing ~/.devlair/logs with 0755 would stay 0755.
+  chmodSync(logsRoot, 0o700);
 
   const runDir = join(logsRoot, runDirName(now));
-  mkdirSync(runDir, { recursive: true, mode: 0o700 });
+  mkdirSync(runDir, { mode: 0o700 });
+  chmodSync(runDir, 0o700);
+
+  const ownership = invokerOwnership();
+  if (ownership) {
+    chownSync(logsRoot, ownership[0], ownership[1]);
+    chownSync(runDir, ownership[0], ownership[1]);
+  }
 
   pruneOldRuns(logsRoot, KEEP_RUNS);
   return runDir;
@@ -56,6 +97,9 @@ function pruneOldRuns(logsRoot: string, keep: number): void {
   for (const stale of entries.slice(keep)) {
     const path = join(logsRoot, stale.name);
     try {
+      // Re-lstat to guard against a TOCTOU race where the entry was replaced
+      // with a symlink between readdirSync and now — never rmSync a symlink target.
+      if (lstatSync(path).isSymbolicLink()) continue;
       rmSync(path, { recursive: true, force: true });
     } catch {
       // Best-effort prune; never fail the run because of a stale log.
@@ -65,10 +109,10 @@ function pruneOldRuns(logsRoot: string, keep: number): void {
 
 /** Resolve `<runDir>/<moduleKey>.log` — caller owns existence. */
 export function moduleLogPath(runDir: string, moduleKey: string): string {
-  return join(runDir, `${moduleKey}.log`);
-}
-
-/** Test helper. */
-export function _logDirExists(runDir: string): boolean {
-  return existsSync(runDir);
+  const resolved = resolve(runDir, `${moduleKey}.log`);
+  // Defense-in-depth: prevent path traversal if moduleKey contains ../
+  if (!resolved.startsWith(`${runDir}/`)) {
+    throw new Error(`Module key resolves outside log directory: ${moduleKey}`);
+  }
+  return resolved;
 }

--- a/cli/src/lib/runner.ts
+++ b/cli/src/lib/runner.ts
@@ -7,6 +7,7 @@
 //   - stderr is buffered and surfaced to callers opting into verbose output.
 
 import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
 import type { ModuleContext, ModuleEvent, ModuleMode, Status } from "./types.js";
 import { ModuleExitCode } from "./types.js";
 
@@ -19,6 +20,11 @@ export interface RunOptions {
   onStderr?: (line: string) => void;
   /** Override the bash executable (defaults to "bash"). Useful for tests. */
   bashPath?: string;
+  /**
+   * Tee every stderr byte to this file as it streams. Created with mode 0600.
+   * Survives abort/timeout so a hung run still leaves a partial log on disk.
+   */
+  logFile?: string;
 }
 
 export interface RunResult {
@@ -129,9 +135,11 @@ export async function* runModule(
 
   let stderrBuf = "";
   let stderrCarry = "";
+  const logStream = options.logFile ? createWriteStream(options.logFile, { mode: 0o600 }) : undefined;
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk: string) => {
     stderrBuf += chunk;
+    logStream?.write(chunk);
     if (!options.onStderr) return;
     stderrCarry += chunk;
     const lines = stderrCarry.split("\n");
@@ -177,5 +185,6 @@ export async function* runModule(
     // If the consumer abandoned the generator (early return / thrown error),
     // kill the process group so detached children don't linger.
     if (!exited) killTree("SIGTERM");
+    logStream?.end();
   }
 }

--- a/cli/src/lib/runner.ts
+++ b/cli/src/lib/runner.ts
@@ -7,7 +7,7 @@
 //   - stderr is buffered and surfaced to callers opting into verbose output.
 
 import { spawn } from "node:child_process";
-import { createWriteStream } from "node:fs";
+import { chownSync, createWriteStream } from "node:fs";
 import type { ModuleContext, ModuleEvent, ModuleMode, Status } from "./types.js";
 import { ModuleExitCode } from "./types.js";
 
@@ -25,6 +25,12 @@ export interface RunOptions {
    * Survives abort/timeout so a hung run still leaves a partial log on disk.
    */
   logFile?: string;
+  /**
+   * If set, chownSync the log file to [uid, gid] immediately after opening it.
+   * Populated from SUDO_UID/SUDO_GID when running under sudo so the invoking
+   * user can read their own module logs without elevated privileges.
+   */
+  chownUidGid?: [number, number];
 }
 
 export interface RunResult {
@@ -136,6 +142,17 @@ export async function* runModule(
   let stderrBuf = "";
   let stderrCarry = "";
   const logStream = options.logFile ? createWriteStream(options.logFile, { mode: 0o600 }) : undefined;
+  if (logStream && options.logFile && options.chownUidGid) {
+    const [uid, gid] = options.chownUidGid;
+    const logFilePath = options.logFile;
+    logStream.once("open", () => {
+      try {
+        chownSync(logFilePath, uid, gid);
+      } catch {
+        // Best-effort; don't fail the run if chown is unavailable (e.g. non-root).
+      }
+    });
+  }
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk: string) => {
     stderrBuf += chunk;

--- a/cli/src/test/logs.test.ts
+++ b/cli/src/test/logs.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createInitLogDir, moduleLogPath } from "../lib/logs.js";
+
+let home: string;
+
+beforeEach(() => {
+  home = join(tmpdir(), `devlair-logs-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(home, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("createInitLogDir", () => {
+  test("creates ~/.devlair/logs/init-<ts>/ with mode 0700", () => {
+    const dir = createInitLogDir(home);
+    const st = statSync(dir);
+    expect(st.isDirectory()).toBe(true);
+    expect(st.mode & 0o777).toBe(0o700);
+    expect(dir.startsWith(join(home, ".devlair", "logs", "init-"))).toBe(true);
+  });
+
+  test("prunes older runs, keeping the 10 most recent", () => {
+    const logsRoot = join(home, ".devlair", "logs");
+    mkdirSync(logsRoot, { recursive: true });
+    // Seed 12 fake older runs, mtimes spaced 1s apart so sort order is stable.
+    for (let i = 0; i < 12; i++) {
+      const name = `init-2025-01-01T00-00-${i.toString().padStart(2, "0")}Z`;
+      const path = join(logsRoot, name);
+      mkdirSync(path);
+      writeFileSync(join(path, "marker"), name);
+      const t = new Date(2025, 0, 1, 0, 0, i).getTime() / 1000;
+      utimesSync(path, t, t);
+    }
+    createInitLogDir(home);
+    const remaining = readdirSync(logsRoot)
+      .filter((n) => n.startsWith("init-"))
+      .sort();
+    // 10 retained including the just-created one.
+    expect(remaining.length).toBe(10);
+    // The oldest seeded entries (00, 01) should be gone.
+    expect(remaining.some((n) => n.endsWith("-00Z"))).toBe(false);
+    expect(remaining.some((n) => n.endsWith("-01Z"))).toBe(false);
+  });
+});
+
+describe("moduleLogPath", () => {
+  test("resolves <runDir>/<key>.log", () => {
+    const dir = createInitLogDir(home);
+    expect(moduleLogPath(dir, "tailscale")).toBe(join(dir, "tailscale.log"));
+  });
+
+  test("runner writes module stderr to the log file", async () => {
+    const { runModule } = await import("../lib/runner.js");
+    const dir = createInitLogDir(home);
+    const script = join(home, "noisy.sh");
+    writeFileSync(script, '#!/usr/bin/env bash\necho "line one" >&2\necho "line two" >&2\n', { mode: 0o755 });
+    const logFile = moduleLogPath(dir, "noisy");
+    const iter = runModule(
+      script,
+      { username: "t", userHome: home, platform: "linux", wslVersion: null, config: {} },
+      "run",
+      { logFile },
+    );
+    while (true) {
+      const { done } = await iter.next();
+      if (done) break;
+    }
+    const contents = readFileSync(logFile, "utf8");
+    expect(contents).toContain("line one");
+    expect(contents).toContain("line two");
+    const st = statSync(logFile);
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
## Summary
- Every `devlair init` now creates `~/.devlair/logs/init-<ISO>/` and streams each module's stderr to `<module>.log`.
- Failure summary surfaces the log directory so users can read the full trace without re-running with ad-hoc `set -x` patches.
- Old runs auto-prune to the most recent 10. Logs are 0600 inside a 0700 parent.

Closes #113

## Test plan
- [x] `bun test` — 160 pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] Manual on fresh WSL: a module failure prints "Logs: ~/.devlair/logs/init-..." and the named .log file contains the full stderr stream <!-- needs-manual: requires fresh WSL with a failing module -->
- [x] After 11+ runs, only the 10 most recent `init-*` directories remain (code-verified — `cli/src/test/logs.test.ts:34-54` seeds 12 dirs and asserts 10 remain after createInitLogDir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
