### PR TITLE
fix(modules): tailscale set -e abort + AWS CLI key 404

### DIFF
--- a/cli/modules/devtools.sh
+++ b/cli/modules/devtools.sh
@@ -151,15 +151,17 @@ do_run() {
     aws_base="https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}"
 
     curl -fsSL "${aws_base}.zip" -o /tmp/awscliv2.zip >&2
-    if cmd_exists gpg; then
-      curl -fsSL "${aws_base}.zip.sig" -o /tmp/awscliv2.zip.sig >&2
-      curl -fsSL "$_AWS_CLI_GPG_KEY_URL" -o /tmp/aws-cli-key.asc >&2
+    # GPG verification is best-effort: AWS no longer publishes the public key
+    # at a stable URL, so a 404 here must not abort the install.
+    if cmd_exists gpg \
+      && curl -fsSL "${aws_base}.zip.sig" -o /tmp/awscliv2.zip.sig 2>/dev/null \
+      && curl -fsSL "$_AWS_CLI_GPG_KEY_URL" -o /tmp/aws-cli-key.asc 2>/dev/null; then
       gpg --batch --import /tmp/aws-cli-key.asc >&2 2>&1 || true
       if gpg --batch --verify /tmp/awscliv2.zip.sig /tmp/awscliv2.zip >&2 2>&1; then
         gpg_verified=true
       fi
-      rm -f /tmp/awscliv2.zip.sig /tmp/aws-cli-key.asc
     fi
+    rm -f /tmp/awscliv2.zip.sig /tmp/aws-cli-key.asc
     unzip -qo /tmp/awscliv2.zip -d /tmp >&2
     /tmp/aws/install >&2
     rm -rf /tmp/awscliv2.zip /tmp/aws

--- a/cli/modules/devtools.sh
+++ b/cli/modules/devtools.sh
@@ -13,7 +13,6 @@ USER_HOME=$(ctx_get userHome)
 PLATFORM=$(ctx_get platform)
 MODE=${1:-run}
 
-# AWS CLI v2 public GPG key URL
 _AWS_CLI_GPG_KEY_URL="https://awscli.amazonaws.com/awscli-exe-linux-public-key.asc"
 
 do_run() {

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -53,10 +53,7 @@ ts_connect() {
   local waited=0
   while (( waited < url_wait_secs )); do
     sleep 1
-    # Avoid `((waited++))` — its post-increment returns 0 on the first
-    # iteration, which under `set -e` would abort the script and fire the
-    # EXIT trap after the local `pid` has gone out of scope, triggering a
-    # "pid: unbound variable" under `set -u`.
+    # $((waited + 1)) avoids set -e abort on the first iteration where ((waited++)) would return 0
     waited=$((waited + 1))
     url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
     [[ -n "$url" ]] && break

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -53,7 +53,11 @@ ts_connect() {
   local waited=0
   while (( waited < url_wait_secs )); do
     sleep 1
-    ((waited++))
+    # Avoid `((waited++))` — its post-increment returns 0 on the first
+    # iteration, which under `set -e` would abort the script and fire the
+    # EXIT trap after the local `pid` has gone out of scope, triggering a
+    # "pid: unbound variable" under `set -u`.
+    waited=$((waited + 1))
     url=$(grep -oE 'https://login\.tailscale\.com/[A-Za-z0-9_/.-]+' "$log" | head -1 || true)
     [[ -n "$url" ]] && break
   done


### PR DESCRIPTION
## Summary
- Fix `((waited++))` in `ts_connect`: under `set -euo pipefail` the first-iteration post-increment returns exit status 1, aborting the script and firing the EXIT trap after `local pid` is out of scope → "pid: unbound variable". Replace with `waited=$((waited + 1))`.
- Make AWS CLI GPG verification best-effort: the canonical `awscli-exe-linux-public-key.asc` URL now 404s, killing the devtools install under `set -e`. The zip itself is still served over HTTPS.

Closes #116

## Test plan
- [x] `bun test` — 36/36 in runner.test.ts pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] Bug reproduced in isolation with `bash -c 'set -euo pipefail; f() { local pid="42"; trap "echo \"\$pid\"" EXIT; local w=0; ((w++)); }; f'` → `line 1: pid: unbound variable`; the fixed form (`w=$((w+1))`) reaches the end of the function.
- [ ] Manual on fresh WSL: `sudo devlair init` reaches the tailscale auth-URL panel instead of aborting at step 2/8; devtools install completes through AWS CLI even with the 404 key URL <!-- needs-manual: requires fresh WSL -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
