### PR TITLE
feat(wizard): interactive github prompt + untimed tailscale auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,11 @@ This downloads the latest `devlair-cli-v*` prerelease asset and installs it as `
 | `devlair disable-password [--yes]` | Linux-only, auto-elevates via sudo. `--yes` skips the interactive confirmation. |
 | `devlair claude [--plan TIER\|--1m on\|off\|--channels]` | Configures the local Claude Code install. No dashboard (see above). |
 
+**v2 wizard behavior notes:**
+
+- **GitHub config step** — when the `github` module is selected in the wizard, a dedicated `wizard-github` step collects `github_email` (required, regex-validated) and `github_name` (optional) before execution begins. In non-interactive mode (`--config`), `github_email` must be supplied via `config.github_email` in the profile YAML or the command exits with an error.
+- **Tailscale auth** — browser-based Tailscale authentication waits indefinitely. There is no timeout; the wizard's `AbortController` / SIGTERM is the only cancellation path (Ctrl-C).
+
 **Develop locally:**
 
 ```bash
@@ -449,7 +454,7 @@ cli/                    # v2 TypeScript CLI (alpha)
     index.tsx           # Ink app entrypoint
     commands/           # init, doctor, upgrade, claude, disable-password
     components/         # Ink UI components (Logo, Help, Progress, Summary)
-    wizard/             # interactive wizard (GroupSelect, ModuleSelect, Confirmation)
+    wizard/             # interactive wizard (GroupSelect, ModuleSelect, Confirmation, GithubConfig)
     lib/                # theme, types, runner, modules, platform detection,
                         # args, selection, profiles, jsonConfig, elevate
   modules/              # shell modules executed by the v2 binary

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -15,16 +15,11 @@ MODE=${1:-run}
 # the protocol, and poll `tailscale status` until the node connects.
 #
 # The backgrounded `tailscale up` keeps running for the duration of the poll;
-# once the user authenticates in their browser it completes on its own. If the
-# poll deadline expires first, we kill it.
+# once the user authenticates in their browser it completes on its own. The
+# wizard cancels the whole tree via SIGTERM (AbortController) if the user
+# bails — there is no internal timeout.
 ts_connect() {
   local url_wait_secs=10
-  local poll_timeout_secs
-  if [[ "${TS_AUTH_POLL_TIMEOUT_SECS:-}" =~ ^[0-9]+$ ]]; then
-    poll_timeout_secs=$TS_AUTH_POLL_TIMEOUT_SECS
-  else
-    poll_timeout_secs=300
-  fi
   local poll_interval_secs=2
 
   local authkey="${TS_AUTHKEY:-}"
@@ -69,19 +64,14 @@ ts_connect() {
 
   json_auth_url "$url" "Open this URL in your browser to authenticate Tailscale"
 
-  # Poll until the node connects. tailscaled writes its `Running` state into
-  # `tailscale status` as soon as auth completes, even before this orphan
-  # `tailscale up` returns.
-  local elapsed=0
-  local timed_out=false
-  while (( elapsed < poll_timeout_secs )); do
-    if tailscale status >/dev/null 2>&1; then
-      break
-    fi
+  # Poll forever until the node connects. tailscaled writes `Running` into
+  # `tailscale status` as soon as auth completes, even before the orphan
+  # `tailscale up` returns. The user is sitting at the wizard; if they need
+  # extra time we let them have it. Ctrl-C in the wizard sends SIGTERM down
+  # the process group and the EXIT trap below cleans up.
+  while ! tailscale status >/dev/null 2>&1; do
     sleep "$poll_interval_secs"
-    elapsed=$((elapsed + poll_interval_secs))
   done
-  (( elapsed >= poll_timeout_secs )) && timed_out=true
 
   # trap handles kill + wait + rm -f on EXIT; explicit cleanup here so the
   # trap becomes a no-op for the normal path.
@@ -91,7 +81,6 @@ ts_connect() {
   rm -f "$log"
 
   TS_AUTH_URL="$url"
-  TS_AUTH_TIMED_OUT="$timed_out"
 }
 
 do_run() {
@@ -105,18 +94,14 @@ do_run() {
   fi
 
   TS_AUTH_URL=""
-  TS_AUTH_TIMED_OUT=""
   if ! tailscale status >/dev/null 2>&1; then
     ts_connect
   fi
 
   local ip
   ip=$(tailscale ip -4 2>/dev/null || true)
-  local poll_mins=$(( ${TS_AUTH_POLL_TIMEOUT_SECS:-300} / 60 ))
   if [[ -n "$ip" ]]; then
     json_result "ok" "$ip"
-  elif [[ "$TS_AUTH_TIMED_OUT" == "true" ]]; then
-    json_result "fail" "auth not completed within ${poll_mins} minutes — open $TS_AUTH_URL or run 'sudo tailscale up'"
   elif [[ -n "$TS_AUTH_URL" ]]; then
     json_result "fail" "tailscale did not connect — open $TS_AUTH_URL or run 'sudo tailscale up'"
   else

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -26,10 +26,11 @@ import { selectModules } from "../lib/selection.js";
 import { D_COMMENT, D_FG, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
 import type { ModuleContext, Status } from "../lib/types.js";
 import { Confirmation } from "../wizard/Confirmation.js";
+import { GithubConfig, type GithubConfigValues } from "../wizard/GithubConfig.js";
 import { GroupSelect } from "../wizard/GroupSelect.js";
 import { ModuleSelect } from "../wizard/ModuleSelect.js";
 
-type Phase = "wizard-groups" | "wizard-modules" | "wizard-confirm" | "running" | "done";
+type Phase = "wizard-groups" | "wizard-modules" | "wizard-confirm" | "wizard-github" | "running" | "done";
 
 function InitHeader({
   username,
@@ -218,6 +219,15 @@ function buildInitState(flags: InitFlags, profile: Profile | null): InitState {
   const context = buildModuleContext(platform, wslVersion, config);
   const profileSelection = profile ? resolveProfileKeys(profile) : undefined;
   const { selected, optional, platformSkipped } = selectModules(flags, platform, profileSelection);
+
+  // Non-interactive mode cannot prompt — surface required config gaps up front
+  // rather than letting the github module silently skip with exit 2.
+  if (selected.some((m) => m.key === "github") && !config.github_email) {
+    throw new ProfileError(
+      "github module requires `config.github_email` in your --config setup.yaml, or run `devlair init` interactively.",
+    );
+  }
+
   return {
     platform,
     context,
@@ -230,10 +240,24 @@ function buildInitState(flags: InitFlags, profile: Profile | null): InitState {
 
 function NonInteractiveInit({ flags }: { flags: InitFlags }) {
   const { exit } = useApp();
-  const [initState, setInitState] = useState<InitState | null>(() =>
-    flags.config ? null : buildInitState(flags, null),
-  );
-  const [error, setError] = useState<string | null>(null);
+  const initial = (() => {
+    if (flags.config) return { state: null, error: null };
+    try {
+      return { state: buildInitState(flags, null), error: null };
+    } catch (err) {
+      const msg = err instanceof ProfileError ? err.message : err instanceof Error ? err.message : String(err);
+      return { state: null, error: msg };
+    }
+  })();
+  const [initState, setInitState] = useState<InitState | null>(initial.state);
+  const [error, setError] = useState<string | null>(initial.error);
+
+  useEffect(() => {
+    if (error !== null) {
+      process.exitCode = 1;
+      setTimeout(() => exit(), 0);
+    }
+  }, [error, exit]);
 
   useEffect(() => {
     if (initState !== null || error !== null) return;
@@ -246,14 +270,12 @@ function NonInteractiveInit({ flags }: { flags: InitFlags }) {
         if (cancelled) return;
         const msg = err instanceof ProfileError ? err.message : err instanceof Error ? err.message : String(err);
         setError(msg);
-        process.exitCode = 1;
-        setTimeout(() => exit(), 0);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [flags, initState, error, exit]);
+  }, [flags, initState, error]);
 
   if (error !== null) {
     return (
@@ -300,11 +322,15 @@ function WizardInit() {
     return { platform, wslVersion, context };
   });
 
-  const { platform, context } = envState;
+  const { platform, context: baseContext } = envState;
 
   const [phase, setPhase] = useState<Phase>("wizard-groups");
   const [selectedGroups, setSelectedGroups] = useState<Set<Group>>(new Set());
   const [selectedModules, setSelectedModules] = useState<ModuleSpec[]>([]);
+  const [extraConfig, setExtraConfig] = useState<Record<string, unknown>>({});
+
+  const githubSelected = selectedModules.some((m) => m.key === "github");
+  const context: ModuleContext = { ...baseContext, config: { ...baseContext.config, ...extraConfig } };
 
   const cancel = () => {
     exit();
@@ -347,8 +373,23 @@ function WizardInit() {
       {phase === "wizard-confirm" && (
         <Confirmation
           modules={selectedModules}
-          onConfirm={() => setPhase("running")}
+          onConfirm={() => setPhase(githubSelected ? "wizard-github" : "running")}
           onBack={() => setPhase("wizard-modules")}
+          onCancel={cancel}
+        />
+      )}
+
+      {phase === "wizard-github" && (
+        <GithubConfig
+          onConfirm={(values: GithubConfigValues) => {
+            setExtraConfig((prev) => ({
+              ...prev,
+              github_email: values.email,
+              ...(values.name ? { github_name: values.name } : {}),
+            }));
+            setPhase("running");
+          }}
+          onBack={() => setPhase("wizard-confirm")}
           onCancel={cancel}
         />
       )}

--- a/cli/src/wizard/GithubConfig.tsx
+++ b/cli/src/wizard/GithubConfig.tsx
@@ -1,0 +1,130 @@
+/**
+ * Wizard step — collect github_email (required) and github_name (optional)
+ * for the github module so its SSH key generation does not silently skip.
+ * Shown after Confirmation, before module execution, only when `github`
+ * is in the selected set and no profile already supplied these values.
+ */
+
+import { Box, Text, useInput } from "ink";
+import { useState } from "react";
+import { D_COMMENT, D_CYAN, D_GREEN, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
+
+export interface GithubConfigValues {
+  email: string;
+  name: string;
+}
+
+export interface GithubConfigProps {
+  onConfirm: (values: GithubConfigValues) => void;
+  onBack: () => void;
+  onCancel: () => void;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type Field = "email" | "name";
+
+export function GithubConfig({ onConfirm, onBack, onCancel }: GithubConfigProps) {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [focus, setFocus] = useState<Field>("email");
+  const [error, setError] = useState<string | null>(null);
+
+  useInput((input, key) => {
+    if (input === "q" && key.ctrl) {
+      onCancel();
+      return;
+    }
+    if (key.escape) {
+      onBack();
+      return;
+    }
+    if (key.tab || key.downArrow) {
+      setFocus((f) => (f === "email" ? "name" : "email"));
+      return;
+    }
+    if (key.upArrow) {
+      setFocus((f) => (f === "email" ? "name" : "email"));
+      return;
+    }
+    if (key.return) {
+      if (!EMAIL_RE.test(email)) {
+        setError("Enter a valid email address.");
+        setFocus("email");
+        return;
+      }
+      onConfirm({ email, name: name.trim() });
+      return;
+    }
+    if (key.backspace || key.delete) {
+      if (focus === "email") setEmail((v) => v.slice(0, -1));
+      else setName((v) => v.slice(0, -1));
+      setError(null);
+      return;
+    }
+    if (input && !key.ctrl && !key.meta) {
+      if (focus === "email") setEmail((v) => v + input);
+      else setName((v) => v + input);
+      setError(null);
+    }
+  });
+
+  const renderField = (field: Field, label: string, value: string, hint: string) => {
+    const isFocused = focus === field;
+    const caret = isFocused ? "│" : " ";
+    return (
+      <Box flexDirection="column" marginBottom={1}>
+        <Box>
+          <Text color={isFocused ? D_PINK : D_COMMENT} bold>
+            {"  "}
+            {label}
+          </Text>
+          <Text color={D_COMMENT}> {hint}</Text>
+        </Box>
+        <Box>
+          <Text color={D_COMMENT}>{"    "}</Text>
+          <Text color={D_CYAN}>{value}</Text>
+          <Text color={isFocused ? D_PINK : D_COMMENT}>{caret}</Text>
+        </Box>
+      </Box>
+    );
+  };
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color={D_PINK} bold>
+          {"  "}GitHub SSH key
+        </Text>
+        <Text color={D_COMMENT}>{"  needed to generate ~/.ssh/id_ed25519_github"}</Text>
+      </Box>
+
+      {renderField("email", "Email", email, "(required)")}
+      {renderField("name", "Name", name, "(optional — git commit author)")}
+
+      {error && (
+        <Box marginBottom={1}>
+          <Text color={D_RED}>
+            {"  "}
+            {error}
+          </Text>
+        </Box>
+      )}
+
+      <Box flexDirection="column">
+        <Box>
+          <Text>{"  "}</Text>
+          <Text color={D_PURPLE}>Press </Text>
+          <Text color={D_GREEN} bold>
+            Enter
+          </Text>
+          <Text color={D_PURPLE}> to continue</Text>
+        </Box>
+        <Box>
+          <Text>{"  "}</Text>
+          <Text color={D_COMMENT}>tab / ↑↓ = switch field, esc = back, ctrl-q = cancel</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/cli/src/wizard/GithubConfig.tsx
+++ b/cli/src/wizard/GithubConfig.tsx
@@ -1,10 +1,3 @@
-/**
- * Wizard step — collect github_email (required) and github_name (optional)
- * for the github module so its SSH key generation does not silently skip.
- * Shown after Confirmation, before module execution, only when `github`
- * is in the selected set and no profile already supplied these values.
- */
-
 import { Box, Text, useInput } from "ink";
 import { useState } from "react";
 import { D_COMMENT, D_CYAN, D_GREEN, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
@@ -20,7 +13,7 @@ export interface GithubConfigProps {
   onCancel: () => void;
 }
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_RE = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;
 
 type Field = "email" | "name";
 
@@ -39,11 +32,7 @@ export function GithubConfig({ onConfirm, onBack, onCancel }: GithubConfigProps)
       onBack();
       return;
     }
-    if (key.tab || key.downArrow) {
-      setFocus((f) => (f === "email" ? "name" : "email"));
-      return;
-    }
-    if (key.upArrow) {
+    if (key.tab || key.downArrow || key.upArrow) {
       setFocus((f) => (f === "email" ? "name" : "email"));
       return;
     }


### PR DESCRIPTION
## Summary

Two UX gaps in the v2 init wizard left users with a half-provisioned machine:

- **GitHub SSH key was silently skipped.** `github.sh` exits 2 with `"skipped"` whenever `ctx_get_config github_email` is empty, and wizard mode never populated it. Added a new wizard step (`GithubConfig.tsx`) after `Confirmation` that prompts for email (required, regex-validated) and name (optional) and merges the values into `ModuleContext.config` before the module runs. Shell module untouched.
- **Tailscale auth had a 5-minute ceiling.** `ts_connect` capped browser auth at 300s. The user is sitting at the terminal — there's no benefit to truncating them. Removed the timeout entirely. Poll forever (2s interval) until `tailscale status` reports connected; Ctrl-C still tears the process group down via the existing AbortController + EXIT trap.

Non-interactive mode (`--config setup.yaml`) now errors clearly when `github` is selected but `config.github_email` is missing, instead of silently skipping.

Closes #119

## Test plan

- [x] `bun test` — 160/160 pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [ ] Manual on fresh WSL: wizard prompts for GitHub email/name when `github` is selected, key is generated, SSH config is written, public key prints to summary <!-- needs-manual: requires fresh WSL with interactive terminal -->
- [ ] Manual on fresh WSL: tailscale browser auth completes successfully after >5 minutes without the step being marked fail <!-- needs-manual: requires fresh WSL + browser auth -->
- [ ] Manual: `sudo devlair init --only github` without `--config` errors with a clear message instead of silently skipping <!-- needs-manual: trivial CLI invocation -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
