### PR TITLE
fix(runner): await log stream flush before generator returns

### DIFF
--- a/cli/src/lib/runner.ts
+++ b/cli/src/lib/runner.ts
@@ -202,6 +202,11 @@ export async function* runModule(
     // If the consumer abandoned the generator (early return / thrown error),
     // kill the process group so detached children don't linger.
     if (!exited) killTree("SIGTERM");
-    logStream?.end();
+    // Await flush so a caller reading the log file immediately after this
+    // returns sees the full stderr stream — otherwise the kernel's pending
+    // writes can lose the race against a follow-up readFileSync.
+    if (logStream) {
+      await new Promise<void>((resolve) => logStream.end(resolve));
+    }
   }
 }

--- a/cli/src/lib/runner.ts
+++ b/cli/src/lib/runner.ts
@@ -206,7 +206,10 @@ export async function* runModule(
     // returns sees the full stderr stream — otherwise the kernel's pending
     // writes can lose the race against a follow-up readFileSync.
     if (logStream) {
-      await new Promise<void>((resolve) => logStream.end(resolve));
+      await new Promise<void>((resolve) => {
+        logStream.once("error", () => resolve());
+        logStream.end(resolve);
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

`logStream?.end()` in `runModule`'s `finally` block returned synchronously, while the kernel's flush to the log file happens asynchronously via the stream's `finish` event. A caller reading `~/.devlair/logs/init-<ts>/<module>.log` immediately after `runModule` returned could lose the race and see an empty or partial file.

The intermittent CI failure of `moduleLogPath > runner writes module stderr to the log file` (e.g. [run 26008548344](https://github.com/ettoreaquino/devlair/actions/runs/26008548344) — failed 3.22 ms; passed 2.16 ms on the next run, same code) was the visible symptom. Users reading the log after a crashed module would have hit the same race silently.

Fix: await the `end` callback so the stream's `finish` event has fired by the time the generator's `finally` block resolves.

Closes #122

## Test plan

- [x] `bun test` — 160/160 pass
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] Repeated `bun test src/test/logs.test.ts` 5x locally — every run 4/4 pass (was previously flaky under load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
