### PR TITLE
fix(wizard): memoize context to prevent run from aborting itself

### DIFF
--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -9,7 +9,7 @@
 import { hostname } from "node:os";
 import { useApp } from "ink";
 import { Box, Text } from "ink";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Logo } from "../components/Logo.js";
 import { type ModuleRun, Progress } from "../components/Progress.js";
@@ -330,7 +330,12 @@ function WizardInit() {
   const [extraConfig, setExtraConfig] = useState<Record<string, unknown>>({});
 
   const githubSelected = selectedModules.some((m) => m.key === "github");
-  const context: ModuleContext = { ...baseContext, config: { ...baseContext.config, ...extraConfig } };
+  // Stable identity: useModuleExecution's run effect depends on `context`, so
+  // recreating it on every render would abort the in-flight run on each setState.
+  const context = useMemo<ModuleContext>(
+    () => ({ ...baseContext, config: { ...baseContext.config, ...extraConfig } }),
+    [baseContext, extraConfig],
+  );
 
   const cancel = () => {
     exit();


### PR DESCRIPTION
## Summary

- Wizard `context` was rebuilt with a fresh object identity on every render, so `useModuleExecution`'s run effect (which lists `context` in its deps) cleaned up + aborted on every `setModules` call inside the run loop. The for-loop exited at `if (signal.aborted) break;` before any module finished, then `setDone(true); exit()` rendered an empty Summary.
- Fix: wrap `context` in `useMemo` keyed on `[baseContext, extraConfig]` so its identity is stable across renders.
- Regression came in with aab6c3d (GitHub prompt feature added `extraConfig` and the per-render spread). The non-interactive path was unaffected — its context lives in `useState`.

Closes #124

## Test plan

- [x] `bun test` — 160/160 pass
- [x] `bun run lint` — clean
- [ ] Manual: `devlair init`, walk through wizard, confirm modules actually execute end-to-end (no empty Summary) <!-- needs-manual: requires a real interactive terminal + system-mutating modules; cannot run in CI -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
