### PR TITLE
chore(sdlc): harden board tracking and add DORA scaffolding

### DIFF
--- a/.claude/commands/board-reconcile.md
+++ b/.claude/commands/board-reconcile.md
@@ -51,9 +51,9 @@ Build a single drift report. Each row: `{number, kind, current, desired, repair}
 | Closed issue / merged PR on board, Status ≠ Done | Status=Done | `item-edit` → Done |
 | Open issue/PR on board, Status=Done | Status=Todo (issue) or In Progress (PR) | `item-edit` → correct status |
 | Item on board with no `Type` field set, where title has a parseable conventional-commit prefix | `Type=<prefix>` | `item-edit` Type field |
-| PR on board with title matching `^chore\(main\): release` | not on board | `item-delete` |
+| PR on board with title matching `^chore\(main\): release` **and** author login == `release-please[bot]` | not on board | `item-delete` |
 
-For the `Type` mapping, use the same prefix→option-id table from `/pr` Step 6.
+For the `Type` mapping, use the prefix→option-id table in the Project board reference section below.
 
 ### Step 3: Print the drift report
 

--- a/.claude/commands/board-reconcile.md
+++ b/.claude/commands/board-reconcile.md
@@ -1,0 +1,123 @@
+---
+description: Audit and repair the devlair roadmap project board. Idempotent — re-runs are safe and report zero drift after a successful run.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+## Instructions
+
+You are reconciling the **devlair roadmap** GitHub Project v2 (#2) against the canonical state in GitHub Issues and Pull Requests. Drift sources we know about:
+
+- Open issues/PRs that bypassed `/pr` and never landed on the board.
+- Closed items still sitting in `Todo` / `In Progress` (built-in workflow disabled at the time, or a manual edit overrode the auto-close).
+- Open items wrongly marked `Done`.
+- Items missing the `Type` field (DORA scaffolding).
+- Release-please bot PRs (`chore(main): release ...`) that got auto-added by mistake — they're noise for Deployment Frequency.
+
+**Idempotency contract:** every repair is a set-to-desired-state write, never a transition. Running `/board-reconcile --fix` twice in a row must report zero drift on the second run. Do not implement compare-and-swap logic; do not add "if currently X then Y" branches.
+
+### Argument parsing
+
+Parse `$ARGUMENTS` for:
+- `--fix` — apply repairs. Default is dry-run (no writes).
+- `--scope=this-pr` — only check the PR linked to the current branch (used by `/pr` for its end-of-flow sanity check). Default is full board.
+
+### Step 1: Snapshot canonical state
+
+Run in parallel:
+
+```bash
+# Open issues and PRs (canonical: should all be on the board, not Done)
+gh issue list --state open --limit 500 --json number,title,state
+gh pr list --state open --limit 500 --json number,title,state
+
+# Closed/merged items (canonical: if on the board, must be Done)
+gh issue list --state closed --limit 500 --json number,title,state,closedAt
+gh pr list --state merged --limit 500 --json number,title,state,mergedAt
+
+# Current board state
+gh project item-list 2 --owner ettoreaquino --limit 500 --format json
+```
+
+Always pass `--limit 500` — the default 100 silently truncates on this project.
+
+### Step 2: Detect drift
+
+Build a single drift report. Each row: `{number, kind, current, desired, repair}`.
+
+| Detector | Desired state | Repair when `--fix` |
+|---|---|---|
+| Open issue not on board | on board, Status=Todo | `item-add` then status Todo |
+| Open PR not on board | on board, Status=In Progress | `item-add` then status In Progress |
+| Closed issue / merged PR on board, Status ≠ Done | Status=Done | `item-edit` → Done |
+| Open issue/PR on board, Status=Done | Status=Todo (issue) or In Progress (PR) | `item-edit` → correct status |
+| Item on board with no `Type` field set, where title has a parseable conventional-commit prefix | `Type=<prefix>` | `item-edit` Type field |
+| PR on board with title matching `^chore\(main\): release` | not on board | `item-delete` |
+
+For the `Type` mapping, use the same prefix→option-id table from `/pr` Step 6.
+
+### Step 3: Print the drift report
+
+Always print, regardless of mode:
+
+```
+Board reconciliation — <YYYY-MM-DD HH:MM> (dry-run | fix)
+
+Open items missing from board:
+  #92  issue  init.tsx: improve stderr fallback ...
+
+Status mismatches:
+  #81  issue  CLOSED -> In Progress (should be Done)
+  #84  issue  CLOSED -> In Progress (should be Done)
+
+Missing Type field:
+  #125 pr     fix(wizard): memoize context ...        -> fix
+
+Bot PRs to drop:
+  #126 pr     chore(main): release devlair-cli 2.5.1-alpha.1
+
+Summary: 4 drift items detected.
+```
+
+If `--scope=this-pr`, restrict the report to the two relevant items (linked issue + the PR for the current branch).
+
+### Step 4: Apply repairs (only when `--fix`)
+
+For each drift row, run the repair from the table above. After each `item-add`, look up the item ID with `--limit 500` before calling `item-edit`. Catch and report any individual failure but continue with the rest — one bad row shouldn't abort the reconciliation.
+
+After all repairs, **re-run Step 1 and Step 2** as a self-check. The second pass must report zero drift; if it doesn't, surface the residual rows as a failure rather than claiming success.
+
+### Step 5: Schedule reminder
+
+If running in `--fix` mode without `--scope=this-pr`, end with:
+
+```
+Next reconciliation: <today + 7 days>. Drift detected here was probably from non-/pr commands; consider running /board-reconcile --fix weekly.
+```
+
+### Project board reference
+
+```
+Project ID:     PVT_kwHOAI_A384BTyaU
+
+Status field:   PVTSSF_lAHOAI_A384BTyaUzhA-6Fg
+  Todo:         f75ad846
+  In Progress:  47fc9ee4
+  Done:         98236657
+
+Type field:     PVTSSF_lAHOAI_A384BTyaUzhTNn1g
+  feat:         fb49f55e
+  fix:          8a8822f4
+  chore:        e4a0286c
+  docs:         229100de
+  refactor:     428d2abe
+
+Incident field: PVTSSF_lAHOAI_A384BTyaUzhTNn2A
+  No:           2c582288
+  Yes:          12d9b2e2
+```
+
+## User message
+
+```text
+$ARGUMENTS
+```

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -9,6 +9,10 @@ You are creating a pull request that follows the devlair SDLC practices. Every P
 
 **Assignment rule:** the linked issue AND the PR must be assigned to the developer running this command. Always pass `--assignee @me` (gh resolves it to the authenticated user) — never hardcode a username. This applies whether the issue is newly created or already existed.
 
+**Idempotency rule:** every board write in this skill is *set-to-desired-state*. `gh project item-add` is a no-op when the item is already on the board (returns the existing item ID), and `item-edit` writes the target status regardless of prior value. Re-running any step is safe.
+
+**Pagination rule:** every `gh project item-list` call must pass `--limit 500`. The default 100-item page can silently miss recently-added items, which manifests as an empty `ITEM_ID` and a `Could not resolve to a node with the global id of ''` error from `item-edit`.
+
 ### Argument parsing
 
 Parse `$ARGUMENTS` for:
@@ -26,7 +30,9 @@ Run these in parallel:
 4. `git rev-parse --abbrev-ref HEAD` — current branch name.
 5. `gh issue list --state open --assignee ettoreaquino --json number,title` — open issues.
 
-### Step 2: Ensure an issue exists
+### Step 2: Ensure an issue exists, on the board, and In Progress
+
+**Both branches (new issue and existing issue) end with the same three operations: assignee attached, item on the board, status In Progress.** That symmetry is what prevents the "existing issue silently skips the board" drift.
 
 If an issue number was provided in `$ARGUMENTS`:
 1. Verify it exists: `gh issue view <number> --json number,assignees`.
@@ -37,17 +43,16 @@ If no issue number was provided:
 1. Analyze the commits and diff to understand the scope of work.
 2. Draft an issue title and body describing the work.
 3. Create it: `gh issue create --title "..." --body "..." --assignee @me`.
-4. Add the issue to the project board as **In Progress**:
-   ```
-   gh project item-add 2 --owner ettoreaquino --url <issue-url>
-   ```
-   Then set status:
-   ```
-   ITEM_ID=$(gh project item-list 2 --owner ettoreaquino --format json --jq '.items[] | select(.content.number == <N>) | .id')
-   gh project item-edit --project-id PVT_kwHOAI_A384BTyaU --id "$ITEM_ID" \
-     --field-id PVTSSF_lAHOAI_A384BTyaUzhA-6Fg \
-     --single-select-option-id 47fc9ee4
-   ```
+
+**Then, for both branches**, ensure the issue is on the board and In Progress:
+
+```bash
+gh project item-add 2 --owner ettoreaquino --url <issue-url>
+ISSUE_ITEM=$(gh project item-list 2 --owner ettoreaquino --limit 500 --format json --jq '.items[] | select(.content.number == <N>) | .id')
+gh project item-edit --project-id PVT_kwHOAI_A384BTyaU --id "$ISSUE_ITEM" \
+  --field-id PVTSSF_lAHOAI_A384BTyaUzhA-6Fg \
+  --single-select-option-id 47fc9ee4
+```
 
 ### Step 3: Push branch
 
@@ -84,38 +89,75 @@ If no issue number was provided:
    ```
 2. Set status to **In Progress**:
    ```
-   PR_ITEM=$(gh project item-list 2 --owner ettoreaquino --format json --jq '.items[] | select(.content.number == <PR_NUMBER>) | .id')
+   PR_ITEM=$(gh project item-list 2 --owner ettoreaquino --limit 500 --format json --jq '.items[] | select(.content.number == <PR_NUMBER>) | .id')
    gh project item-edit --project-id PVT_kwHOAI_A384BTyaU --id "$PR_ITEM" \
      --field-id PVTSSF_lAHOAI_A384BTyaUzhA-6Fg \
      --single-select-option-id 47fc9ee4
    ```
 
-### Step 6: Also set the linked issue to In Progress (if not already)
+### Step 6: Set the `Type` field on the PR (DORA scaffolding)
 
-```
-ISSUE_ITEM=$(gh project item-list 2 --owner ettoreaquino --format json --jq '.items[] | select(.content.number == <ISSUE_NUMBER>) | .id')
-gh project item-edit --project-id PVT_kwHOAI_A384BTyaU --id "$ISSUE_ITEM" \
-  --field-id PVTSSF_lAHOAI_A384BTyaUzhA-6Fg \
-  --single-select-option-id 47fc9ee4
+Parse the PR title's conventional-commit prefix and set the `Type` field. This powers DORA Deployment Frequency slicing (e.g. exclude `chore` release PRs from the count).
+
+```bash
+# Extract prefix: "feat(wizard): foo" -> "feat", "fix: bar" -> "fix"
+TYPE_NAME=$(echo "<PR_TITLE>" | awk -F'[(:]' '{print $1}' | tr -d ' ')
+case "$TYPE_NAME" in
+  feat)     TYPE_OPT=fb49f55e ;;
+  fix)      TYPE_OPT=8a8822f4 ;;
+  chore)    TYPE_OPT=e4a0286c ;;
+  docs)     TYPE_OPT=229100de ;;
+  refactor) TYPE_OPT=428d2abe ;;
+  *)        TYPE_OPT="" ;;  # leave field empty for unknown prefixes
+esac
+if [ -n "$TYPE_OPT" ]; then
+  gh project item-edit --project-id PVT_kwHOAI_A384BTyaU --id "$PR_ITEM" \
+    --field-id PVTSSF_lAHOAI_A384BTyaUzhTNn1g \
+    --single-select-option-id "$TYPE_OPT"
+fi
 ```
 
-### Step 7: Report
+Idempotent: setting `Type=feat` twice is a no-op. Unknown prefixes leave the field blank rather than guessing.
+
+### Step 7: Final reconciliation check
+
+Quick verification that both items landed on the board with the expected status — surfaces silent no-ops from pagination or eventual-consistency races:
+
+```bash
+gh project item-list 2 --owner ettoreaquino --limit 500 --format json \
+  --jq '.items[] | select(.content.number == <ISSUE_NUMBER> or .content.number == <PR_NUMBER>) | "#\(.content.number) \(.status)"'
+```
+
+Both lines must show `In Progress`. If either is missing or wrong, re-run Step 2 (issue) or Step 5 (PR) — they are idempotent.
+
+### Step 8: Report
 
 Print a summary:
 - Issue: `#<N>` (created or existing)
 - PR: `#<PR>` — URL
 - Branch: `<branch>`
-- Project board: both items set to **In Progress**
+- Project board: both items In Progress, PR `Type=<feat|fix|...>`
 
 ### Project board reference
 
 ```
 Project ID:     PVT_kwHOAI_A384BTyaU
-Field ID:       PVTSSF_lAHOAI_A384BTyaUzhA-6Fg
-Status options:
+
+Status field:   PVTSSF_lAHOAI_A384BTyaUzhA-6Fg
   Todo:         f75ad846
   In Progress:  47fc9ee4
   Done:         98236657
+
+Type field:     PVTSSF_lAHOAI_A384BTyaUzhTNn1g
+  feat:         fb49f55e
+  fix:          8a8822f4
+  chore:        e4a0286c
+  docs:         229100de
+  refactor:     428d2abe
+
+Incident field: PVTSSF_lAHOAI_A384BTyaUzhTNn2A
+  No:           2c582288
+  Yes:          12d9b2e2
 ```
 
 ## User message

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -101,7 +101,7 @@ Parse the PR title's conventional-commit prefix and set the `Type` field. This p
 
 ```bash
 # Extract prefix: "feat(wizard): foo" -> "feat", "fix: bar" -> "fix"
-TYPE_NAME=$(echo "<PR_TITLE>" | awk -F'[(:]' '{print $1}' | tr -d ' ')
+TYPE_NAME=$(gh pr view <PR_NUMBER> --json title --jq '.title | split("(") | .[0] | split(":") | .[0]')
 case "$TYPE_NAME" in
   feat)     TYPE_OPT=fb49f55e ;;
   fix)      TYPE_OPT=8a8822f4 ;;

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,18 @@
             "command": "jq -r '.tool_input.command // \"\"' | head -1 | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A pull request was just created. You MUST now run the /review-pr command to fan out the four code reviewers, then pr-fix-applier, then pr-readme-updater, and post one structured comment. Use the PR number from the gh pr create output. The command body lives at .claude/commands/review-pr.md — read and follow it.\"}}' || true",
             "timeout": 5,
             "statusMessage": "Checking for PR review..."
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command // \"\"' | head -1); echo \"$CMD\" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+issue[[:space:]]+create\\b' && ! echo \"$CMD\" | grep -qE '/pr\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Heads up: gh issue create was run outside /pr. The issue may not be on the devlair roadmap board. Run /board-reconcile --dry-run to check, or /board-reconcile --fix to add it.\"}}' || true",
+            "timeout": 5,
+            "statusMessage": "Checking issue board coverage..."
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(jq -r '.tool_input.command // \"\"' | head -1); echo \"$CMD\" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create\\b' && ! echo \"$CMD\" | grep -qE '/pr\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Heads up: gh pr create was run outside /pr. The PR may not be on the board, may lack the Type field, and may not be linked to its issue properly. After /review-pr, run /board-reconcile --dry-run to verify.\"}}' || true",
+            "timeout": 5,
+            "statusMessage": "Checking PR board coverage..."
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,13 +12,13 @@
           },
           {
             "type": "command",
-            "command": "CMD=$(jq -r '.tool_input.command // \"\"' | head -1); echo \"$CMD\" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+issue[[:space:]]+create\\b' && ! echo \"$CMD\" | grep -qE '/pr\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Heads up: gh issue create was run outside /pr. The issue may not be on the devlair roadmap board. Run /board-reconcile --dry-run to check, or /board-reconcile --fix to add it.\"}}' || true",
+            "command": "jq -r '.tool_input.command // \"\"' | head -1 | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+issue[[:space:]]+create\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Board coverage check: if this gh issue create ran outside /pr, run /board-reconcile --fix to ensure it is tracked on the devlair roadmap.\"}}' || true",
             "timeout": 5,
             "statusMessage": "Checking issue board coverage..."
           },
           {
             "type": "command",
-            "command": "CMD=$(jq -r '.tool_input.command // \"\"' | head -1); echo \"$CMD\" | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create\\b' && ! echo \"$CMD\" | grep -qE '/pr\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Heads up: gh pr create was run outside /pr. The PR may not be on the board, may lack the Type field, and may not be linked to its issue properly. After /review-pr, run /board-reconcile --dry-run to verify.\"}}' || true",
+            "command": "jq -r '.tool_input.command // \"\"' | head -1 | grep -qE '(^|[[:space:]]|&&[[:space:]]*|;[[:space:]]*|\\|[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create\\b' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Board coverage check: if this gh pr create ran outside /pr, run /board-reconcile --fix to ensure the PR is tracked, has the Type field set, and is linked to its issue.\"}}' || true",
             "timeout": 5,
             "statusMessage": "Checking PR board coverage..."
           }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,32 +179,86 @@ Each subagent returns a compact JSON object, keeping the main context small.
 - Post-review agents — `.claude/agents/pr-fix-applier.md`, `.claude/agents/pr-readme-updater.md`
 - `/pr` — PR creation with issue linking and board management (`.claude/commands/pr.md`)
 - `/board` — project board visibility (`.claude/skills/board.md`)
+- `/board-reconcile` — audit + repair board drift; idempotent (`.claude/commands/board-reconcile.md`)
 
 ## Project board
 
 All work is tracked on the **devlair roadmap** project (GitHub Projects #2). The board has three columns: **Todo**, **In Progress**, **Done**.
 
 Workflow:
-1. **When starting work on an issue/epic:** set the issue to **In Progress** on the project board
-2. **When opening a PR:** add the PR to the project board as **In Progress** — use `gh project item-add 2 --owner ettoreaquino --url <PR_URL>` then set the status field
-3. **When the PR merges:** the `Closes #N` keyword auto-closes the issue; set both the issue and merged PR to **Done** on the board
-4. **Epics** stay **In Progress** until all child tasks/PRs are merged, then move to **Done**
+1. **When starting work on an issue/epic:** `/pr` sets the issue to **In Progress** automatically (both for newly created and pre-existing issues).
+2. **When opening a PR:** `/pr` adds the PR to the board as **In Progress** and sets its `Type` field from the conventional-commit prefix.
+3. **When the PR merges:** GitHub Projects automation moves both the PR and the auto-closed issue to **Done**. **Do not edit Status manually** except via `/board-reconcile --fix`.
+4. **Epics** stay **In Progress** until all child tasks/PRs are merged, then move to **Done** (manual — epics have no closing PR).
 
-CLI commands for project board management:
+### Automation source-of-truth
+
+The following Projects v2 built-in workflows are enabled in the project's **Settings → Workflows**:
+
+| Workflow | Effect |
+|---|---|
+| Auto-add to project (filter: `repo:ettoreaquino/devlair is:issue,pr -title:"chore(main): release"`) | New issues/PRs land on the board automatically; release-please bot PRs are excluded so they don't inflate Deployment Frequency |
+| Item closed → Status: Done | Covers `Closes #N` auto-closes |
+| Item reopened → Status: In Progress | Reverses the above |
+| Pull request merged → Status: Done | Direct merge transition |
+
+If a workflow is disabled or a bypass occurs (manual `gh issue create`, web-UI creation outside the filter, etc.), `/board-reconcile` catches it.
+
+### Reconciliation
+
+- `/board-reconcile` (alias `/board-reconcile --dry-run`) — audit only, prints a drift table.
+- `/board-reconcile --fix` — apply repairs. Every repair is set-to-desired-state, so re-running immediately after a successful pass reports zero drift.
+- `/pr` runs `/board-reconcile --dry-run --scope=this-pr` at end of flow as a per-PR sanity check.
+- Run `/board-reconcile --fix` weekly (use `/loop 7d /board-reconcile --fix` or `/schedule`).
+
+### DORA metrics
+
+Mapping each metric to a board/API query (all measurable today; field IDs documented below):
+
+| Metric | Query |
+|---|---|
+| **Deployment Frequency** | Merged PRs per window where `Type ≠ chore` (release-please excluded by board filter; explicit `Type` filter excludes the rare chore PR that did get added). |
+| **Lead Time for Changes** | `mergedAt(PR) − createdAt(linked issue)` per merged non-chore PR. Average / median over the window. |
+| **Change Failure Rate** | `count(Incident=Yes issues closed in window) / count(non-chore merged PRs in window)`. Set `Incident=Yes` manually when a bug is a regression from a prior deploy. |
+| **MTTR** | `closedAt(Incident=Yes issue) − mergedAt(introducing PR)` per incident. |
+
+### CLI commands for board management
+
+Use `/pr` and `/board-reconcile` for routine work. Raw `gh` is only needed for one-off ops:
+
 ```bash
-# Add an item (issue or PR) to the project
+# Add an item (idempotent — no-op if already present)
 gh project item-add 2 --owner ettoreaquino --url <URL>
 
-# Update status (get item ID from item-list, field/option IDs from field-list)
+# Update a field (always pass --limit 500 when looking up the item ID)
+ITEM_ID=$(gh project item-list 2 --owner ettoreaquino --limit 500 --format json \
+  --jq '.items[] | select(.content.number == <N>) | .id')
 gh project item-edit --project-id PVT_kwHOAI_A384BTyaU \
-  --id <ITEM_ID> \
-  --field-id PVTSSF_lAHOAI_A384BTyaUzhA-6Fg \
-  --single-select-option-id <STATUS_OPTION_ID>
+  --id "$ITEM_ID" \
+  --field-id <FIELD_ID> \
+  --single-select-option-id <OPTION_ID>
+```
 
-# Status option IDs:
-#   Todo:        f75ad846
-#   In Progress: 47fc9ee4
-#   Done:        98236657
+### Field reference
+
+```
+Project ID:     PVT_kwHOAI_A384BTyaU
+
+Status field:   PVTSSF_lAHOAI_A384BTyaUzhA-6Fg
+  Todo:         f75ad846
+  In Progress:  47fc9ee4
+  Done:         98236657
+
+Type field:     PVTSSF_lAHOAI_A384BTyaUzhTNn1g       (DORA: slice Deployment Frequency)
+  feat:         fb49f55e
+  fix:          8a8822f4
+  chore:        e4a0286c
+  docs:         229100de
+  refactor:     428d2abe
+
+Incident field: PVTSSF_lAHOAI_A384BTyaUzhTNn2A       (DORA: Change Failure Rate, MTTR)
+  No:           2c582288
+  Yes:          12d9b2e2
 ```
 
 ## Evolution context


### PR DESCRIPTION
## Summary

Closes the drift sources behind the recent board state issues by making the SDLC automation idempotent, self-healing, and DORA-ready.

- **`.claude/commands/pr.md`** — existing-issue branch now does the same `item-add` + status-set as the new-issue branch (closes the "manually-filed issues never reach the board" drift). Every `gh project item-list` call passes `--limit 500`. New Step 6 sets the `Type` field from the conventional-commit prefix. New Step 7 runs a per-PR reconciliation check.
- **`.claude/commands/board-reconcile.md`** (new) — single audit + repair pass. `/board-reconcile` dry-runs by default; `/board-reconcile --fix` applies repairs. Every write is set-to-state, so re-running reports zero drift. Detects: items missing from board, status mismatches against actual issue/PR state, missing `Type` field, release-please bot PRs that snuck on.
- **`.claude/settings.json`** — two non-blocking warning hooks. Detect raw `gh issue create` / `gh pr create` run outside `/pr` and nudge the user toward `/board-reconcile`. (The `gh issue create` one fired during the creation of #127 in this very session — works as intended.)
- **`CLAUDE.md`** — Project board section rewritten. Automation is the source of truth; manual Status edits only via `/board-reconcile --fix`. Documents the four Projects v2 built-in workflows the user must enable in the UI. Adds DORA metric mappings (Deployment Frequency, Lead Time, Change Failure Rate, MTTR) and the `Type` / `Incident` field reference.

**Out-of-band in this session (no code change):**
- Drift cleanup applied: #92 → Todo, #81/#84/#94 → Done.
- Created `Type` (feat/fix/chore/docs/refactor) and `Incident` (No/Yes) custom fields on Projects v2.

**Manual user step remaining (documented in CLAUDE.md):**
- Enable four Projects v2 workflows in the project Settings UI: auto-add (with `-title:"chore(main): release"` filter), item-closed → Done, item-reopened → In Progress, PR-merged → Done.

Closes #127

## Test plan

- [ ] `/board-reconcile --dry-run` reports zero drift on current board state <!-- needs-manual: requires interactive skill invocation -->
- [ ] `/pr 96` (existing issue, no PR) sets #96 to In Progress on the board; re-running is a no-op <!-- needs-manual: would mutate live board for an unrelated issue -->
- [ ] After this PR merges, GitHub auto-closes #127 and the workflow moves both #127 and #128 to Done with no manual intervention (verifies workflow enablement once user flips the UI toggles) <!-- needs-manual: depends on user enabling Projects v2 workflows + actual merge -->
- [x] Test issue created via raw `gh issue create` triggers the warning hook with the `/board-reconcile` nudge — observed in this session when creating #127
- [x] `Type` field is set on this PR to `chore` after `/pr` Step 6 runs — verified `gh project item-list` shows `type=chore` on #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
