### PR TITLE
fix(init): accumulate progress history and honour warn status

### DIFF
--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -112,6 +112,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
         status: "pending" as const,
         detail: "",
         progressMsg: "",
+        progressHistory: [],
       })),
     );
     setDone(false);
@@ -139,6 +140,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
 
         let finalStatus: Status = "fail";
         let finalDetail = "";
+        let resultEmitted = false;
 
         try {
           const scriptPath = moduleScriptPath(spec.key);
@@ -152,7 +154,9 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
           while (true) {
             const { value, done: iterDone } = await iter.next();
             if (iterDone) {
-              finalStatus = value.status;
+              // Only fall back to exit-code status when the module never emitted
+              // a `result` event — otherwise we'd promote warn→ok on exit 0.
+              if (!resultEmitted) finalStatus = value.status;
               // A module that exits non-zero without emitting a `result` event
               // (e.g. a missing runtime dep aborting _lib.sh early) leaves the
               // UI showing a bare ✗. Fall back to the last non-empty stderr
@@ -168,9 +172,21 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
               break;
             }
             if (value.type === "progress") {
-              setModules((prev) => prev.map((m, j) => (j === i ? { ...m, progressMsg: value.message } : m)));
+              setModules((prev) =>
+                prev.map((m, j) =>
+                  j === i
+                    ? {
+                        ...m,
+                        progressMsg: value.message,
+                        progressHistory: m.progressMsg ? [...m.progressHistory, m.progressMsg] : m.progressHistory,
+                      }
+                    : m,
+                ),
+              );
             } else if (value.type === "result") {
+              finalStatus = value.status;
               finalDetail = value.detail;
+              resultEmitted = true;
             } else if (value.type === "auth_url") {
               const authUrl = { url: value.url, message: value.message };
               setModules((prev) => prev.map((m, j) => (j === i ? { ...m, authUrl } : m)));
@@ -183,7 +199,9 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
 
         setModules((prev) =>
           prev.map((m, j) =>
-            j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "", authUrl: undefined } : m,
+            j === i
+              ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "", progressHistory: [], authUrl: undefined }
+              : m,
           ),
         );
       }

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -157,10 +157,6 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
               // Only fall back to exit-code status when the module never emitted
               // a `result` event — otherwise we'd promote warn→ok on exit 0.
               if (!resultEmitted) finalStatus = value.status;
-              // A module that exits non-zero without emitting a `result` event
-              // (e.g. a missing runtime dep aborting _lib.sh early) leaves the
-              // UI showing a bare ✗. Fall back to the last non-empty stderr
-              // line so the user sees what actually happened.
               if (!finalDetail && finalStatus !== "ok") {
                 const lastErr = value.stderr
                   .split("\n")

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -196,7 +196,14 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
         setModules((prev) =>
           prev.map((m, j) =>
             j === i
-              ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "", progressHistory: [], authUrl: undefined }
+              ? {
+                  ...m,
+                  status: finalStatus,
+                  detail: finalDetail,
+                  progressMsg: "",
+                  progressHistory: [],
+                  authUrl: undefined,
+                }
               : m,
           ),
         );

--- a/cli/src/commands/upgrade.tsx
+++ b/cli/src/commands/upgrade.tsx
@@ -262,6 +262,7 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
         status: "pending" as const,
         detail: "",
         progressMsg: "",
+        progressHistory: [],
       })),
     );
 
@@ -276,6 +277,7 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
 
         let finalStatus: Status = "fail";
         let finalDetail = "";
+        let resultEmitted = false;
 
         try {
           const scriptPath = moduleScriptPath(spec.key);
@@ -284,13 +286,25 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
           while (true) {
             const { value, done } = await iter.next();
             if (done) {
-              finalStatus = value.status;
+              if (!resultEmitted) finalStatus = value.status;
               break;
             }
             if (value.type === "progress") {
-              setReapplyModules((prev) => prev.map((m, j) => (j === i ? { ...m, progressMsg: value.message } : m)));
+              setReapplyModules((prev) =>
+                prev.map((m, j) =>
+                  j === i
+                    ? {
+                        ...m,
+                        progressMsg: value.message,
+                        progressHistory: m.progressMsg ? [...m.progressHistory, m.progressMsg] : m.progressHistory,
+                      }
+                    : m,
+                ),
+              );
             } else if (value.type === "result") {
+              finalStatus = value.status;
               finalDetail = value.detail;
+              resultEmitted = true;
             }
           }
         } catch (err) {
@@ -299,7 +313,9 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
         }
 
         setReapplyModules((prev) =>
-          prev.map((m, j) => (j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "" } : m)),
+          prev.map((m, j) =>
+            j === i ? { ...m, status: finalStatus, detail: finalDetail, progressMsg: "", progressHistory: [] } : m,
+          ),
         );
       }
 

--- a/cli/src/components/Progress.tsx
+++ b/cli/src/components/Progress.tsx
@@ -51,7 +51,7 @@ function ModuleLine({ mod, index, total }: { mod: ModuleRun; index: number; tota
           </Text>
           {mod.progressMsg ? <Text color={D_COMMENT}> {mod.progressMsg}</Text> : null}
         </Box>
-        {mod.progressHistory.length > 0 ? (
+        {mod.progressHistory.length > 0 && (
           <Box flexDirection="column" marginLeft={6}>
             {mod.progressHistory.map((msg, idx) => (
               <Text key={idx} color={D_COMMENT}>
@@ -60,7 +60,7 @@ function ModuleLine({ mod, index, total }: { mod: ModuleRun; index: number; tota
               </Text>
             ))}
           </Box>
-        ) : null}
+        )}
         {mod.authUrl ? <AuthPanel url={mod.authUrl.url} message={mod.authUrl.message} /> : null}
       </Box>
     );

--- a/cli/src/components/Progress.tsx
+++ b/cli/src/components/Progress.tsx
@@ -13,6 +13,7 @@ export interface ModuleRun {
   status: ModuleRunStatus;
   detail: string;
   progressMsg: string;
+  progressHistory: string[];
   authUrl?: { url: string; message: string };
 }
 
@@ -50,6 +51,16 @@ function ModuleLine({ mod, index, total }: { mod: ModuleRun; index: number; tota
           </Text>
           {mod.progressMsg ? <Text color={D_COMMENT}> {mod.progressMsg}</Text> : null}
         </Box>
+        {mod.progressHistory.length > 0 ? (
+          <Box flexDirection="column" marginLeft={6}>
+            {mod.progressHistory.map((msg, idx) => (
+              <Text key={idx} color={D_COMMENT}>
+                {"✓ "}
+                {msg}
+              </Text>
+            ))}
+          </Box>
+        ) : null}
         {mod.authUrl ? <AuthPanel url={mod.authUrl.url} message={mod.authUrl.message} /> : null}
       </Box>
     );

--- a/cli/src/components/Progress.tsx
+++ b/cli/src/components/Progress.tsx
@@ -53,8 +53,8 @@ function ModuleLine({ mod, index, total }: { mod: ModuleRun; index: number; tota
         </Box>
         {mod.progressHistory.length > 0 && (
           <Box flexDirection="column" marginLeft={6}>
-            {mod.progressHistory.map((msg, idx) => (
-              <Text key={idx} color={D_COMMENT}>
+            {mod.progressHistory.map((msg) => (
+              <Text key={msg} color={D_COMMENT}>
                 {"✓ "}
                 {msg}
               </Text>


### PR DESCRIPTION
## Summary

- **Progress history**: add `progressHistory: string[]` to `ModuleRun`; each new progress event moves the previous message into history, rendered as dimmed sub-lines while the module runs. Fixes devtools (and any other long module) silently overwriting progress steps — users now see a running list of completed steps under the spinner.
- **Warn shown as ✓**: `init.tsx` and `upgrade.tsx` were capturing `detail` from the module's `result` event but discarding its `status`, always overwriting `finalStatus` from the exit code. Since `github.sh` exits 0 on a failed connection test, `warn` was silently promoted to `ok`. Fixed with a `resultEmitted` flag — exit-code status is only the fallback when no `result` event was emitted.
- Same fix applied to `upgrade.tsx` (reapply loop uses the same pattern).

Closes #132

## Test plan

- [x] `bun test` passes (160/160)
- [x] `bun run typecheck` clean
- [ ] Run `devlair init` on WSL: dev tools step shows accumulated progress sub-lines during install <!-- needs-manual: requires fresh WSL distro with long-running module install -->
- [ ] Simulate GitHub SSH connection failure: module shows `⚠` not `✓` <!-- needs-manual: requires SSH connection test environment -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
