### PR TITLE
fix(install): make v2 the default install channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.s
 devlair init
 ```
 
-That's it. The installer downloads a prebuilt binary for your architecture and places it in `/usr/local/bin`. `devlair init` takes care of the rest.
-
-> [!NOTE]
-> **v2 is now stable.** Install with `curl ... | sudo bash -s -- --pre`. The v2 rewrite drops `sync`, `filesystem`, and `claw` — see [v2 (TypeScript + Ink)](#v2-typescript--ink--stable).
+That's it. The installer downloads the v2 (TypeScript + Ink) binary for your architecture and places it in `/usr/local/bin`. `devlair init` takes care of the rest.
 
 ## Why devlair
 
@@ -351,13 +348,13 @@ uv run ruff check devlair/ tests/
 
 ### v2 (TypeScript + Ink — stable)
 
-**Install v2:**
+**Install v2 (default):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash -s -- --pre
+curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash
 ```
 
-This downloads the latest `devlair-cli-v*` asset and installs it as `/usr/local/bin/devlair`, replacing v1. The companion `modules.tar.gz` (shell scripts invoked by the wizard) is verified against the same `checksums.txt` and extracted to `/usr/local/share/devlair/modules/`. To roll back to v1, re-run the installer without `--pre`.
+The installer downloads the latest `devlair-cli-linux-{arch}` binary and places it at `/usr/local/bin/devlair`. The companion `modules.tar.gz` (shell scripts invoked by the wizard) is verified against `checksums.txt` and extracted to `/usr/local/share/devlair/modules/`. To install the legacy v1 (Python) instead, pass `--v1`.
 
 **Removed in v2** (vs. v1):
 

--- a/install.sh
+++ b/install.sh
@@ -3,18 +3,19 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash
-#   curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash -s -- --pre
+#   curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash -s -- --v1
 #
 # Channels:
-#   stable   Latest v1 release (Python). Default.
-#   --pre    Latest v2 alpha (TypeScript + Ink). Preview — see breaking changes below.
+#   (default)  Latest v2 release (TypeScript + Ink).
+#   --v1       Latest v1 release (Python). Legacy.
+#   --pre      Deprecated — v2 is now the default. Accepted for backward compatibility.
 set -euo pipefail
 
 REPO="ettoreaquino/devlair"
 BIN="devlair"
 INSTALL_DIR="/usr/local/bin"
 SHARE_DIR="/usr/local/share/devlair"
-CHANNEL="stable"
+CHANNEL="v2"
 
 # Computed after we know INSTALL_DIR — reused for binary install, modules
 # install, and any apt-get fallbacks below so the sudo decision is made once.
@@ -79,8 +80,9 @@ verify_checksum() {
 # ── Parse flags ───────────────────────────────────────────────────────────────
 for arg in "$@"; do
   case "$arg" in
-    --pre)    CHANNEL="pre" ;;
-    --stable) CHANNEL="stable" ;;
+    --v1)    CHANNEL="v1" ;;
+    --stable) CHANNEL="v1" ;;  # --stable used to mean v1; kept for compat
+    --pre)   ;;                # no-op: v2 is now the default
     -h|--help)
       sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
@@ -109,18 +111,19 @@ printf "\n%s%s devlair installer%s  %s· channel: %s · arch: %s%s\n\n" \
 
 # ── Channel configuration ─────────────────────────────────────────────────────
 section "Resolving release"
-if [[ "$CHANNEL" == "pre" ]]; then
-  ASSET_PREFIX="devlair-cli"
-  # v2 releases use plain v2.x.x tags — filter by major version to distinguish
-  # from v1 (v1.x.x) without relying on the old devlair-cli-v* prefix.
+if [[ "$CHANNEL" == "v1" ]]; then
+  ASSET_PREFIX="devlair"
+  # v1 releases use v1.x.x tags — filter by major version.
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
-    | grep -o '"tag_name": *"v2\.[^"]*"' \
+    | grep -o '"tag_name": *"v1\.[^"]*"' \
     | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"')
 else
-  ASSET_PREFIX="devlair"
-  LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep -o '"tag_name": *"[^"]*"' | head -1 \
+  ASSET_PREFIX="devlair-cli"
+  # v2 releases use v2.x.x tags — filter by major version.
+  LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
+    | grep -o '"tag_name": *"v2\.[^"]*"' \
+    | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"')
 fi
 
@@ -143,9 +146,13 @@ curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
 ok "downloaded ${ASSET}"
 
 # ── Verify SHA-256 checksum ──────────────────────────────────────────────────
-# Stable channel: soft-warn on missing entry (pre-existing behavior; tracked
-# separately). Mismatches still hard-fail inside verify_checksum.
-verify_checksum "$TMP" "$ASSET" "$TMP_CHECKSUMS" 0
+# v1: soft-warn on missing entry (pre-existing behavior). Mismatches always abort.
+# v2: hard-fail — the release CI always publishes checksums.
+if [[ "$CHANNEL" == "v1" ]]; then
+  verify_checksum "$TMP" "$ASSET" "$TMP_CHECKSUMS" 0
+else
+  verify_checksum "$TMP" "$ASSET" "$TMP_CHECKSUMS" 1
+fi
 
 chmod 755 "$TMP"
 
@@ -155,11 +162,11 @@ $MAYBE_SUDO mv "$TMP" "${INSTALL_DIR}/${BIN}"
 $MAYBE_SUDO chmod 755 "${INSTALL_DIR}/${BIN}"
 ok "${INSTALL_DIR}/${BIN}"
 
-# ── Pre-release: fetch modules tarball ────────────────────────────────────────
+# ── v2: fetch modules tarball ─────────────────────────────────────────────────
 # v2 shell modules live outside the compiled binary and ship as a separate
-# tarball. v1 (stable) is self-contained and does not need this step.
-if [[ "$CHANNEL" == "pre" ]]; then
-  section "Fetching v2 modules"
+# tarball. v1 is self-contained and does not need this step.
+if [[ "$CHANNEL" != "v1" ]]; then
+  section "Fetching modules"
   TMP_MODULES=$(mktemp)
   curl -fsSL "${BASE_URL}/modules.tar.gz" -o "$TMP_MODULES"
 
@@ -187,7 +194,7 @@ if [[ "$CHANNEL" == "pre" ]]; then
   rm -rf "$STAGE_DIR"
   ok "modules installed to ${SHARE_DIR}/modules"
 
-  # ── Pre-release: WSL-specific dpkg state cleanup ──────────────────────────
+  # ── WSL-specific dpkg state cleanup ──────────────────────────────────────
   # Ubuntu 24.04 WSL ships with openssh-server in a half-configured state:
   # its postinst calls `systemctl restart ssh`, but systemd isn't running by
   # default on WSL, so the postinst exits 1 and dpkg leaves the package in
@@ -208,7 +215,7 @@ if [[ "$CHANNEL" == "pre" ]]; then
     $MAYBE_SUDO dpkg --configure -a >/dev/null 2>&1 || true
   fi
 
-  # ── Pre-release: bootstrap runtime deps ────────────────────────────────────
+  # ── Bootstrap runtime deps ────────────────────────────────────────────────
   # modules/_lib.sh hard-requires jq for context parsing; on a fresh Ubuntu
   # the binary installs cleanly but every `devlair init` step exits 1 before
   # emitting any output. Install jq up-front so the first wizard run works.
@@ -230,8 +237,8 @@ rm -f "$TMP_CHECKSUMS"
 printf "\n%s✓%s %sdevlair %s installed%s\n" "$C_GREEN" "$C_RESET" "$C_BOLD" "$LATEST" "$C_RESET"
 printf "  %s%s%s\n\n" "$C_COMMENT" "${INSTALL_DIR}/${BIN}" "$C_RESET"
 
-# ── Channel-specific post-install notice ──────────────────────────────────────
-if [[ "$CHANNEL" == "pre" ]]; then
+# ── Post-install notice (v2 only) ─────────────────────────────────────────────
+if [[ "$CHANNEL" != "v1" ]]; then
   printf "%s!%s %sv2%s — the following v1 commands have been REMOVED:\n\n" \
     "$C_ORANGE" "$C_RESET" "$C_BOLD" "$C_RESET"
   printf "  %sdevlair filesystem%s   not ported\n\n" "$C_PINK" "$C_RESET"

--- a/install.sh
+++ b/install.sh
@@ -113,18 +113,22 @@ printf "\n%s%s devlair installer%s  %s· channel: %s · arch: %s%s\n\n" \
 section "Resolving release"
 if [[ "$CHANNEL" == "v1" ]]; then
   ASSET_PREFIX="devlair"
-  # v1 releases use v1.x.x tags — filter by major version.
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
     | grep -o '"tag_name": *"v1\.[^"]*"' \
     | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"')
+  if [[ -n "${LATEST:-}" && ! "$LATEST" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then
+    err "Unexpected version format: $LATEST"; exit 1
+  fi
 else
   ASSET_PREFIX="devlair-cli"
-  # v2 releases use v2.x.x tags — filter by major version.
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
     | grep -o '"tag_name": *"v2\.[^"]*"' \
     | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"')
+  if [[ -n "${LATEST:-}" && ! "$LATEST" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then
+    err "Unexpected version format: $LATEST"; exit 1
+  fi
 fi
 
 if [[ -z "${LATEST:-}" ]]; then
@@ -141,6 +145,8 @@ section "Downloading binary"
 BASE_URL="https://github.com/${REPO}/releases/download/${LATEST}"
 TMP=$(mktemp)
 TMP_CHECKSUMS=$(mktemp)
+cleanup() { rm -f "${TMP:-}" "${TMP_CHECKSUMS:-}" "${TMP_MODULES:-}"; rm -rf "${STAGE_DIR:-}"; }
+trap cleanup EXIT
 curl -fsSL "${BASE_URL}/${ASSET}" -o "$TMP"
 curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
 ok "downloaded ${ASSET}"
@@ -181,7 +187,7 @@ if [[ "$CHANNEL" != "v1" ]]; then
   # under sudo; chmod immediately after pins a known-safe mode regardless of
   # the installer's umask.
   STAGE_DIR=$(mktemp -d)
-  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR" --no-same-owner --no-same-permissions
+  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR" --no-same-owner --no-same-permissions --no-absolute-filenames
   chmod -R u=rwX,go=rX "$STAGE_DIR/modules"
   rm -f "$TMP_MODULES"
 


### PR DESCRIPTION
## Summary

- `curl | bash` (no flags) now installs v2 (TypeScript + Ink) — v2 is stable
- `--pre` accepted as no-op for backward compatibility with existing scripts
- `--v1` / `--stable` install the legacy Python binary
- v2 checksum verification upgraded to hard-fail (CI always publishes checksums)
- WSL dpkg cleanup and jq bootstrap now run on the default v2 path, not only `--pre`
- README quick start and v2 install section updated to drop the `--pre` flag

Closes #141

## Test plan

- [x] `curl | bash` resolves a `v2.*` tag and downloads `devlair-cli-linux-{arch}`
- [x] `curl | bash -s -- --pre` is accepted (no error), installs v2
- [x] `curl | bash -s -- --v1` resolves a `v1.*` tag and downloads `devlair-linux-{arch}`
- [ ] `devlair init` works on a fresh WSL machine after plain install <!-- needs-manual: requires a live WSL environment -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)