### PR TITLE
chore(release): exclude manifest from v1 trigger paths

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "exclude-paths": ["cli", ".claude", ".github", "CLAUDE.md", "README.md", "install.sh"],
+      "exclude-paths": ["cli", ".claude", ".github", "CLAUDE.md", "README.md", "install.sh", ".release-please-manifest.json"],
       "extra-files": [
         "devlair/__init__.py"
       ]


### PR DESCRIPTION
## Summary

- Adds `.release-please-manifest.json` to v1's `exclude-paths` in `release-please-config.json`
- Prevents spurious v1 Python release PRs when only the manifest changes (e.g. after a v2 CLI release)

Closes #143

## Test plan

- [ ] No new v1 release PR appears after the next v2 CLI release bumps the manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)