### PR TITLE
fix(install): remove unsupported --no-absolute-filenames tar flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ if [[ "$CHANNEL" != "v1" ]]; then
   # under sudo; chmod immediately after pins a known-safe mode regardless of
   # the installer's umask.
   STAGE_DIR=$(mktemp -d)
-  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR" --no-same-owner --no-same-permissions --no-absolute-filenames
+  tar -xzf "$TMP_MODULES" -C "$STAGE_DIR" --no-same-owner --no-same-permissions
   chmod -R u=rwX,go=rX "$STAGE_DIR/modules"
   rm -f "$TMP_MODULES"
 


### PR DESCRIPTION
## Summary

- Removes `--no-absolute-filenames` from the `tar` invocation in `install.sh`
- The flag is not a valid GNU tar option and breaks installation on Ubuntu WSL
- GNU tar already strips leading `/` by default — the flag was redundant

Closes #146

## Test plan

- [x] `bash -n install.sh` passes
- [ ] `curl | bash` completes successfully on Ubuntu WSL

🤖 Generated with [Claude Code](https://claude.com/claude-code)