### PR TITLE
feat(wizard): wait for GitHub SSH connection before completing module

### DIFF
--- a/cli/modules/github.sh
+++ b/cli/modules/github.sh
@@ -49,23 +49,7 @@ EOF
     chown_user "$ssh_conf"
   fi
 
-  # Display public key for the user (via progress event)
-  local pub
-  pub=$(cat "${gh_key}.pub")
-  json_progress "Add this public key to GitHub: $pub"
-
-  # Test connection
-  local connected=false
-  if run_as "$USERNAME" ssh -T git@github.com -o StrictHostKeyChecking=accept-new >/dev/null 2>&1; then
-    connected=true
-  else
-    # ssh -T returns exit 1 on success with "successfully authenticated" on stderr
-    if run_as "$USERNAME" ssh -T git@github.com -o StrictHostKeyChecking=accept-new 2>&1 | grep -q "successfully authenticated"; then
-      connected=true
-    fi
-  fi
-
-  # Git global config
+  # Git global config (no network required — do this before the wait)
   run_as "$USERNAME" git config --global user.email "$email" >&2
   local git_name
   git_name=$(ctx_get_config github_name)
@@ -74,11 +58,23 @@ EOF
   fi
   run_as "$USERNAME" git config --global init.defaultBranch main >&2
 
-  if [[ "$connected" == "true" ]]; then
-    json_result "ok" "connected"
-  else
-    json_result "warn" "key added but connection test failed — check GitHub"
-  fi
+  # Surface the public key and wait for the user to add it to GitHub.
+  # AuthPanel renders: key (pink) + URL (cyan) + "Waiting for authentication…"
+  # No timeout — user completes the step at their own pace; Ctrl-C in the
+  # wizard sends SIGTERM and cancels the whole tree.
+  local pub
+  pub=$(cat "${gh_key}.pub")
+  json_auth_url "https://github.com/settings/ssh/new" "$pub"
+
+  local poll_interval=3
+  while true; do
+    if run_as "$USERNAME" ssh -T git@github.com -o StrictHostKeyChecking=accept-new 2>&1 | grep -q "successfully authenticated"; then
+      break
+    fi
+    sleep "$poll_interval"
+  done
+
+  json_result "ok" "connected"
 }
 
 do_check() {

--- a/cli/modules/github.sh
+++ b/cli/modules/github.sh
@@ -49,7 +49,6 @@ EOF
     chown_user "$ssh_conf"
   fi
 
-  # Git global config (no network required — do this before the wait)
   run_as "$USERNAME" git config --global user.email "$email" >&2
   local git_name
   git_name=$(ctx_get_config github_name)
@@ -86,7 +85,7 @@ do_check() {
     return
   fi
 
-  if run_as "$USERNAME" ssh -T git@github.com -o StrictHostKeyChecking=no 2>&1 | grep -q "successfully authenticated"; then
+  if run_as "$USERNAME" ssh -T git@github.com -o StrictHostKeyChecking=accept-new 2>&1 | grep -q "successfully authenticated"; then
     json_check "github connection" "ok"
   else
     json_check "github connection" "fail"


### PR DESCRIPTION
## Summary

- GitHub module now surfaces the SSH public key via `AuthPanel` (same sticky UI as Tailscale auth) and polls until `ssh -T git@github.com` succeeds
- No timeout — user adds the key at their own pace; Ctrl-C cancels cleanly via SIGTERM
- Git global config (email, name, defaultBranch) applied before the wait since it requires no network

Closes #148

## Test plan

- [ ] `devlair init` with `github` module: AuthPanel appears with the public key and `https://github.com/settings/ssh/new`
- [ ] Adding the key to GitHub causes the module to complete with `✓ connected`
- [ ] Ctrl-C during the wait cancels the wizard cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)