### PR TITLE
chore(release): exclude release-please-config.json from v1 trigger paths

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
       "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "exclude-paths": ["cli", ".claude", ".github", "CLAUDE.md", "README.md", "install.sh", ".release-please-manifest.json"],
+      "exclude-paths": ["cli", ".claude", ".github", "CLAUDE.md", "README.md", "install.sh", ".release-please-manifest.json", "release-please-config.json"],
       "extra-files": [
         "devlair/__init__.py"
       ]


### PR DESCRIPTION
## Summary

- Adds `release-please-config.json` to v1's `exclude-paths`
- `fix(release)` commits updating this file were triggering spurious v1 Python release PRs (seen as #131, #145, #150 — all closed without merging)
- Follows the same pattern as the previous `.release-please-manifest.json` exclusion (#144)

Closes #153

## Test plan

- [ ] No new v1 release PR appears after the next release-please-config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)