### PR TITLE
feat(macos): brew_install helper and macOS platform flags for portable modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 
 ## What gets installed
 
-`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL.
+`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`. Linux-only modules (auto-skipped elsewhere): `timezone`, `ssh`, `firewall`, `gnome_terminal`.
 
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
@@ -329,7 +329,7 @@ Checks for a new devlair binary first — if a new version is available, it down
 
 ## Requirements
 
-- **OS:** Ubuntu 24.04 LTS or WSL 2 (Ubuntu)
+- **OS:** Ubuntu 24.04 LTS, WSL 2 (Ubuntu), or macOS (portable modules only — see module list above)
 - **Arch:** x86_64 or aarch64
 - **Privileges:** root or a user with `sudo`
 - **WSL extras:** Docker Desktop for Windows with WSL integration enabled (for Docker-dependent modules)

--- a/devlair/modules/__init__.py
+++ b/devlair/modules/__init__.py
@@ -36,17 +36,17 @@ class ModuleSpec:
 MODULE_SPECS: list[ModuleSpec] = [
     ModuleSpec("system",         "System update",          system,         "core"),
     ModuleSpec("timezone",       "Timezone",               timezone,       "core",                                    platforms={"linux"}),
-    ModuleSpec("tailscale",      "Tailscale",              tailscale,      "network",                                 default_on={"linux"}),
+    ModuleSpec("tailscale",      "Tailscale",              tailscale,      "network",                                 default_on={"linux"},                          platforms={"linux", "wsl", "macos"}),
     ModuleSpec("ssh",            "SSH",                    ssh,            "network",     deps=["tailscale"],        platforms={"linux"}),
     ModuleSpec("firewall",       "Firewall + Fail2Ban",    firewall,       "network",     deps=["ssh"],              platforms={"linux"}),
-    ModuleSpec("zsh",            "Zsh + Dracula",          zsh,            "core",        reapply=True),
-    ModuleSpec("tmux",           "tmux",                   tmux,           "coding",      reapply=True),
+    ModuleSpec("zsh",            "Zsh + Dracula",          zsh,            "core",        reapply=True,              platforms={"linux", "wsl", "macos"}),
+    ModuleSpec("tmux",           "tmux",                   tmux,           "coding",      reapply=True,              platforms={"linux", "wsl", "macos"}),
     ModuleSpec("devtools",       "Dev tools",              devtools,       "coding",      reapply=True),
-    ModuleSpec("rclone",         "rclone sync",            rclone,         "cloud-sync",                              default_on=set()),
-    ModuleSpec("github",         "GitHub SSH key",         github,         "coding"),
-    ModuleSpec("shell",          "Shell aliases",          shell,          "core",        deps=["zsh"], reapply=True),
+    ModuleSpec("rclone",         "rclone sync",            rclone,         "cloud-sync",                              default_on=set(),                              platforms={"linux", "wsl", "macos"}),
+    ModuleSpec("github",         "GitHub SSH key",         github,         "coding",                                 platforms={"linux", "wsl", "macos"}),
+    ModuleSpec("shell",          "Shell aliases",          shell,          "core",        deps=["zsh"], reapply=True, platforms={"linux", "wsl", "macos"}),
     ModuleSpec("gnome_terminal", "Gnome Terminal Dracula", gnome_terminal, "desktop",     reapply=True,              platforms={"linux"}),
-    ModuleSpec("claude",         "Claude Code",            claude,         "ai",          deps=["devtools"], reapply=True, default_on=set()),
+    ModuleSpec("claude",         "Claude Code",            claude,         "ai",          deps=["devtools"], reapply=True, default_on=set(),                         platforms={"linux", "wsl", "macos"}),
 ]
 # fmt: on
 

--- a/devlair/runner.py
+++ b/devlair/runner.py
@@ -65,6 +65,10 @@ def apt_install(*packages: str, quiet: bool = False) -> None:
     run(["apt-get", "install", "-y", "-qq"] + list(packages), capture=quiet)
 
 
+def brew_install(*packages: str, quiet: bool = False) -> None:
+    run(["brew", "install"] + list(packages), capture=quiet)
+
+
 def get_output(cmd: str | list) -> str:
     result = run(cmd, capture=True, check=False)
     return result.stdout.strip()

--- a/devlair/runner.py
+++ b/devlair/runner.py
@@ -66,7 +66,7 @@ def apt_install(*packages: str, quiet: bool = False) -> None:
 
 
 def brew_install(*packages: str, quiet: bool = False) -> None:
-    run(["brew", "install"] + list(packages), capture=quiet)
+    run(["brew", "install"] + (["--quiet"] if quiet else []) + list(packages), capture=quiet)
 
 
 def get_output(cmd: str | list) -> str:


### PR DESCRIPTION
## Summary

- Adds `brew_install(*packages)` helper to `devlair/runner.py`, mirroring the existing `apt_install` interface
- Enables macOS as an eligible platform (`platforms={"linux", "wsl", "macos"}`) for seven portable modules: `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`
- No module code changes in this PR — platform eligibility is the gate; PRs 1b and 1c add the per-module macOS tweaks

Part of #158

## Test plan

- [x] `uv run pytest tests/unit/` passes (150 tests, no regressions)
- [x] `uv run ruff check devlair/ tests/` clean
- [x] `resolve_order(platform="macos")` now includes `zsh`, `tmux`, `github`, `shell`, `rclone` and excludes `system`, `timezone`, `ssh`, `firewall`, `gnome_terminal`, `devtools`
- [x] `resolve_order(platform="linux")` unchanged — no Linux/WSL regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
