### PR TITLE
feat(macos): make zsh, shell, and tmux modules portable to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Installs zsh, sets it as default, and configures [zimfw](https://zimfw.sh) with:
 <details>
 <summary><b>tmux</b> — Dracula-themed multiplexer</summary>
 
-Writes `~/.tmux.conf` with Dracula colors, `C-a` prefix, mouse support, 50k line history, and intuitive split bindings (`|` and `-`). Vi copy-mode with mouse drag selection piped to the system clipboard (`wl-copy` on Wayland, `xclip` on X11, OSC 52 fallback). Installs `wl-clipboard` automatically when no clipboard tool is found. Includes [TPM](https://github.com/tmux-plugins/tpm), [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) + [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) for automatic session save/restore — TPM plugins are installed non-interactively during init/upgrade. Claude Code popup on `C-a y`.
+Writes `~/.tmux.conf` with Dracula colors, `C-a` prefix, mouse support, 50k line history, and intuitive split bindings (`|` and `-`). Vi copy-mode with mouse drag selection piped to the system clipboard (`pbcopy` on macOS, `wl-copy` on Wayland, `xclip` on X11, OSC 52 fallback). Installs `wl-clipboard` automatically on Linux/WSL when no clipboard tool is found. Includes [TPM](https://github.com/tmux-plugins/tpm), [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) + [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) for automatic session save/restore — TPM plugins are installed non-interactively during init/upgrade. Claude Code popup on `C-a y`.
 
 </details>
 
@@ -277,7 +277,7 @@ Generates an `ed25519` SSH key for GitHub, configures `~/.ssh/config`, tests the
 <details>
 <summary><b>Shell</b> — aliases + login banner</summary>
 
-Appends aliases to `.zshrc` (`ll`, `..`, `ports`, `dps`, `t` for tmux, `bcat` → `bat`, etc.) and a `tmx` command for session management. The login banner shows live tmux sessions and named channel sessions:
+Appends aliases to `.zshrc` and a `tmx` command for session management. Aliases are platform-aware: `ll`, `ports`, and `update` expand differently on macOS (`ls -G`, `lsof`, `brew`) vs Linux/WSL (`ls --color`, `ss`, `apt`). The `BROWSER` env var is set to `open` on macOS and `wslview` on WSL. The login banner shows live tmux sessions and named channel sessions:
 
 ```
 ╭─ myhost ──────────────────────────────────────╮

--- a/devlair/modules/shell.py
+++ b/devlair/modules/shell.py
@@ -7,12 +7,18 @@ LABEL = "Shell aliases"
 
 ZSHRC_ALIASES = """
 # ── devlair aliases ───────────────────────────────────────────────────────────
-alias ll='ls -lah --color=auto'
+if [[ "$(uname)" == "Darwin" ]]; then
+  alias ll='ls -lah -G'
+  alias ports='sudo lsof -i -P | grep LISTEN'
+  alias update='brew update && brew upgrade'
+else
+  alias ll='ls -lah --color=auto'
+  alias ports='sudo ss -tulnp'
+  alias update='sudo apt update && sudo apt upgrade -y'
+fi
 alias ..='cd ..'
 alias ...='cd ../..'
-alias ports='sudo ss -tulnp'
 alias dps='docker ps --format "table {{.Names}}\\t{{.Status}}\\t{{.Ports}}"'
-alias update='sudo apt update && sudo apt upgrade -y'
 alias ts='tailscale status'
 alias t='tmux new-session -A -s dev'
 alias bcat='bat --paging=never'
@@ -44,10 +50,11 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 # ── fzf ───────────────────────────────────────────────────────────────────────
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
-# ── WSL browser ──────────────────────────────────────────────────────────────
-# Redirect xdg-open / BROWSER to the Windows default browser via wslview
+# ── Browser ───────────────────────────────────────────────────────────────────
 if [ -n "$WSL_DISTRO_NAME" ] && command -v wslview &>/dev/null; then
   export BROWSER=wslview
+elif [[ "$(uname)" == "Darwin" ]]; then
+  export BROWSER=open
 fi
 
 # ── Claude Code ───────────────────────────────────────────────────────────────
@@ -64,7 +71,11 @@ if [ -t 0 ]; then
   _dl_host=${HOST:-$(hostname)}
   _dl_ip=$(tailscale ip -4 2>/dev/null || echo "TS off")
   _dl_disk=$(df -h / | awk 'NR==2{print $3"/"$2}')
-  _dl_mem=$(free -h | awk 'NR==2{gsub(/i/,"",$3); gsub(/i/,"",$2); print $3"/"$2}')
+  if [[ "$(uname)" == "Darwin" ]]; then
+    _dl_mem="$(( $(sysctl -n hw.memsize) / 1073741824 ))G"
+  else
+    _dl_mem=$(free -h | awk 'NR==2{gsub(/i/,"",$3); gsub(/i/,"",$2); print $3"/"$2}')
+  fi
   _dl_dashes=${(l:_dl_IW::─:)}
 
   # row helper — prints │ content padded to inner width │
@@ -110,8 +121,8 @@ if [ -t 0 ]; then
     _dl_row "  no sessions — type 't' to start"
   fi
 
-  # synced drives
-  _dl_svcs=(~/.config/systemd/user/rclone-*.service(N))
+  # synced drives (systemd-based; not applicable on macOS)
+  [[ "$(uname)" == "Darwin" ]] && _dl_svcs=() || _dl_svcs=(~/.config/systemd/user/rclone-*.service(N))
   if [ ${#_dl_svcs[@]} -gt 0 ]; then
     _dl_row ""
     _dl_row "  syncs:"
@@ -200,6 +211,7 @@ def _clean_zshrc(text: str) -> str:
 
 def run(ctx: SetupContext) -> ModuleResult:
     zshrc = ctx.user_home / ".zshrc"
+    group = None if ctx.platform == "macos" else ctx.username
 
     existing = zshrc.read_text() if zshrc.exists() else ""
 
@@ -208,13 +220,13 @@ def run(ctx: SetupContext) -> ModuleResult:
         header = existing[: existing.index(MARKER)]
         header = _clean_zshrc(header)
         zshrc.write_text(header + ZSHRC_ALIASES.lstrip("\n"))
-        shutil.chown(zshrc, ctx.username, ctx.username)
+        shutil.chown(zshrc, ctx.username, group)
         return ModuleResult(status="ok", detail="aliases refreshed in .zshrc")
 
     # Clean any junk before appending
     cleaned = _clean_zshrc(existing)
     zshrc.write_text(cleaned + ZSHRC_ALIASES)
-    shutil.chown(zshrc, ctx.username, ctx.username)
+    shutil.chown(zshrc, ctx.username, group)
 
     return ModuleResult(status="ok", detail="aliases added to .zshrc")
 

--- a/devlair/modules/tmux.py
+++ b/devlair/modules/tmux.py
@@ -107,9 +107,11 @@ run '~/.tmux/plugins/tpm/tpm'
 
 
 def run(ctx: SetupContext) -> ModuleResult:
+    group = None if ctx.platform == "macos" else ctx.username
+
     conf = ctx.user_home / ".tmux.conf"
     conf.write_text(TMUX_CONF)
-    shutil.chown(conf, ctx.username, ctx.username)
+    shutil.chown(conf, ctx.username, group)
 
     # Clipboard helper: macOS has pbcopy built-in; Linux/WSL may need wl-clipboard
     if ctx.platform != "macos" and not runner.cmd_exists("wl-copy") and not runner.cmd_exists("xclip"):
@@ -117,8 +119,8 @@ def run(ctx: SetupContext) -> ModuleResult:
 
     plugins_dir = ctx.user_home / ".tmux" / "plugins"
     plugins_dir.mkdir(parents=True, exist_ok=True)
-    shutil.chown(plugins_dir, ctx.username, ctx.username)
-    shutil.chown(plugins_dir.parent, ctx.username, ctx.username)
+    shutil.chown(plugins_dir, ctx.username, group)
+    shutil.chown(plugins_dir.parent, ctx.username, group)
 
     tpm_path = plugins_dir / "tpm"
     if not tpm_path.exists():

--- a/devlair/modules/tmux.py
+++ b/devlair/modules/tmux.py
@@ -37,8 +37,8 @@ bind r source-file ~/.tmux.conf \\; display "Reloaded"
 set -g mode-keys vi
 set -g set-clipboard on
 
-# Clipboard command: wl-copy (Wayland) > xclip (X11) > cat /dev/null (OSC 52 only)
-CLIP_CMD='command -v wl-copy >/dev/null && wl-copy || { command -v xclip >/dev/null && xclip -selection clipboard || cat >/dev/null; }'
+# Clipboard command: pbcopy (macOS) > wl-copy (Wayland) > xclip (X11) > cat /dev/null (OSC 52 only)
+CLIP_CMD='command -v pbcopy >/dev/null && pbcopy || { command -v wl-copy >/dev/null && wl-copy || { command -v xclip >/dev/null && xclip -selection clipboard || cat >/dev/null; }; }'
 
 # v begins selection, C-v toggles rectangle, y yanks to system clipboard
 bind -T copy-mode-vi v     send-keys -X begin-selection
@@ -111,8 +111,8 @@ def run(ctx: SetupContext) -> ModuleResult:
     conf.write_text(TMUX_CONF)
     shutil.chown(conf, ctx.username, ctx.username)
 
-    # Clipboard helper for Wayland/X11 copy support inside tmux
-    if not runner.cmd_exists("wl-copy") and not runner.cmd_exists("xclip"):
+    # Clipboard helper: macOS has pbcopy built-in; Linux/WSL may need wl-clipboard
+    if ctx.platform != "macos" and not runner.cmd_exists("wl-copy") and not runner.cmd_exists("xclip"):
         runner.apt_install("wl-clipboard", quiet=True)
 
     plugins_dir = ctx.user_home / ".tmux" / "plugins"
@@ -142,7 +142,7 @@ def check() -> list[CheckItem]:
     plugins_dir = Path("~/.tmux/plugins").expanduser()
     continuum_ok = (plugins_dir / "tmux-continuum").exists()
     resurrect_ok = (plugins_dir / "tmux-resurrect").exists()
-    clip_ok = runner.cmd_exists("wl-copy") or runner.cmd_exists("xclip")
+    clip_ok = runner.cmd_exists("pbcopy") or runner.cmd_exists("wl-copy") or runner.cmd_exists("xclip")
     return [
         CheckItem(label="tmux installed", status="ok" if tmux_ok else "fail"),
         CheckItem(
@@ -155,7 +155,7 @@ def check() -> list[CheckItem]:
             status="ok" if resurrect_ok and continuum_ok else "warn",
         ),
         CheckItem(
-            label="Clipboard tool (wl-copy / xclip)",
+            label="Clipboard tool (pbcopy / wl-copy / xclip)",
             status="ok" if clip_ok else "warn",
         ),
     ]

--- a/devlair/modules/zsh.py
+++ b/devlair/modules/zsh.py
@@ -1,3 +1,4 @@
+import pwd as _pwd
 import shutil
 from pathlib import Path
 
@@ -49,14 +50,17 @@ source "$ZIM_HOME/init.zsh"
 
 
 def run(ctx: SetupContext) -> ModuleResult:
-    # Install zsh if missing
+    # Install zsh if missing (pre-installed on macOS; apt on Linux/WSL)
     if not runner.cmd_exists("zsh"):
-        runner.apt_install("zsh", quiet=True)
+        if ctx.platform == "macos":
+            runner.brew_install("zsh", quiet=True)
+        else:
+            runner.apt_install("zsh", quiet=True)
 
     zsh_bin = runner.get_output("which zsh")
 
-    # Set as default shell for the user
-    current_shell = runner.get_output(f"getent passwd {ctx.username} | cut -d: -f7")
+    # Set as default shell for the user (pwd module is portable; getent is Linux-only)
+    current_shell = _pwd.getpwnam(ctx.username).pw_shell
     if current_shell != zsh_bin:
         runner.run(["chsh", "-s", zsh_bin, ctx.username])
 
@@ -64,20 +68,23 @@ def run(ctx: SetupContext) -> ModuleResult:
     zimrc = ctx.user_home / ".zimrc"
     zshrc = ctx.user_home / ".zshrc"
 
+    # On macOS primary groups don't match the username (typically "staff")
+    group = None if ctx.platform == "macos" else ctx.username
+
     # Write .zimrc
     zimrc.write_text(ZIMRC)
-    shutil.chown(zimrc, ctx.username, ctx.username)
+    shutil.chown(zimrc, ctx.username, group)
 
     # Prevent system /etc/zsh/zshrc from calling compinit before zimfw
     zshenv = ctx.user_home / ".zshenv"
     if not zshenv.exists() or "skip_global_compinit" not in zshenv.read_text():
         zshenv.write_text(ZSHENV)
-        shutil.chown(zshenv, ctx.username, ctx.username)
+        shutil.chown(zshenv, ctx.username, group)
 
     # Write .zshrc header (only if not already managed by devlair)
     if not zshrc.exists() or "devlair" not in zshrc.read_text():
         zshrc.write_text(ZSHRC_HEADER)
-        shutil.chown(zshrc, ctx.username, ctx.username)
+        shutil.chown(zshrc, ctx.username, group)
 
     # Bootstrap zimfw and install modules as the user
     runner.run_shell_as(
@@ -93,7 +100,7 @@ def run(ctx: SetupContext) -> ModuleResult:
         quiet=True,
     )
 
-    shutil.chown(zim_home, ctx.username, ctx.username)
+    shutil.chown(zim_home, ctx.username, group)
 
     return ModuleResult(status="ok", detail="zsh with Dracula via zimfw")
 

--- a/tests/unit/test_tmux.py
+++ b/tests/unit/test_tmux.py
@@ -135,4 +135,4 @@ def test_check_reports_tpm_plugins_and_clipboard(mocker, tmp_path):
     items = tmux.check()
     labels = [i.label for i in items]
     assert "TPM plugins (resurrect + continuum)" in labels
-    assert "Clipboard tool (wl-copy / xclip)" in labels
+    assert "Clipboard tool (pbcopy / wl-copy / xclip)" in labels


### PR DESCRIPTION
## Summary

- **zsh**: replace `getent passwd` (Linux-only) with Python `pwd` module for portable shell detection; use `brew_install` instead of `apt_install` on macOS; pass `group=None` to `shutil.chown` on macOS (primary group is `staff`, not the username)
- **shell**: add macOS-variant aliases (`ls -G`, `lsof`, `brew update/upgrade`); add `BROWSER=open` branch for macOS; use `sysctl hw.memsize` for memory reporting instead of `free`; skip systemd-based rclone service glob on macOS
- **tmux**: extend `CLIP_CMD` in generated `~/.tmux.conf` to probe `pbcopy` before `wl-copy`/`xclip`; skip `wl-clipboard` apt install on macOS; add `pbcopy` to `check()` health check label

Part of the macOS dev environment epic — this is **PR 1b** (portable modules) after PR 1a (foundation: brew helper + MODULE_SPECS platform flags).

Closes #158

## Test plan

- [x] All 150 unit tests pass (`uv run pytest tests/unit/`)
- [x] `ruff check devlair/ tests/` — no lint errors
- [x] On Linux/WSL: aliases block uses `ll='ls -lah --color=auto'`, `ports='sudo ss -tulnp'`, `update='sudo apt...'` — no regression
- [x] On macOS: aliases block uses `ls -G`, `lsof`, `brew` variants
- [x] `tmux check()` label reads `Clipboard tool (pbcopy / wl-copy / xclip)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
