### PR TITLE
feat(macos): add macOS branches to devtools module

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 
 ## What gets installed
 
-`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`. Linux-only modules (auto-skipped elsewhere): `timezone`, `ssh`, `firewall`, `gnome_terminal`.
+`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. Linux-only modules (auto-skipped elsewhere): `timezone`, `ssh`, `firewall`, `gnome_terminal`.
 
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
@@ -263,6 +263,8 @@ Installs (skipping any that already exist):
 | [gh](https://cli.github.com/) | GitHub CLI |
 | [aws](https://aws.amazon.com/cli/) | AWS CLI v2 |
 | [Bun](https://bun.sh/) | JavaScript runtime (required for Claude Code channels) |
+
+On macOS, `pyenv`, `gh`, and `aws` are installed via `brew` instead of apt/curl. Build dependencies for pyenv (openssl, readline, sqlite3, xz, zlib) are also installed via brew. Docker is not installed on macOS — the module prints guidance to install Docker Desktop for Mac and continues without error.
 
 </details>
 

--- a/devlair/modules/devtools.py
+++ b/devlair/modules/devtools.py
@@ -153,71 +153,71 @@ def run(ctx: SetupContext) -> ModuleResult:
     # ── GitHub CLI ────────────────────────────────────────────────────────────
     if runner.cmd_exists("gh"):
         skipped.append("gh")
-    elif ctx.platform == "macos":
-        console.print("    [muted]gh...[/muted]")
-        runner.brew_install("gh", quiet=True)
-        safe_log_install(ctx.user_home, tool="gh", source="brew:cli.github.com", verified=True)
-        installed.append("gh")
     else:
         console.print("    [muted]gh...[/muted]")
-        runner.run_shell(
-            """
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-                | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
-                https://cli.github.com/packages stable main" \
-                | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            apt-get update -qq
-            apt-get install -y -qq gh
-        """,
-            quiet=True,
-        )
-        safe_log_install(ctx.user_home, tool="gh", source="apt:cli.github.com", verified=True)
+        if ctx.platform == "macos":
+            runner.brew_install("gh", quiet=True)
+            safe_log_install(ctx.user_home, tool="gh", source="brew:cli.github.com", verified=True)
+        else:
+            runner.run_shell(
+                """
+                curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+                    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+                chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+                echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+                    https://cli.github.com/packages stable main" \
+                    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+                apt-get update -qq
+                apt-get install -y -qq gh
+            """,
+                quiet=True,
+            )
+            safe_log_install(ctx.user_home, tool="gh", source="apt:cli.github.com", verified=True)
         installed.append("gh")
 
     # ── AWS CLI v2 (with GPG signature verification) ────────────────────────
     if runner.cmd_exists("aws"):
         skipped.append("aws")
-    elif ctx.platform == "macos":
-        console.print("    [muted]aws cli...[/muted]")
-        runner.brew_install("awscli", quiet=True)
-        safe_log_install(ctx.user_home, tool="aws", source="brew:awscli", verified=True)
-        installed.append("aws")
     else:
         console.print("    [muted]aws cli...[/muted]")
-        raw_arch = runner.get_output("uname -m")
-        aws_arch = "aarch64" if raw_arch == "aarch64" else "x86_64"
-        aws_base = f"https://awscli.amazonaws.com/awscli-exe-linux-{aws_arch}"
-        gpg_ok_marker = runner.safe_tempfile(suffix=".gpg_ok")
-        gpg_ok_marker.unlink()  # remove so touch is the signal
-        runner.run_shell(
-            f"""
-            curl -fsSL "{aws_base}.zip" -o /tmp/awscliv2.zip
-            if command -v gpg >/dev/null 2>&1; then
-                curl -fsSL "{aws_base}.zip.sig" -o /tmp/awscliv2.zip.sig
-                curl -fsSL "{_AWS_CLI_GPG_KEY_URL}" -o /tmp/aws-cli-key.asc
-                gpg --batch --import /tmp/aws-cli-key.asc 2>/dev/null || true
-                if gpg --batch --verify /tmp/awscliv2.zip.sig /tmp/awscliv2.zip 2>/dev/null; then
-                    echo "✓ AWS CLI GPG signature verified"
-                    touch "{gpg_ok_marker}"
+        if ctx.platform == "macos":
+            runner.brew_install("awscli", quiet=True)
+            safe_log_install(ctx.user_home, tool="aws", source="brew:awscli", verified=True)
+            installed.append("aws")
+        else:
+            raw_arch = runner.get_output("uname -m")
+            aws_arch = "aarch64" if raw_arch == "aarch64" else "x86_64"
+            assert aws_arch in ("aarch64", "x86_64"), f"Unexpected arch: {aws_arch}"
+            aws_base = f"https://awscli.amazonaws.com/awscli-exe-linux-{aws_arch}"
+            gpg_ok_marker = runner.safe_tempfile(suffix=".gpg_ok")
+            gpg_ok_marker.unlink()  # remove so touch is the signal
+            runner.run_shell(
+                f"""
+                curl -fsSL "{aws_base}.zip" -o /tmp/awscliv2.zip
+                if command -v gpg >/dev/null 2>&1; then
+                    curl -fsSL "{aws_base}.zip.sig" -o /tmp/awscliv2.zip.sig
+                    curl -fsSL "{_AWS_CLI_GPG_KEY_URL}" -o /tmp/aws-cli-key.asc
+                    gpg --batch --import /tmp/aws-cli-key.asc 2>/dev/null || true
+                    if gpg --batch --verify /tmp/awscliv2.zip.sig /tmp/awscliv2.zip 2>/dev/null; then
+                        echo "✓ AWS CLI GPG signature verified"
+                        touch "{gpg_ok_marker}"
+                    else
+                        echo "⚠ GPG verification failed — installing anyway" >&2
+                    fi
+                    rm -f /tmp/awscliv2.zip.sig /tmp/aws-cli-key.asc
                 else
-                    echo "⚠ GPG verification failed — installing anyway" >&2
+                    echo "⚠ gpg not found — skipping signature verification"
                 fi
-                rm -f /tmp/awscliv2.zip.sig /tmp/aws-cli-key.asc
-            else
-                echo "⚠ gpg not found — skipping signature verification"
-            fi
-            unzip -qo /tmp/awscliv2.zip -d /tmp
-            /tmp/aws/install
-            rm -rf /tmp/awscliv2.zip /tmp/aws
-        """,
-            quiet=True,
-        )
-        gpg_verified = gpg_ok_marker.exists()
-        gpg_ok_marker.unlink(missing_ok=True)
-        safe_log_install(ctx.user_home, tool="aws", source="awscli.amazonaws.com", verified=gpg_verified)
-        installed.append("aws")
+                unzip -qo /tmp/awscliv2.zip -d /tmp
+                /tmp/aws/install
+                rm -rf /tmp/awscliv2.zip /tmp/aws
+            """,
+                quiet=True,
+            )
+            gpg_verified = gpg_ok_marker.exists()
+            gpg_ok_marker.unlink(missing_ok=True)
+            safe_log_install(ctx.user_home, tool="aws", source="awscli.amazonaws.com", verified=gpg_verified)
+            installed.append("aws")
 
     # ── Bun ───────────────────────────────────────────────────────────────────
     if _bun_exists(ctx.user_home):

--- a/devlair/modules/devtools.py
+++ b/devlair/modules/devtools.py
@@ -41,20 +41,23 @@ def run(ctx: SetupContext) -> ModuleResult:
         skipped.append("pyenv")
     else:
         console.print("    [muted]pyenv...[/muted]")
-        runner.apt_install(
-            "libssl-dev",
-            "libbz2-dev",
-            "libreadline-dev",
-            "libsqlite3-dev",
-            "libncursesw5-dev",
-            "xz-utils",
-            "tk-dev",
-            "libxml2-dev",
-            "libxmlsec1-dev",
-            "libffi-dev",
-            "liblzma-dev",
-            quiet=True,
-        )
+        if ctx.platform == "macos":
+            runner.brew_install("openssl", "readline", "sqlite3", "xz", "zlib", quiet=True)
+        else:
+            runner.apt_install(
+                "libssl-dev",
+                "libbz2-dev",
+                "libreadline-dev",
+                "libsqlite3-dev",
+                "libncursesw5-dev",
+                "xz-utils",
+                "tk-dev",
+                "libxml2-dev",
+                "libxmlsec1-dev",
+                "libffi-dev",
+                "liblzma-dev",
+                quiet=True,
+            )
         script = runner.download_script("https://pyenv.run")
         try:
             runner.run_shell_as(ctx.username, f'bash "{script}"', quiet=True)
@@ -114,8 +117,12 @@ def run(ctx: SetupContext) -> ModuleResult:
     # ── Docker ────────────────────────────────────────────────────────────────
     if runner.cmd_exists("docker"):
         skipped.append("docker")
-    elif ctx.platform == "wsl":
-        console.print("    [warning]docker — install Docker Desktop on Windows, not inside WSL[/warning]")
+    elif ctx.platform in ("wsl", "macos"):
+        console.print(
+            "    [warning]docker — install Docker Desktop"
+            + (" on Windows, not inside WSL" if ctx.platform == "wsl" else " for Mac")
+            + "[/warning]"
+        )
         skipped.append("docker")
     else:
         console.print("    [muted]docker...[/muted]")
@@ -146,6 +153,11 @@ def run(ctx: SetupContext) -> ModuleResult:
     # ── GitHub CLI ────────────────────────────────────────────────────────────
     if runner.cmd_exists("gh"):
         skipped.append("gh")
+    elif ctx.platform == "macos":
+        console.print("    [muted]gh...[/muted]")
+        runner.brew_install("gh", quiet=True)
+        safe_log_install(ctx.user_home, tool="gh", source="brew:cli.github.com", verified=True)
+        installed.append("gh")
     else:
         console.print("    [muted]gh...[/muted]")
         runner.run_shell(
@@ -167,10 +179,15 @@ def run(ctx: SetupContext) -> ModuleResult:
     # ── AWS CLI v2 (with GPG signature verification) ────────────────────────
     if runner.cmd_exists("aws"):
         skipped.append("aws")
+    elif ctx.platform == "macos":
+        console.print("    [muted]aws cli...[/muted]")
+        runner.brew_install("awscli", quiet=True)
+        safe_log_install(ctx.user_home, tool="aws", source="brew:awscli", verified=True)
+        installed.append("aws")
     else:
         console.print("    [muted]aws cli...[/muted]")
-        arch = runner.get_output("dpkg --print-architecture")
-        aws_arch = "x86_64" if arch == "amd64" else "aarch64"
+        raw_arch = runner.get_output("uname -m")
+        aws_arch = "aarch64" if raw_arch == "aarch64" else "x86_64"
         aws_base = f"https://awscli.amazonaws.com/awscli-exe-linux-{aws_arch}"
         gpg_ok_marker = runner.safe_tempfile(suffix=".gpg_ok")
         gpg_ok_marker.unlink()  # remove so touch is the signal

--- a/tests/unit/test_devtools.py
+++ b/tests/unit/test_devtools.py
@@ -24,7 +24,10 @@ def mock_runner(mocker):
     mocker.patch("devlair.modules.devtools.runner.run")
     mocker.patch("devlair.modules.devtools.runner.get_output", return_value="")
     mocker.patch("devlair.modules.devtools.runner.download_script", return_value=MagicMock(unlink=lambda **kw: None))
-    mocker.patch("devlair.modules.devtools.runner.safe_tempfile", return_value=MagicMock(exists=lambda: False, unlink=lambda **kw: None))
+    mocker.patch(
+        "devlair.modules.devtools.runner.safe_tempfile",
+        return_value=MagicMock(exists=lambda: False, unlink=lambda **kw: None),
+    )
     mocker.patch("devlair.modules.devtools.safe_log_install")
     mocker.patch("devlair.modules.devtools.console.print")
     return mocker
@@ -55,25 +58,13 @@ def test_pyenv_uses_apt_on_linux(mock_runner, tmp_path):
     brew_install.assert_not_called()
 
 
-def test_docker_skipped_on_macos(mock_runner, tmp_path):
+@pytest.mark.parametrize("platform", ["macos", "wsl"])
+def test_docker_skipped(mock_runner, tmp_path, platform):
     mock_runner.patch(
         "devlair.modules.devtools.runner.cmd_exists",
         side_effect=lambda cmd: cmd != "docker",
     )
-    ctx = _ctx("macos", tmp_path)
-
-    result = devtools.run(ctx)
-
-    assert "docker" in result.detail
-    assert "skipped" in result.detail
-
-
-def test_docker_skipped_on_wsl(mock_runner, tmp_path):
-    mock_runner.patch(
-        "devlair.modules.devtools.runner.cmd_exists",
-        side_effect=lambda cmd: cmd != "docker",
-    )
-    ctx = _ctx("wsl", tmp_path)
+    ctx = _ctx(platform, tmp_path)
 
     result = devtools.run(ctx)
 

--- a/tests/unit/test_devtools.py
+++ b/tests/unit/test_devtools.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from devlair.context import SetupContext
+from devlair.modules import devtools
+
+
+def _ctx(platform: str, tmp_path) -> SetupContext:
+    ctx = MagicMock(spec=SetupContext)
+    ctx.platform = platform
+    ctx.username = "testuser"
+    ctx.user_home = tmp_path
+    return ctx
+
+
+@pytest.fixture()
+def mock_runner(mocker):
+    mocker.patch("devlair.modules.devtools.runner.cmd_exists", return_value=True)
+    mocker.patch("devlair.modules.devtools.runner.brew_install")
+    mocker.patch("devlair.modules.devtools.runner.apt_install")
+    mocker.patch("devlair.modules.devtools.runner.run_shell_as")
+    mocker.patch("devlair.modules.devtools.runner.run_shell")
+    mocker.patch("devlair.modules.devtools.runner.run")
+    mocker.patch("devlair.modules.devtools.runner.get_output", return_value="")
+    mocker.patch("devlair.modules.devtools.runner.download_script", return_value=MagicMock(unlink=lambda **kw: None))
+    mocker.patch("devlair.modules.devtools.runner.safe_tempfile", return_value=MagicMock(exists=lambda: False, unlink=lambda **kw: None))
+    mocker.patch("devlair.modules.devtools.safe_log_install")
+    mocker.patch("devlair.modules.devtools.console.print")
+    return mocker
+
+
+def test_pyenv_uses_brew_on_macos(mock_runner, tmp_path):
+    mock_runner.patch("devlair.modules.devtools.runner.cmd_exists", return_value=False)
+    brew_install = mock_runner.patch("devlair.modules.devtools.runner.brew_install")
+    apt_install = mock_runner.patch("devlair.modules.devtools.runner.apt_install")
+    # pyenv dir does not exist → will try to install
+    ctx = _ctx("macos", tmp_path)
+
+    devtools.run(ctx)
+
+    brew_install.assert_any_call("openssl", "readline", "sqlite3", "xz", "zlib", quiet=True)
+    apt_install.assert_not_called()
+
+
+def test_pyenv_uses_apt_on_linux(mock_runner, tmp_path):
+    mock_runner.patch("devlair.modules.devtools.runner.cmd_exists", return_value=False)
+    brew_install = mock_runner.patch("devlair.modules.devtools.runner.brew_install")
+    apt_install = mock_runner.patch("devlair.modules.devtools.runner.apt_install")
+    ctx = _ctx("linux", tmp_path)
+
+    devtools.run(ctx)
+
+    apt_install.assert_called_once()
+    brew_install.assert_not_called()
+
+
+def test_docker_skipped_on_macos(mock_runner, tmp_path):
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.cmd_exists",
+        side_effect=lambda cmd: cmd != "docker",
+    )
+    ctx = _ctx("macos", tmp_path)
+
+    result = devtools.run(ctx)
+
+    assert "docker" in result.detail
+    assert "skipped" in result.detail
+
+
+def test_docker_skipped_on_wsl(mock_runner, tmp_path):
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.cmd_exists",
+        side_effect=lambda cmd: cmd != "docker",
+    )
+    ctx = _ctx("wsl", tmp_path)
+
+    result = devtools.run(ctx)
+
+    assert "docker" in result.detail
+    assert "skipped" in result.detail
+
+
+def test_gh_uses_brew_on_macos(mock_runner, tmp_path):
+    brew_install = mock_runner.patch("devlair.modules.devtools.runner.brew_install")
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.cmd_exists",
+        side_effect=lambda cmd: cmd != "gh",
+    )
+    ctx = _ctx("macos", tmp_path)
+
+    devtools.run(ctx)
+
+    brew_install.assert_any_call("gh", quiet=True)
+
+
+def test_aws_uses_brew_on_macos(mock_runner, tmp_path):
+    brew_install = mock_runner.patch("devlair.modules.devtools.runner.brew_install")
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.cmd_exists",
+        side_effect=lambda cmd: cmd != "aws",
+    )
+    ctx = _ctx("macos", tmp_path)
+
+    devtools.run(ctx)
+
+    brew_install.assert_any_call("awscli", quiet=True)
+
+
+def test_aws_uses_uname_arch_on_linux(mock_runner, tmp_path):
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.get_output",
+        side_effect=lambda cmd: "aarch64" if "uname" in cmd else "",
+    )
+    run_shell = mock_runner.patch("devlair.modules.devtools.runner.run_shell")
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.cmd_exists",
+        side_effect=lambda cmd: cmd != "aws",
+    )
+    ctx = _ctx("linux", tmp_path)
+
+    devtools.run(ctx)
+
+    shell_calls = " ".join(str(c) for c in run_shell.call_args_list)
+    assert "aarch64" in shell_calls
+    assert "dpkg" not in shell_calls
+
+
+def test_aws_x86_fallback_on_linux(mock_runner, tmp_path):
+    mock_runner.patch("devlair.modules.devtools.runner.get_output", return_value="x86_64")
+    run_shell = mock_runner.patch("devlair.modules.devtools.runner.run_shell")
+    mock_runner.patch(
+        "devlair.modules.devtools.runner.cmd_exists",
+        side_effect=lambda cmd: cmd != "aws",
+    )
+    ctx = _ctx("linux", tmp_path)
+
+    devtools.run(ctx)
+
+    shell_calls = " ".join(str(c) for c in run_shell.call_args_list)
+    assert "x86_64" in shell_calls


### PR DESCRIPTION
## Summary

- **pyenv**: use `brew_install("openssl", "readline", "sqlite3", "xz", "zlib")` on macOS instead of the Linux apt build-dep list
- **docker**: skip on macOS with "install Docker Desktop for Mac" message, matching the existing WSL skip pattern
- **gh**: use `brew_install("gh")` on macOS instead of the apt keyring-based install
- **aws**: use `brew_install("awscli")` on macOS; on Linux replace `dpkg --print-architecture` with `uname -m` (`x86_64`/`aarch64` map directly — no translation needed)

This is **PR 1c** (devtools macOS branches), completing the macOS coding-group epic. PR 1a (foundation) and PR 1b (portable modules: zsh, shell, tmux) are already merged.

Adds `tests/unit/test_devtools.py` with 8 tests covering all four macOS branches and Linux regressions.

Closes #158

## Test plan

- [x] All 158 unit tests pass (`uv run pytest tests/unit/`)
- [x] `ruff check devlair/ tests/` — no lint errors
- [x] On macOS: pyenv install calls `brew_install("openssl", "readline", "sqlite3", "xz", "zlib")`, not `apt_install`
- [x] On macOS: docker block prints "install Docker Desktop for Mac" and skips
- [x] On macOS: gh install calls `brew_install("gh")`
- [x] On macOS: aws install calls `brew_install("awscli")`
- [x] On Linux (aarch64): aws install URL contains `aarch64`; no `dpkg` call
- [x] On Linux (x86_64): aws install URL contains `x86_64`; no `dpkg` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
