### PR TITLE
fix(system): guard systemd-only packages behind linux platform check

### DIFF
--- a/devlair/modules/system.py
+++ b/devlair/modules/system.py
@@ -56,8 +56,8 @@ def check() -> list[CheckItem]:
     return [
         CheckItem(
             label=label,
-            status="ok" if runner.cmd_exists(cmd) else "fail",
-            detail="installed" if runner.cmd_exists(cmd) else "missing",
+            status="ok" if (exists := runner.cmd_exists(cmd)) else "fail",
+            detail="installed" if exists else "missing",
         )
         for label, cmd in checks
     ]

--- a/devlair/modules/system.py
+++ b/devlair/modules/system.py
@@ -1,12 +1,9 @@
 from devlair import runner
-from devlair.context import CheckItem, ModuleResult, SetupContext
+from devlair.context import CheckItem, ModuleResult, SetupContext, detect_platform
 
 LABEL = "System update"
 
 ESSENTIALS = [
-    "openssh-server",
-    "ufw",
-    "fail2ban",
     "curl",
     "wget",
     "git",
@@ -15,7 +12,6 @@ ESSENTIALS = [
     "tmux",
     "unzip",
     "net-tools",
-    "avahi-daemon",
     "build-essential",
     "ca-certificates",
     "gnupg",
@@ -28,11 +24,16 @@ ESSENTIALS = [
     "locales",
 ]
 
+# ssh, firewall, and service-discovery daemons require systemd — unavailable on WSL
+LINUX_ESSENTIALS = ["openssh-server", "ufw", "fail2ban", "avahi-daemon"]
+
 
 def run(ctx: SetupContext) -> ModuleResult:
     runner.run("apt-get update -qq", capture=True)
     runner.run("apt-get upgrade -y -qq", capture=True)
     runner.apt_install(*ESSENTIALS, quiet=True)
+    if ctx.platform == "linux":
+        runner.apt_install(*LINUX_ESSENTIALS, quiet=True)
 
     # WSL extras: wslu provides wslview for opening URLs in the Windows browser
     if ctx.platform == "wsl":
@@ -48,21 +49,15 @@ def run(ctx: SetupContext) -> ModuleResult:
 
 
 def check() -> list[CheckItem]:
-    items = []
-    for label, cmd in [
-        ("git", "git"),
-        ("curl", "curl"),
-        ("tmux", "tmux"),
-        ("zsh", "zsh"),
-        ("ufw", "ufw"),
-        ("fail2ban", "fail2ban-client"),
-    ]:
-        ok = runner.cmd_exists(cmd)
-        items.append(
-            CheckItem(
-                label=label,
-                status="ok" if ok else "fail",
-                detail="installed" if ok else "missing",
-            )
+    checks = [("git", "git"), ("curl", "curl"), ("tmux", "tmux"), ("zsh", "zsh")]
+    if detect_platform() == "linux":
+        checks += [("ufw", "ufw"), ("fail2ban", "fail2ban-client")]
+
+    return [
+        CheckItem(
+            label=label,
+            status="ok" if runner.cmd_exists(cmd) else "fail",
+            detail="installed" if runner.cmd_exists(cmd) else "missing",
         )
-    return items
+        for label, cmd in checks
+    ]

--- a/tests/unit/test_system.py
+++ b/tests/unit/test_system.py
@@ -18,15 +18,26 @@ def test_run_calls_apt_upgrade(ctx: SetupContext, mock_runner):
     assert any("upgrade" in c for c in run_calls)
 
 
-def test_run_installs_essentials(ctx: SetupContext, mock_runner):
+def test_run_installs_essentials_on_linux(ctx: SetupContext, mock_runner):
+    ctx.platform = "linux"
     system.run(ctx)
 
-    apt_calls = mock_runner["apt_install"].call_args_list
-    assert len(apt_calls) == 1
+    all_installed = [pkg for call in mock_runner["apt_install"].call_args_list for pkg in call.args]
+    for pkg in ["git", "curl", "tmux", "zsh"]:
+        assert pkg in all_installed
+    for pkg in ["openssh-server", "ufw", "fail2ban", "avahi-daemon"]:
+        assert pkg in all_installed
 
-    installed = apt_calls[0].args  # positional *packages
-    for pkg in ["git", "curl", "tmux", "zsh", "ufw", "fail2ban"]:
-        assert pkg in installed, f"Expected '{pkg}' in apt_install call"
+
+def test_run_skips_linux_essentials_on_wsl(ctx: SetupContext, mock_runner):
+    ctx.platform = "wsl"
+    system.run(ctx)
+
+    all_installed = [pkg for call in mock_runner["apt_install"].call_args_list for pkg in call.args]
+    for pkg in ["git", "curl", "tmux", "zsh"]:
+        assert pkg in all_installed
+    for pkg in ["openssh-server", "ufw", "fail2ban", "avahi-daemon"]:
+        assert pkg not in all_installed, f"'{pkg}' should not be installed on WSL"
 
 
 def test_run_returns_ok(ctx: SetupContext, mock_runner):
@@ -41,13 +52,27 @@ def test_idempotent(ctx: SetupContext, mock_runner):
     assert result2.status == "ok"
 
 
-def test_check_installed(mocker):
+def test_check_installed_on_linux(mocker):
     mocker.patch("devlair.runner.cmd_exists", return_value=True)
+    mocker.patch("devlair.modules.system.detect_platform", return_value="linux")
     items = system.check()
+    labels = [i.label for i in items]
     assert all(i.status == "ok" for i in items)
+    assert "ufw" in labels
+    assert "fail2ban" in labels
 
 
-def test_check_missing(mocker):
+def test_check_missing_on_linux(mocker):
     mocker.patch("devlair.runner.cmd_exists", return_value=False)
+    mocker.patch("devlair.modules.system.detect_platform", return_value="linux")
     items = system.check()
     assert all(i.status == "fail" for i in items)
+
+
+def test_check_excludes_linux_tools_on_wsl(mocker):
+    mocker.patch("devlair.runner.cmd_exists", return_value=True)
+    mocker.patch("devlair.modules.system.detect_platform", return_value="wsl")
+    items = system.check()
+    labels = [i.label for i in items]
+    assert "ufw" not in labels
+    assert "fail2ban" not in labels


### PR DESCRIPTION
## Summary

- Splits `ESSENTIALS` into `ESSENTIALS` (cross-platform) and `LINUX_ESSENTIALS` (`openssh-server`, `ufw`, `fail2ban`, `avahi-daemon`)
- `LINUX_ESSENTIALS` is only installed when `ctx.platform == "linux"` — WSL skips it entirely
- Removes `ufw` and `fail2ban` from `check()` on non-linux platforms so `devlair doctor` doesn't report false failures on WSL
- Adds `detect_platform` import at module level (top-of-file) so it is patchable in tests

These four packages require systemd which is unavailable on WSL. They are already handled by the dedicated `ssh.py` and `firewall.py` modules (both `platforms={"linux"}`), so installing them unconditionally was both redundant and error-prone.

Closes #96

## Test plan

- [x] All 160 unit tests pass (`uv run pytest tests/unit/`)
- [x] `ruff check devlair/ tests/` — no lint errors
- [x] On linux: `openssh-server`, `ufw`, `fail2ban`, `avahi-daemon` are installed (`test_run_installs_essentials_on_linux`)
- [x] On WSL: those four packages are NOT installed (`test_run_skips_linux_essentials_on_wsl`)
- [x] `check()` on linux includes `ufw` and `fail2ban` items (`test_check_installed_on_linux`)
- [x] `check()` on WSL excludes `ufw` and `fail2ban` items (`test_check_excludes_linux_tools_on_wsl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)