### PR TITLE
fix(init): improve stderr heuristic to surface apt root-cause line

### DIFF
--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -23,6 +23,7 @@ import { detectPlatform, detectWslVersion } from "../lib/platform.js";
 import { type Profile, ProfileError, loadProfile, resolveProfileKeys } from "../lib/profiles.js";
 import { runModule } from "../lib/runner.js";
 import { selectModules } from "../lib/selection.js";
+import { pickStderrDetail } from "../lib/stderr.js";
 import { D_COMMENT, D_FG, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
 import type { ModuleContext, Status } from "../lib/types.js";
 import { Confirmation } from "../wizard/Confirmation.js";
@@ -158,12 +159,8 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
               // a `result` event — otherwise we'd promote warn→ok on exit 0.
               if (!resultEmitted) finalStatus = value.status;
               if (!finalDetail && finalStatus !== "ok") {
-                const lastErr = value.stderr
-                  .split("\n")
-                  .map((s) => s.trim())
-                  .filter(Boolean)
-                  .pop();
-                if (lastErr) finalDetail = lastErr;
+                const picked = pickStderrDetail(value.stderr);
+                if (picked) finalDetail = picked;
               }
               break;
             }

--- a/cli/src/lib/stderr.ts
+++ b/cli/src/lib/stderr.ts
@@ -1,8 +1,6 @@
 const MAX_DETAIL_LEN = 120;
 
 /**
- * Pick the most useful single line from module stderr for display in the UI.
- *
  * Strategy (apt prints root-cause errors before summaries):
  *   1. First `E:` line — the original error, not the meta-summary.
  *   2. Last non-empty line that contains at least one alphanumeric character.
@@ -19,7 +17,7 @@ export function pickStderrDetail(stderr: string): string {
   const firstErr = lines.find((l) => l.startsWith("E:"));
   if (firstErr) return cap(firstErr);
 
-  const meaningful = lines.filter((l) => /[a-zA-Z0-9]/.test(l));
+  const meaningful = lines.filter((l) => /[a-z0-9]/i.test(l));
   const picked = meaningful.length > 0 ? meaningful[meaningful.length - 1] : lines[lines.length - 1];
   return cap(picked);
 }

--- a/cli/src/lib/stderr.ts
+++ b/cli/src/lib/stderr.ts
@@ -1,0 +1,29 @@
+const MAX_DETAIL_LEN = 120;
+
+/**
+ * Pick the most useful single line from module stderr for display in the UI.
+ *
+ * Strategy (apt prints root-cause errors before summaries):
+ *   1. First `E:` line — the original error, not the meta-summary.
+ *   2. Last non-empty line that contains at least one alphanumeric character.
+ *   3. Empty string when stderr is blank.
+ */
+export function pickStderrDetail(stderr: string): string {
+  const lines = stderr
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) return "";
+
+  const firstErr = lines.find((l) => l.startsWith("E:"));
+  if (firstErr) return cap(firstErr);
+
+  const meaningful = lines.filter((l) => /[a-zA-Z0-9]/.test(l));
+  const picked = meaningful.length > 0 ? meaningful[meaningful.length - 1] : lines[lines.length - 1];
+  return cap(picked);
+}
+
+function cap(s: string): string {
+  return s.length > MAX_DETAIL_LEN ? `${s.slice(0, MAX_DETAIL_LEN - 1)}…` : s;
+}

--- a/cli/src/test/stderr.test.ts
+++ b/cli/src/test/stderr.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { pickStderrDetail } from "../lib/stderr.js";
+
+describe("pickStderrDetail", () => {
+  test("returns empty string for blank stderr", () => {
+    expect(pickStderrDetail("")).toBe("");
+    expect(pickStderrDetail("   \n\n  ")).toBe("");
+  });
+
+  test("prefers first E: line over apt meta-summary", () => {
+    const stderr = [
+      "Setting up openssh-server (1:9.2p1-2ubuntu3) ...",
+      "E: Could not execute systemctl",
+      "Errors were encountered while processing:",
+      "  openssh-server",
+      "E: Sub-process /usr/bin/dpkg returned an error code (1)",
+    ].join("\n");
+
+    expect(pickStderrDetail(stderr)).toBe("E: Could not execute systemctl");
+  });
+
+  test("picks first E: line when multiple E: lines exist (root cause first)", () => {
+    const stderr = [
+      "E: installed openssh-server package post-installation script subprocess returned error exit status 1",
+      "E: Sub-process /usr/bin/dpkg returned an error code (1)",
+    ].join("\n");
+
+    expect(pickStderrDetail(stderr)).toBe(
+      "E: installed openssh-server package post-installation script subprocess returned error exit status 1",
+    );
+  });
+
+  test("falls back to last meaningful line for dpkg non-E: errors", () => {
+    const stderr = [
+      "dpkg: error processing package broken-pkg (--configure):",
+      " subprocess installed post-installation script returned error exit status 1",
+      "Errors were encountered while processing:",
+      " broken-pkg",
+    ].join("\n");
+
+    expect(pickStderrDetail(stderr)).toBe("broken-pkg");
+  });
+
+  test("falls back to last meaningful line for generic command-not-found", () => {
+    const stderr = "/bin/sh: 1: timedatectl: not found";
+    expect(pickStderrDetail(stderr)).toBe("/bin/sh: 1: timedatectl: not found");
+  });
+
+  test("skips separator-only lines when falling back", () => {
+    const stderr = ["something went wrong", "---", "..."].join("\n");
+    expect(pickStderrDetail(stderr)).toBe("something went wrong");
+  });
+
+  test("truncates lines longer than 120 characters", () => {
+    const long = `E: ${"x".repeat(200)}`;
+    const result = pickStderrDetail(long);
+    expect(result.length).toBe(120);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  test("preserves short lines unchanged", () => {
+    expect(pickStderrDetail("E: Permission denied")).toBe("E: Permission denied");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts stderr-picking logic into `cli/src/lib/stderr.ts` as `pickStderrDetail()`
- Prefers the **first** `E:` line when present — apt prints root-cause errors before meta-summaries, so the old `pop()` was surfacing the wrong line (e.g. `E: Sub-process /usr/bin/dpkg returned an error code (1)` instead of `E: Could not execute systemctl`)
- Falls back to the last line containing at least one alphanumeric character, skipping pure separator lines
- Caps output at 120 characters to fit a single UI row

Closes #92

## Test plan

- [x] 8 unit tests in `stderr.test.ts` covering: blank stderr, apt multi-`E:` block, dpkg non-`E:` fallback, command-not-found, separator-skipping, truncation, and short line passthrough
- [x] All 167 tests pass (`bun test`)
- [x] Lint clean (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)