### PR TITLE
feat(macos): add system module with brew helpers (PR 2a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 
 ## What gets installed
 
-`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. Linux-only modules (auto-skipped elsewhere): `timezone`, `ssh`, `firewall`, `gnome_terminal`.
+`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. Linux-only modules (auto-skipped elsewhere): `timezone`, `ssh`, `firewall`, `gnome_terminal`.
 
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
 
-Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `htop`, `tmux`, `zsh`, `bat`, `fzf`, `build-essential`, and more. On bare Linux it also installs `openssh-server`, `ufw`, `fail2ban`, and `avahi-daemon`; these are skipped on WSL because they ship systemd-managed postinst scripts that don't work under WSL's systemd-less default (the dedicated `ssh` and `firewall` modules are also Linux-only).
+Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `htop`, `tmux`, `zsh`, `bat`, `fzf`, `build-essential`, and more. On bare Linux it also installs `openssh-server`, `ufw`, `fail2ban`, and `avahi-daemon`; these are skipped on WSL because they ship systemd-managed postinst scripts that don't work under WSL's systemd-less default (the dedicated `ssh` and `firewall` modules are also Linux-only). On macOS, the module ensures Homebrew is installed, runs `brew update && brew upgrade`, and installs a set of macOS essentials via `brew install` (`git`, `curl`, `wget`, `vim`, `htop`, `tmux`, `unzip`, `jq`, `tree`, `rsync`, `zsh`, `bat`, `fzf`, `gnupg`).
 
 </details>
 

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -99,6 +99,32 @@ apt_install() {
   apt-get install -y -qq "$@" >&2
 }
 
+# brew_install PKG... -- install Homebrew packages quietly with a progress event.
+brew_install() {
+  json_progress "installing $*"
+  brew install --quiet "$@" >&2
+}
+
+# brew_ensure -- ensure Homebrew is on PATH, installing it if absent.
+# Uses download-then-execute to avoid piping curl to bash directly.
+# After install, sources brew shellenv so subsequent brew calls work.
+brew_ensure() {
+  if cmd_exists brew; then
+    return 0
+  fi
+  json_progress "installing Homebrew"
+  local tmp
+  tmp=$(download_script "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh")
+  NONINTERACTIVE=1 bash "$tmp" >&2
+  rm -f "$tmp"
+  # Add brew to PATH for the remainder of this script session
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+}
+
 # run_as USER CMD... -- run a command as another user via sudo.
 run_as() {
   local user=$1; shift

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -122,6 +122,9 @@ brew_ensure() {
     eval "$(/opt/homebrew/bin/brew shellenv)"
   elif [[ -x /usr/local/bin/brew ]]; then
     eval "$(/usr/local/bin/brew shellenv)"
+  else
+    json_result "fail" "Homebrew installed but brew not found at expected paths"
+    exit 1
   fi
 }
 

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -28,8 +28,6 @@ ESSENTIALS=(
 # bare Linux already.
 LINUX_ESSENTIALS=( openssh-server ufw fail2ban avahi-daemon )
 
-# macOS package list — net-tools/build-essential/ca-certificates/locales are
-# Linux-specific; Keychain handles CAs, Xcode CLT handles build tooling.
 # Excludes from ESSENTIALS: net-tools, build-essential, ca-certificates, locales
 # (Linux/apt-specific; macOS handles these via system frameworks and Xcode CLT)
 MACOS_ESSENTIALS=( git curl wget vim htop tmux unzip jq tree rsync zsh bat fzf gnupg )

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -30,6 +30,8 @@ LINUX_ESSENTIALS=( openssh-server ufw fail2ban avahi-daemon )
 
 # macOS package list — net-tools/build-essential/ca-certificates/locales are
 # Linux-specific; Keychain handles CAs, Xcode CLT handles build tooling.
+# Excludes from ESSENTIALS: net-tools, build-essential, ca-certificates, locales
+# (Linux/apt-specific; macOS handles these via system frameworks and Xcode CLT)
 MACOS_ESSENTIALS=( git curl wget vim htop tmux unzip jq tree rsync zsh bat fzf gnupg )
 
 do_run() {
@@ -70,6 +72,9 @@ do_check() {
   local checks=( "git:git" "curl:curl" "tmux:tmux" "zsh:zsh" )
   if [[ "$PLATFORM" == "linux" ]]; then
     checks+=( "ufw:ufw" "fail2ban:fail2ban-client" )
+  fi
+  if [[ "$PLATFORM" == "macos" ]]; then
+    checks+=( "brew:brew" )
   fi
   for pair in "${checks[@]}"; do
     label="${pair%%:*}"

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -28,7 +28,22 @@ ESSENTIALS=(
 # bare Linux already.
 LINUX_ESSENTIALS=( openssh-server ufw fail2ban avahi-daemon )
 
+# macOS package list — net-tools/build-essential/ca-certificates/locales are
+# Linux-specific; Keychain handles CAs, Xcode CLT handles build tooling.
+MACOS_ESSENTIALS=( git curl wget vim htop tmux unzip jq tree rsync zsh bat fzf gnupg )
+
 do_run() {
+  if [[ "$PLATFORM" == "macos" ]]; then
+    brew_ensure
+    json_progress "updating Homebrew"
+    brew update --quiet >&2
+    json_progress "upgrading packages"
+    brew upgrade --quiet >&2
+    brew_install "${MACOS_ESSENTIALS[@]}"
+    json_result "ok" "packages up to date"
+    return
+  fi
+
   json_progress "updating package lists"
   apt-get update -qq >&2
   json_progress "upgrading packages"

--- a/cli/src/lib/modules.ts
+++ b/cli/src/lib/modules.ts
@@ -38,7 +38,7 @@ function spec(
 }
 
 export const MODULE_SPECS: readonly ModuleSpec[] = [
-  spec("system", "System update", "core"),
+  spec("system", "System update", "core", { platforms: ["linux", "wsl", "macos"] }),
   spec("timezone", "Timezone", "core", { platforms: ["linux"] }),
   spec("tailscale", "Tailscale", "network", { defaultOn: ["linux"] }),
   spec("ssh", "SSH", "network", { deps: ["tailscale"], platforms: ["linux"] }),

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -110,7 +110,6 @@ describe("resolveOrder", () => {
   test("filters by platform: macos", () => {
     const macosSpecs = resolveOrder(undefined, "macos");
     const macosKeys = macosSpecs.map((s) => s.key);
-    // system runs on macOS (PR 2a)
     expect(macosKeys).toContain("system");
     // Linux/WSL-only modules are excluded
     expect(macosKeys).not.toContain("timezone");

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -93,7 +93,7 @@ describe("resolveOrder", () => {
     expect(keys).toContain("firewall");
   });
 
-  test("filters by platform", () => {
+  test("filters by platform: wsl", () => {
     const wslSpecs = resolveOrder(undefined, "wsl");
     const wslKeys = wslSpecs.map((s) => s.key);
     // Linux-only modules should be excluded on WSL
@@ -105,6 +105,18 @@ describe("resolveOrder", () => {
     expect(wslKeys).toContain("system");
     expect(wslKeys).toContain("zsh");
     expect(wslKeys).toContain("devtools");
+  });
+
+  test("filters by platform: macos", () => {
+    const macosSpecs = resolveOrder(undefined, "macos");
+    const macosKeys = macosSpecs.map((s) => s.key);
+    // system runs on macOS (PR 2a)
+    expect(macosKeys).toContain("system");
+    // Linux/WSL-only modules are excluded
+    expect(macosKeys).not.toContain("timezone");
+    expect(macosKeys).not.toContain("ssh");
+    expect(macosKeys).not.toContain("firewall");
+    expect(macosKeys).not.toContain("gnome_terminal");
   });
 
   test("combines keys + platform filter", () => {


### PR DESCRIPTION
## Summary

- **`cli/src/lib/modules.ts`** — adds `"macos"` to the `system` module's platforms, enabling `devlair init --group core` to run on macOS
- **`cli/modules/_lib.sh`** — adds `brew_install()` (mirrors `apt_install`) and `brew_ensure()` helpers:
  - `brew_ensure()` checks if `brew` is on PATH and installs it if absent using download-then-execute (no pipe-to-bash), matching existing security conventions
  - Sources `brew shellenv` after install so subsequent `brew` calls work in the same script session
- **`cli/modules/system.sh`** — adds macOS branch in `do_run()`:
  - Calls `brew_ensure`, `brew update`, `brew upgrade`, then installs `MACOS_ESSENTIALS`
  - Package list excludes Linux-specific packages (`net-tools`, `build-essential`, `ca-certificates`, `locales`) — macOS handles CAs via Keychain and build tooling via Xcode CLT
  - Skips `locale-gen`/`update-locale` (macOS defaults to UTF-8)
- **`cli/src/test/modules.test.ts`** — adds `"filters by platform: macos"` test verifying `system` is included and `timezone`/`ssh`/`firewall`/`gnome_terminal` are excluded

This is PR 2a of epic #159 (macOS system services support).

Closes #159

## Test plan

- [x] All 168 unit tests pass (`bun test`)
- [x] Lint clean (`bun run lint`)
- [x] `resolveOrder(undefined, "macos")` includes `system` and excludes `timezone`, `ssh`, `firewall`, `gnome_terminal` (`test/modules.test.ts`)
- [ ] On macOS: `devlair init --group core` runs `system.sh` macOS branch, installs MACOS_ESSENTIALS via brew <!-- needs-manual: requires macOS machine -->
- [ ] On macOS: `devlair doctor` reports `git`, `curl`, `tmux`, `zsh` as ok <!-- needs-manual: requires macOS machine -->
- [x] On Linux/WSL: no regression — apt path unchanged, 168 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)