### PR TITLE
fix(security): remove world-readable chmod from download_script

### DIFF
--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -146,7 +146,6 @@ download_script() {
   local url=$1
   local tmp
   tmp=$(mktemp --suffix=.sh)
-  chmod 644 "$tmp"
   curl -fsSL "$url" -o "$tmp" >&2
   printf '%s' "$tmp"
 }


### PR DESCRIPTION
## Summary

- Removes the \`chmod 644\` line from \`download_script()\` in \`cli/modules/_lib.sh\`
- \`mktemp\` already creates the file at \`0600\` (owner-only); widening to \`0644\` before the curl write left the installer script world-readable during the download window — a TOCTOU exposure on multi-user machines
- \`root\` (devlair's execution user) can already read and execute a \`0600\` file it owns — the chmod served no purpose
- All seven callers are fixed by this single-line deletion: \`brew_ensure\`, \`uv\`, \`pyenv\`, \`nvm\`, \`bun\`, \`tailscale\`, \`claude\`

Closes #168

## Test plan

- [x] All 168 unit tests pass (`bun test`)
- [x] Lint clean (`bun run lint`)
- [x] `download_script` callers are unchanged — only the unnecessary chmod is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)