### PR TITLE
feat(macos): add macOS support to ssh module

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 
 ## What gets installed
 
-`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. Linux-only modules (auto-skipped elsewhere): `timezone`, `ssh`, `firewall`, `gnome_terminal`.
+`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`, `ssh`. Linux-only modules (auto-skipped elsewhere): `timezone`, `firewall`, `gnome_terminal`.
 
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
@@ -220,6 +220,8 @@ Creates `/etc/ssh/sshd_config.d/99-hardened.conf` with:
 - ListenAddress restricted to Tailscale IP (when available)
 
 Prompts for your SSH public key if `authorized_keys` is empty.
+
+On macOS, enables Remote Login via `systemsetup -setremotelogin on` and manages `sshd` through `launchctl`. The hardened config drop-in and authorized_keys setup are identical across platforms.
 
 </details>
 

--- a/cli/modules/ssh.sh
+++ b/cli/modules/ssh.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# modules/ssh.sh — SSH
+# cli/modules/ssh.sh — SSH
 # devlair module: ssh
 set -euo pipefail
 
@@ -10,17 +10,13 @@ read_context
 
 USERNAME=$(ctx_get username)
 USER_HOME=$(ctx_get userHome)
+PLATFORM=$(ctx_get platform)
 MODE=${1:-run}
 
 SSHD_CONF="/etc/ssh/sshd_config.d/99-hardened.conf"
 
 do_run() {
-  # Back up existing config
-  if [[ -f /etc/ssh/sshd_config ]]; then
-    cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
-  fi
-
-  # Get Tailscale IP for ListenAddress
+  # Get Tailscale IP for ListenAddress (optional on all platforms)
   local ts_ip listen
   ts_ip=$(tailscale ip -4 2>/dev/null || true)
   if [[ -n "$ts_ip" ]]; then
@@ -29,7 +25,17 @@ do_run() {
     listen="# ListenAddress <set after tailscale connects>"
   fi
 
-  # Write hardened sshd config from template
+  if [[ "$PLATFORM" == "macos" ]]; then
+    json_progress "enabling remote login"
+    systemsetup -setremotelogin on >&2
+  else
+    # Back up existing config
+    if [[ -f /etc/ssh/sshd_config ]]; then
+      cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+    fi
+  fi
+
+  # Write hardened sshd config from template (portable across Linux and macOS)
   json_progress "writing hardened sshd config"
   mkdir -p "$(dirname "$SSHD_CONF")"
   sed -e "s|%%LISTEN_ADDRESS%%|$listen|" \
@@ -64,7 +70,13 @@ do_run() {
     fi
   fi
 
-  systemctl restart ssh >&2 || true
+  # Restart sshd — launchctl on macOS, systemctl on Linux
+  json_progress "restarting sshd"
+  if [[ "$PLATFORM" == "macos" ]]; then
+    launchctl kickstart -k system/com.openssh.sshd >&2 || true
+  else
+    systemctl restart ssh >&2 || true
+  fi
 
   if [[ -n "$ts_ip" ]]; then
     json_result "ok" "locked to $ts_ip"
@@ -74,12 +86,20 @@ do_run() {
 }
 
 do_check() {
-  local sshd_status
-  sshd_status=$(systemctl is-active ssh 2>/dev/null || echo "inactive")
-  if [[ "$sshd_status" == "active" ]]; then
-    json_check "sshd running" "ok"
+  if [[ "$PLATFORM" == "macos" ]]; then
+    if launchctl list com.openssh.sshd 2>/dev/null | grep -q '"PID"'; then
+      json_check "sshd running" "ok"
+    else
+      json_check "sshd running" "fail"
+    fi
   else
-    json_check "sshd running" "fail"
+    local sshd_status
+    sshd_status=$(systemctl is-active ssh 2>/dev/null || echo "inactive")
+    if [[ "$sshd_status" == "active" ]]; then
+      json_check "sshd running" "ok"
+    else
+      json_check "sshd running" "fail"
+    fi
   fi
 
   if [[ -f "$SSHD_CONF" ]]; then

--- a/cli/modules/ssh.sh
+++ b/cli/modules/ssh.sh
@@ -25,14 +25,28 @@ do_run() {
     listen="# ListenAddress <set after tailscale connects>"
   fi
 
+  # Back up existing config on all platforms before any writes
+  if [[ -f /etc/ssh/sshd_config ]]; then
+    cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+    chmod 600 /etc/ssh/sshd_config.bak
+  fi
+
   if [[ "$PLATFORM" == "macos" ]]; then
     json_progress "enabling remote login"
     systemsetup -setremotelogin on >&2
-  else
-    # Back up existing config
-    if [[ -f /etc/ssh/sshd_config ]]; then
-      cp /etc/ssh/sshd_config /etc/ssh/sshd_config.bak
+
+    # Ensure sshd reads the drop-in directory on macOS
+    local base_conf="/etc/ssh/sshd_config"
+    if ! grep -q 'Include /etc/ssh/sshd_config.d/' "$base_conf" 2>/dev/null; then
+      json_progress "enabling sshd drop-in includes"
+      printf '\nInclude /etc/ssh/sshd_config.d/*.conf\n' >> "$base_conf"
     fi
+  fi
+
+  # Validate USERNAME before interpolating into sed
+  if [[ ! "$USERNAME" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+    json_result "fail" "invalid username: $USERNAME"
+    exit 1
   fi
 
   # Write hardened sshd config from template (portable across Linux and macOS)
@@ -73,7 +87,8 @@ do_run() {
   # Restart sshd — launchctl on macOS, systemctl on Linux
   json_progress "restarting sshd"
   if [[ "$PLATFORM" == "macos" ]]; then
-    launchctl kickstart -k system/com.openssh.sshd >&2 || true
+    sshd -t >&2
+    launchctl kickstart -k system/com.openssh.sshd >&2
   else
     systemctl restart ssh >&2 || true
   fi
@@ -87,7 +102,7 @@ do_run() {
 
 do_check() {
   if [[ "$PLATFORM" == "macos" ]]; then
-    if launchctl list com.openssh.sshd 2>/dev/null | grep -q '"PID"'; then
+    if launchctl print system/com.openssh.sshd 2>/dev/null | grep -q 'state = running'; then
       json_check "sshd running" "ok"
     else
       json_check "sshd running" "fail"

--- a/cli/src/lib/modules.ts
+++ b/cli/src/lib/modules.ts
@@ -41,7 +41,7 @@ export const MODULE_SPECS: readonly ModuleSpec[] = [
   spec("system", "System update", "core", { platforms: ["linux", "wsl", "macos"] }),
   spec("timezone", "Timezone", "core", { platforms: ["linux"] }),
   spec("tailscale", "Tailscale", "network", { defaultOn: ["linux"] }),
-  spec("ssh", "SSH", "network", { deps: ["tailscale"], platforms: ["linux"] }),
+  spec("ssh", "SSH", "network", { deps: ["tailscale"], platforms: ["linux", "macos"] }),
   spec("firewall", "Firewall + Fail2Ban", "network", { deps: ["ssh"], platforms: ["linux"] }),
   spec("zsh", "Zsh + Dracula", "core", { reapply: true }),
   spec("tmux", "tmux", "coding", { reapply: true }),

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -111,9 +111,9 @@ describe("resolveOrder", () => {
     const macosSpecs = resolveOrder(undefined, "macos");
     const macosKeys = macosSpecs.map((s) => s.key);
     expect(macosKeys).toContain("system");
+    expect(macosKeys).toContain("ssh");
     // Linux/WSL-only modules are excluded
     expect(macosKeys).not.toContain("timezone");
-    expect(macosKeys).not.toContain("ssh");
     expect(macosKeys).not.toContain("firewall");
     expect(macosKeys).not.toContain("gnome_terminal");
   });


### PR DESCRIPTION
## Summary

- `cli/modules/ssh.sh`: branch service management by platform — macOS uses `systemsetup -setremotelogin on` to enable Remote Login and `launchctl kickstart -k system/com.openssh.sshd` to restart sshd; Linux keeps the existing `systemctl` path
- `sshd_config` hardening, `authorized_keys` setup, and Tailscale IP binding are portable and shared across both platform paths
- `cli/src/lib/modules.ts`: adds `"macos"` to `ssh` module platforms
- `cli/src/test/modules.test.ts`: updates macOS platform filter test to expect `ssh`

Closes #170

## Test plan

- [x] All 168 unit tests pass (`bun test`)
- [x] Lint clean (`bun run lint`)
- [x] `resolveOrder(undefined, "macos")` includes `ssh` (automated — `test/modules.test.ts`)
- [ ] On macOS: `devlair init --group network` enables Remote Login, writes `99-hardened.conf`, restarts sshd via launchctl <!-- needs-manual: requires macOS machine -->
- [ ] On macOS: `devlair doctor` reports `sshd running` and `99-hardened.conf` status <!-- needs-manual: requires macOS machine -->
- [ ] On Linux/WSL: no regression — `systemctl` path unchanged <!-- needs-manual: runtime verification -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
