### PR TITLE
fix(ci): replace macos-13 with macos-15-intel for Intel x86_64 build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -114,7 +114,7 @@ jobs:
             os: darwin
             arch: aarch64
             target: bun-darwin-arm64
-          - runs-on: macos-13
+          - runs-on: macos-15-intel
             os: darwin
             arch: x86_64
             target: bun-darwin-x64


### PR DESCRIPTION
## Summary

- Replaces the deprecated `macos-13` runner with `macos-15-intel` in the `build-cli` matrix
- `macos-13` was deprecated September 2025 and fully unsupported since December 4, 2025; GitHub capacity is degraded — jobs queue indefinitely
- `macos-15-intel` is the last Intel (x86_64) macOS image, supported until August 2027

Closes #176

## Test plan

- [ ] CI `build-cli (macos-15-intel, darwin, x86_64, bun-darwin-x64)` picks up a runner promptly on next release
- [ ] `devlair-cli-darwin-x86_64` artifact is produced and uploaded to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)