### PR TITLE
feat(init): add --brand flag to customise the init banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ SSH hardening, UFW firewall, Fail2Ban, and Tailscale VPN are set up out of the b
   vX.Y.Z
 
   Setup & Health
-    init [--only MOD] [--skip MOD] [--group GRP] [--config FILE]  Interactive wizard (or non-interactive with flags)
+    init [--only MOD] [--skip MOD] [--group GRP] [--config FILE] [--brand NAME]  Interactive wizard (or non-interactive with flags)
     doctor [--fix]                      Check system health & fix drift
     upgrade [--no-self]                 Upgrade tools & re-apply configs
     disable-password                    Lock SSH to key-only auth

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -38,21 +38,23 @@ function InitHeader({
   host,
   platform,
   profileName,
+  brand,
 }: {
   username: string;
   host: string;
   platform: string;
   profileName?: string;
+  brand?: string;
 }) {
   const suffix = platform === "wsl" ? " (WSL)" : platform === "macos" ? " (macOS)" : "";
 
   return (
     <Box flexDirection="column">
-      <Logo />
+      <Logo brand={brand} />
       <Box marginBottom={1}>
         <Text>{"  "}</Text>
         <Text color={D_PURPLE} bold>
-          devlair
+          {brand ?? "devlair"}
         </Text>
         <Text color={D_PINK} bold>
           {"  init"}
@@ -309,16 +311,22 @@ function NonInteractiveInit({ flags }: { flags: InitFlags }) {
       </Box>
     );
   }
-  return <NonInteractiveInitView state={initState} />;
+  return <NonInteractiveInitView state={initState} brand={flags.brand ?? undefined} />;
 }
 
-function NonInteractiveInitView({ state }: { state: InitState }) {
+function NonInteractiveInitView({ state, brand }: { state: InitState; brand?: string }) {
   const { platform, context, selected, optional, skippedNames, profile } = state;
   const { modules, done, logDir } = useModuleExecution(selected, context, true);
 
   return (
     <Box flexDirection="column">
-      <InitHeader username={context.username} host={hostname()} platform={platform} profileName={profile?.name} />
+      <InitHeader
+        username={context.username}
+        host={hostname()}
+        platform={platform}
+        profileName={profile?.name}
+        brand={brand}
+      />
       <PlatformSkipped names={skippedNames} />
       <Progress modules={modules} total={selected.length} />
       {done && <Summary modules={modules} logDir={logDir} />}
@@ -330,7 +338,7 @@ function NonInteractiveInitView({ state }: { state: InitState }) {
 
 // ── Interactive wizard init (no flags) ─────────────────────────────────────
 
-function WizardInit() {
+function WizardInit({ brand }: { brand?: string }) {
   const { exit } = useApp();
 
   const [envState] = useState(() => {
@@ -368,7 +376,7 @@ function WizardInit() {
 
   return (
     <Box flexDirection="column">
-      <InitHeader username={context.username} host={hostname()} platform={platform} />
+      <InitHeader username={context.username} host={hostname()} platform={platform} brand={brand} />
 
       {phase === "wizard-groups" && (
         <GroupSelect
@@ -435,5 +443,5 @@ export function InitView({ flags }: { flags: InitFlags }) {
   if (hasExplicitFlags(flags)) {
     return <NonInteractiveInit flags={flags} />;
   }
-  return <WizardInit />;
+  return <WizardInit brand={flags.brand ?? undefined} />;
 }

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -11,7 +11,7 @@ import { useApp } from "ink";
 import { Box, Text } from "ink";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { Logo } from "../components/Logo.js";
+import { BRAND, Logo } from "../components/Logo.js";
 import { type ModuleRun, Progress } from "../components/Progress.js";
 import { OptionalHint, Summary } from "../components/Summary.js";
 import type { InitFlags } from "../lib/args.js";
@@ -54,7 +54,7 @@ function InitHeader({
       <Box marginBottom={1}>
         <Text>{"  "}</Text>
         <Text color={D_PURPLE} bold>
-          {brand ?? "devlair"}
+          {brand ?? BRAND}
         </Text>
         <Text color={D_PINK} bold>
           {"  init"}
@@ -311,7 +311,7 @@ function NonInteractiveInit({ flags }: { flags: InitFlags }) {
       </Box>
     );
   }
-  return <NonInteractiveInitView state={initState} brand={flags.brand ?? undefined} />;
+  return <NonInteractiveInitView state={initState} brand={flags.brand} />;
 }
 
 function NonInteractiveInitView({ state, brand }: { state: InitState; brand?: string }) {
@@ -443,5 +443,5 @@ export function InitView({ flags }: { flags: InitFlags }) {
   if (hasExplicitFlags(flags)) {
     return <NonInteractiveInit flags={flags} />;
   }
-  return <WizardInit brand={flags.brand ?? undefined} />;
+  return <WizardInit brand={flags.brand} />;
 }

--- a/cli/src/components/Logo.tsx
+++ b/cli/src/components/Logo.tsx
@@ -1,7 +1,8 @@
 import { Box, Text } from "ink";
+import stripAnsi from "strip-ansi";
 import { D_COMMENT, D_FG, D_PINK, D_PURPLE } from "../lib/theme.js";
 
-const BRAND = "d e v l a i r";
+export const BRAND = "d e v l a i r";
 const INNER_WIDTH = 48;
 const MIN_W_SHORT = 16;
 
@@ -52,8 +53,8 @@ function Border({ W, left, right }: { W: number; left: string; right: string }) 
 function ContentRow({ W, children }: { W: number; children: string }) {
   const innerLen = [...children].length;
   const pad = W - innerLen;
-  const padL = Math.floor(pad / 2);
-  const padR = pad - padL;
+  const padL = Math.max(0, Math.floor(pad / 2));
+  const padR = Math.max(0, pad - padL);
   return (
     <Text>
       <Text color={D_PURPLE}>{"  │"}</Text>
@@ -67,11 +68,11 @@ function ContentRow({ W, children }: { W: number; children: string }) {
 
 function FullLogo({ W, grad, brand }: { W: number; grad: string; brand: string }) {
   const gradR = [...grad].reverse().join("");
-  const gap = W - grad.length - gradR.length - 4;
-  const iw = brand.length + 4;
-  const ib = "═".repeat(iw - 2);
-  const pt = Math.floor((W - iw) / 2);
-  const pr = W - iw - pt;
+  const gap = Math.max(0, W - grad.length - gradR.length - 4);
+  const iw = [...brand].length + 4;
+  const ib = "═".repeat(Math.max(0, iw - 2));
+  const pt = Math.max(0, Math.floor((W - iw) / 2));
+  const pr = Math.max(0, W - iw - pt);
 
   const GradRow = () => (
     <Text>
@@ -120,10 +121,10 @@ function FullLogo({ W, grad, brand }: { W: number; grad: string; brand: string }
 
 function MediumLogo({ W, grad, brand }: { W: number; grad: string; brand: string }) {
   const gradR = [...grad].reverse().join("");
-  const innerLen = grad.length + 2 + brand.length + 2 + gradR.length;
+  const innerLen = grad.length + 2 + [...brand].length + 2 + gradR.length;
   const pad = W - innerLen;
-  const padL = Math.floor(pad / 2);
-  const padR = pad - padL;
+  const padL = Math.max(0, Math.floor(pad / 2));
+  const padR = Math.max(0, pad - padL);
 
   return (
     <Box flexDirection="column">
@@ -159,7 +160,7 @@ function ShortLogo({ W, brand }: { W: number; brand: string }) {
 export function Logo({ cols, brand }: { cols?: number; brand?: string }) {
   const termCols = cols ?? process.stdout.columns ?? 80;
   const { W, grad, innerBox } = resolveDecoration(termCols);
-  const b = brand ?? BRAND;
+  const b = stripAnsi(brand ?? BRAND).slice(0, 40);
 
   if (grad && innerBox) return <FullLogo W={W} grad={grad} brand={b} />;
   if (grad) return <MediumLogo W={W} grad={grad} brand={b} />;

--- a/cli/src/components/Logo.tsx
+++ b/cli/src/components/Logo.tsx
@@ -65,10 +65,10 @@ function ContentRow({ W, children }: { W: number; children: string }) {
   );
 }
 
-function FullLogo({ W, grad }: { W: number; grad: string }) {
+function FullLogo({ W, grad, brand }: { W: number; grad: string; brand: string }) {
   const gradR = [...grad].reverse().join("");
   const gap = W - grad.length - gradR.length - 4;
-  const iw = BRAND.length + 4;
+  const iw = brand.length + 4;
   const ib = "═".repeat(iw - 2);
   const pt = Math.floor((W - iw) / 2);
   const pr = W - iw - pt;
@@ -105,7 +105,7 @@ function FullLogo({ W, grad }: { W: number; grad: string }) {
         {" ".repeat(pt)}
         <Text color={D_PINK}>{"║ "}</Text>
         <Text color={D_FG} bold>
-          {BRAND}
+          {brand}
         </Text>
         <Text color={D_PINK}>{" ║"}</Text>
         {" ".repeat(pr)}
@@ -118,9 +118,9 @@ function FullLogo({ W, grad }: { W: number; grad: string }) {
   );
 }
 
-function MediumLogo({ W, grad }: { W: number; grad: string }) {
+function MediumLogo({ W, grad, brand }: { W: number; grad: string; brand: string }) {
   const gradR = [...grad].reverse().join("");
-  const innerLen = grad.length + 2 + BRAND.length + 2 + gradR.length;
+  const innerLen = grad.length + 2 + brand.length + 2 + gradR.length;
   const pad = W - innerLen;
   const padL = Math.floor(pad / 2);
   const padR = pad - padL;
@@ -134,7 +134,7 @@ function MediumLogo({ W, grad }: { W: number; grad: string }) {
         <Text color={D_COMMENT}>{grad}</Text>
         {"  "}
         <Text color={D_FG} bold>
-          {BRAND}
+          {brand}
         </Text>
         {"  "}
         <Text color={D_COMMENT}>{gradR}</Text>
@@ -146,21 +146,22 @@ function MediumLogo({ W, grad }: { W: number; grad: string }) {
   );
 }
 
-function ShortLogo({ W }: { W: number }) {
+function ShortLogo({ W, brand }: { W: number; brand: string }) {
   return (
     <Box flexDirection="column">
       <Border W={W} left="╭" right="╮" />
-      <ContentRow W={W}>{BRAND}</ContentRow>
+      <ContentRow W={W}>{brand}</ContentRow>
       <Border W={W} left="╰" right="╯" />
     </Box>
   );
 }
 
-export function Logo({ cols }: { cols?: number }) {
+export function Logo({ cols, brand }: { cols?: number; brand?: string }) {
   const termCols = cols ?? process.stdout.columns ?? 80;
   const { W, grad, innerBox } = resolveDecoration(termCols);
+  const b = brand ?? BRAND;
 
-  if (grad && innerBox) return <FullLogo W={W} grad={grad} />;
-  if (grad) return <MediumLogo W={W} grad={grad} />;
-  return <ShortLogo W={W} />;
+  if (grad && innerBox) return <FullLogo W={W} grad={grad} brand={b} />;
+  if (grad) return <MediumLogo W={W} grad={grad} brand={b} />;
+  return <ShortLogo W={W} brand={b} />;
 }

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -5,7 +5,7 @@ export interface InitFlags {
   skip: Set<string>;
   group: Set<string> | null;
   config: string | null;
-  brand: string | null;
+  brand: string | undefined;
 }
 
 export interface DoctorFlags {
@@ -24,7 +24,7 @@ const STRING_FLAGS = new Set(["--config", "--brand"]);
  * Splits comma-separated values for --only, --skip, --group.
  */
 export function parseInitFlags(args: readonly string[]): InitFlags {
-  const flags: InitFlags = { only: null, skip: new Set(), group: null, config: null, brand: null };
+  const flags: InitFlags = { only: null, skip: new Set(), group: null, config: null, brand: undefined };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -5,6 +5,7 @@ export interface InitFlags {
   skip: Set<string>;
   group: Set<string> | null;
   config: string | null;
+  brand: string | null;
 }
 
 export interface DoctorFlags {
@@ -16,14 +17,14 @@ export interface UpgradeFlags {
 }
 
 const SET_FLAGS = new Set(["--only", "--skip", "--group"]);
-const STRING_FLAGS = new Set(["--config"]);
+const STRING_FLAGS = new Set(["--config", "--brand"]);
 
 /**
  * Parse init-specific flags from argv (after the "init" command is consumed).
  * Splits comma-separated values for --only, --skip, --group.
  */
 export function parseInitFlags(args: readonly string[]): InitFlags {
-  const flags: InitFlags = { only: null, skip: new Set(), group: null, config: null };
+  const flags: InitFlags = { only: null, skip: new Set(), group: null, config: null, brand: null };
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -44,6 +45,10 @@ export function parseInitFlags(args: readonly string[]): InitFlags {
         continue;
       }
       if (arg === "--config") flags.config = value;
+      else if (arg === "--brand") flags.brand = value;
+    } else if (arg.startsWith("--")) {
+      process.stderr.write(`Unknown flag: ${arg}\nRun 'devlair init --help' for usage.\n`);
+      process.exit(1);
     }
   }
 

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -5,7 +5,7 @@ export interface InitFlags {
   skip: Set<string>;
   group: Set<string> | null;
   config: string | null;
-  brand: string | undefined;
+  brand?: string;
 }
 
 export interface DoctorFlags {


### PR DESCRIPTION
## Summary

- Adds `--brand <name>` flag to `devlair init` — replaces the hardcoded "d e v l a i r" label in the logo and the subtitle line with the provided value
- Logo component now accepts an optional `brand` prop; all three size variants (full/medium/short) honour it, including the inner-box width calculation
- Unknown flags now exit 1 with a clear error message instead of being silently ignored

Closes #160

## Test plan

- [ ] `devlair init --brand serena` shows "serena" in the logo box and subtitle
- [ ] `devlair init` (no flag) still shows "d e v l a i r" unchanged
- [ ] `devlair init --brand serena --group core` (non-interactive path) shows the brand
- [ ] `devlair init --unknown-flag` prints "Unknown flag: --unknown-flag" and exits 1
- [ ] lint passes (`bun run lint`)
- [ ] 168 tests pass (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)