### PR TITLE
fix(macos): root-aware modules, home dir, remove FDA-gated system modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 
 ## What gets installed
 
-`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`, `ssh`, `timezone`. Linux-only modules (auto-skipped elsewhere): `firewall`, `gnome_terminal`.
+`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. Linux-only modules (auto-skipped elsewhere): `firewall`, `gnome_terminal`, `ssh`, `timezone`.
 
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
@@ -199,7 +199,7 @@ Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `
 <details>
 <summary><b>Timezone</b> — interactive timezone configuration</summary>
 
-Displays the current timezone and prompts for a new one. On Linux/WSL, uses `timedatectl set-timezone`. On macOS, sets the timezone by symlinking `/etc/localtime` to `/usr/share/zoneinfo/<tz>` (compatible with macOS 15+). The configured timezone is IANA-validated before being applied; `do_check` reports `fail` when the timezone cannot be read.
+Displays the current timezone and prompts for a new one. Uses `timedatectl set-timezone` on Linux/WSL. The configured timezone is IANA-validated before being applied; `do_check` reports `fail` when the timezone cannot be read. Linux-only — auto-skipped on WSL and macOS.
 
 </details>
 
@@ -219,9 +219,7 @@ Creates `/etc/ssh/sshd_config.d/99-hardened.conf` with:
 - Max 3 auth attempts
 - ListenAddress restricted to Tailscale IP (when available)
 
-Prompts for your SSH public key if `authorized_keys` is empty.
-
-On macOS, enables Remote Login via `systemsetup -setremotelogin on` and manages `sshd` through `launchctl`. The hardened config drop-in and authorized_keys setup are identical across platforms.
+Prompts for your SSH public key if `authorized_keys` is empty. Linux-only — auto-skipped on macOS and WSL.
 
 </details>
 

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -93,6 +93,20 @@ ctx_get_config() {
 # cmd_exists NAME -- check if a command is available on PATH.
 cmd_exists() { command -v "$1" >/dev/null 2>&1; }
 
+# _is_root -- true when the effective UID is 0.
+# Caches the result in a string to avoid repeated subshell forks.
+_IS_ROOT_CACHED=""
+_is_root() {
+  if [[ -z "$_IS_ROOT_CACHED" ]]; then
+    if [[ "$(id -u)" == "0" ]]; then
+      _IS_ROOT_CACHED="true"
+    else
+      _IS_ROOT_CACHED="false"
+    fi
+  fi
+  [[ "$_IS_ROOT_CACHED" == "true" ]]
+}
+
 # apt_install PKG... -- install packages quietly with a progress event.
 apt_install() {
   json_progress "installing $*"
@@ -104,7 +118,7 @@ apt_install() {
 # because Homebrew refuses to run as root.
 brew_install() {
   json_progress "installing $*"
-  if [[ "$(id -u)" == "0" ]]; then
+  if _is_root; then
     sudo -u "${USERNAME:?USERNAME not set}" brew install --quiet "$@" >&2
   else
     brew install --quiet "$@" >&2
@@ -120,7 +134,7 @@ brew_ensure() {
   if cmd_exists brew; then
     return 0
   fi
-  if [[ "$(id -u)" == "0" ]] && sudo -u "${USERNAME:?USERNAME not set}" command -v brew >/dev/null 2>&1; then
+  if _is_root && sudo -u "${USERNAME:?USERNAME not set}" command -v brew >/dev/null 2>&1; then
     # brew is installed for the target user; PATH just isn't set for root
     eval "$(sudo -u "$USERNAME" brew shellenv 2>/dev/null)" || true
     return 0
@@ -128,7 +142,7 @@ brew_ensure() {
   json_progress "installing Homebrew"
   local tmp
   tmp=$(download_script "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh")
-  if [[ "$(id -u)" == "0" ]]; then
+  if _is_root; then
     sudo -u "${USERNAME:?USERNAME not set}" NONINTERACTIVE=1 bash "$tmp" >&2
   else
     NONINTERACTIVE=1 bash "$tmp" >&2
@@ -162,7 +176,7 @@ run_shell_as() {
 # When running as root (sudo devlair init), drops privileges via sudo -u.
 # Requires USERNAME to be set (done after read_context).
 _run_as_user() {
-  if [[ "$(id -u)" == "0" ]]; then
+  if _is_root; then
     run_shell_as "${USERNAME:?USERNAME not set}" "$1"
   else
     bash -c "$1"

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -100,22 +100,39 @@ apt_install() {
 }
 
 # brew_install PKG... -- install Homebrew packages quietly with a progress event.
+# When running as root (sudo devlair init on macOS), drops to the target user
+# because Homebrew refuses to run as root.
 brew_install() {
   json_progress "installing $*"
-  brew install --quiet "$@" >&2
+  if [[ "$(id -u)" == "0" ]]; then
+    sudo -u "${USERNAME:?USERNAME not set}" brew install --quiet "$@" >&2
+  else
+    brew install --quiet "$@" >&2
+  fi
 }
 
 # brew_ensure -- ensure Homebrew is on PATH, installing it if absent.
 # Uses download-then-execute to avoid piping curl to bash directly.
 # After install, sources brew shellenv so subsequent brew calls work.
+# When running as root, installs and invokes brew as the target user.
 brew_ensure() {
+  # Check if brew is accessible (either as root or as the target user)
   if cmd_exists brew; then
+    return 0
+  fi
+  if [[ "$(id -u)" == "0" ]] && sudo -u "${USERNAME:?USERNAME not set}" command -v brew >/dev/null 2>&1; then
+    # brew is installed for the target user; PATH just isn't set for root
+    eval "$(sudo -u "$USERNAME" brew shellenv 2>/dev/null)" || true
     return 0
   fi
   json_progress "installing Homebrew"
   local tmp
   tmp=$(download_script "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh")
-  NONINTERACTIVE=1 bash "$tmp" >&2
+  if [[ "$(id -u)" == "0" ]]; then
+    sudo -u "${USERNAME:?USERNAME not set}" NONINTERACTIVE=1 bash "$tmp" >&2
+  else
+    NONINTERACTIVE=1 bash "$tmp" >&2
+  fi
   rm -f "$tmp"
   # Add brew to PATH for the remainder of this script session
   if [[ -x /opt/homebrew/bin/brew ]]; then
@@ -140,14 +157,15 @@ run_shell_as() {
   sudo -u "$user" bash -c "$script"
 }
 
-# _run_as_user SCRIPT -- run a shell script as the module's target user on
-# Linux, or directly in the current shell on macOS (where sudo is not needed).
-# Requires USERNAME and PLATFORM to be set (done after read_context).
+# _run_as_user SCRIPT -- run a shell script as the module's target user.
+# When already running as that user (no sudo), executes directly.
+# When running as root (sudo devlair init), drops privileges via sudo -u.
+# Requires USERNAME to be set (done after read_context).
 _run_as_user() {
-  if [[ "${PLATFORM:-}" == "macos" ]]; then
-    bash -c "$1"
-  else
+  if [[ "$(id -u)" == "0" ]]; then
     run_shell_as "${USERNAME:?USERNAME not set}" "$1"
+  else
+    bash -c "$1"
   fi
 }
 

--- a/cli/modules/github.sh
+++ b/cli/modules/github.sh
@@ -33,8 +33,8 @@ do_run() {
   json_progress "generating SSH key"
   mkdir -p "$USER_HOME/.ssh"
   chmod 700 "$USER_HOME/.ssh"
-  [[ "$(id -u)" == "0" ]] && chown_user "$USER_HOME/.ssh"
-  if [[ "$(id -u)" == "0" ]]; then
+  _is_root && chown_user "$USER_HOME/.ssh"
+  if _is_root; then
     run_as "$USERNAME" ssh-keygen -t ed25519 -C "$email" -f "$gh_key" -N "" >&2
   else
     ssh-keygen -t ed25519 -C "$email" -f "$gh_key" -N "" >&2
@@ -68,21 +68,37 @@ Host github.com
 EOF
     fi
     chmod 600 "$ssh_conf"
-    [[ "$(id -u)" == "0" ]] && chown_user "$ssh_conf"
+    _is_root && chown_user "$ssh_conf"
   fi
 
   # Add key to macOS Keychain so it persists across reboots
   if [[ "$PLATFORM" == "macos" ]]; then
-    _run_as_user "ssh-add --apple-use-keychain \"$gh_key\"" >&2 || true
+    if _is_root; then
+      run_as "$USERNAME" ssh-add --apple-use-keychain "$gh_key" >&2 || true
+    else
+      ssh-add --apple-use-keychain "$gh_key" >&2 || true
+    fi
   fi
 
-  _run_as_user "git config --global user.email \"$email\"" >&2
+  if _is_root; then
+    run_as "$USERNAME" git config --global user.email "$email" >&2
+  else
+    git config --global user.email "$email" >&2
+  fi
   local git_name
   git_name=$(ctx_get_config github_name)
   if [[ -n "$git_name" ]]; then
-    _run_as_user "git config --global user.name \"$git_name\"" >&2
+    if _is_root; then
+      run_as "$USERNAME" git config --global user.name "$git_name" >&2
+    else
+      git config --global user.name "$git_name" >&2
+    fi
   fi
-  _run_as_user "git config --global init.defaultBranch main" >&2
+  if _is_root; then
+    run_as "$USERNAME" git config --global init.defaultBranch main >&2
+  else
+    git config --global init.defaultBranch main >&2
+  fi
 
   # Surface the public key and wait for the user to add it to GitHub.
   local pub

--- a/cli/modules/github.sh
+++ b/cli/modules/github.sh
@@ -33,10 +33,11 @@ do_run() {
   json_progress "generating SSH key"
   mkdir -p "$USER_HOME/.ssh"
   chmod 700 "$USER_HOME/.ssh"
-  if [[ "$PLATFORM" == "macos" ]]; then
-    ssh-keygen -t ed25519 -C "$email" -f "$gh_key" -N "" >&2
-  else
+  [[ "$(id -u)" == "0" ]] && chown_user "$USER_HOME/.ssh"
+  if [[ "$(id -u)" == "0" ]]; then
     run_as "$USERNAME" ssh-keygen -t ed25519 -C "$email" -f "$gh_key" -N "" >&2
+  else
+    ssh-keygen -t ed25519 -C "$email" -f "$gh_key" -N "" >&2
   fi
 
   # SSH config entry (idempotent)
@@ -67,33 +68,21 @@ Host github.com
 EOF
     fi
     chmod 600 "$ssh_conf"
-    [[ "$PLATFORM" != "macos" ]] && chown_user "$ssh_conf"
+    [[ "$(id -u)" == "0" ]] && chown_user "$ssh_conf"
   fi
 
   # Add key to macOS Keychain so it persists across reboots
   if [[ "$PLATFORM" == "macos" ]]; then
-    ssh-add --apple-use-keychain "$gh_key" >&2 || true
+    _run_as_user "ssh-add --apple-use-keychain \"$gh_key\"" >&2 || true
   fi
 
-  if [[ "$PLATFORM" == "macos" ]]; then
-    git config --global user.email "$email" >&2
-  else
-    run_as "$USERNAME" git config --global user.email "$email" >&2
-  fi
+  _run_as_user "git config --global user.email \"$email\"" >&2
   local git_name
   git_name=$(ctx_get_config github_name)
   if [[ -n "$git_name" ]]; then
-    if [[ "$PLATFORM" == "macos" ]]; then
-      git config --global user.name "$git_name" >&2
-    else
-      run_as "$USERNAME" git config --global user.name "$git_name" >&2
-    fi
+    _run_as_user "git config --global user.name \"$git_name\"" >&2
   fi
-  if [[ "$PLATFORM" == "macos" ]]; then
-    git config --global init.defaultBranch main >&2
-  else
-    run_as "$USERNAME" git config --global init.defaultBranch main >&2
-  fi
+  _run_as_user "git config --global init.defaultBranch main" >&2
 
   # Surface the public key and wait for the user to add it to GitHub.
   local pub

--- a/cli/modules/tmux.sh
+++ b/cli/modules/tmux.sh
@@ -29,12 +29,12 @@ do_run() {
 
   json_progress "writing tmux config"
   cp "$SCRIPT_DIR/configs/tmux.conf" "$conf"
-  [[ "$PLATFORM" != "macos" ]] && chown_user "$conf"
+  [[ "$(id -u)" == "0" ]] && chown_user "$conf"
 
   # TPM (tmux plugin manager)
   local plugins_dir="$USER_HOME/.tmux/plugins"
   mkdir -p "$plugins_dir"
-  if [[ "$PLATFORM" != "macos" ]]; then
+  if [[ "$(id -u)" == "0" ]]; then
     chown_user "$USER_HOME/.tmux"
     chown_user "$plugins_dir"
   fi
@@ -42,10 +42,10 @@ do_run() {
   local tpm_path="$plugins_dir/tpm"
   if [[ ! -d "$tpm_path" ]]; then
     json_progress "installing TPM"
-    if [[ "$PLATFORM" == "macos" ]]; then
-      git clone https://github.com/tmux-plugins/tpm "$tpm_path" >&2
-    else
+    if [[ "$(id -u)" == "0" ]]; then
       run_as "$USERNAME" git clone https://github.com/tmux-plugins/tpm "$tpm_path" >&2
+    else
+      git clone https://github.com/tmux-plugins/tpm "$tpm_path" >&2
     fi
   fi
 
@@ -53,10 +53,10 @@ do_run() {
   local install_script="$tpm_path/bin/install_plugins"
   if [[ -x "$install_script" ]]; then
     json_progress "installing TPM plugins"
-    if [[ "$PLATFORM" == "macos" ]]; then
-      "$install_script" >&2 || true
-    else
+    if [[ "$(id -u)" == "0" ]]; then
       run_as "$USERNAME" "$install_script" >&2 || true
+    else
+      "$install_script" >&2 || true
     fi
   fi
 

--- a/cli/modules/tmux.sh
+++ b/cli/modules/tmux.sh
@@ -29,12 +29,12 @@ do_run() {
 
   json_progress "writing tmux config"
   cp "$SCRIPT_DIR/configs/tmux.conf" "$conf"
-  [[ "$(id -u)" == "0" ]] && chown_user "$conf"
+  _is_root && chown_user "$conf"
 
   # TPM (tmux plugin manager)
   local plugins_dir="$USER_HOME/.tmux/plugins"
   mkdir -p "$plugins_dir"
-  if [[ "$(id -u)" == "0" ]]; then
+  if _is_root; then
     chown_user "$USER_HOME/.tmux"
     chown_user "$plugins_dir"
   fi
@@ -42,7 +42,7 @@ do_run() {
   local tpm_path="$plugins_dir/tpm"
   if [[ ! -d "$tpm_path" ]]; then
     json_progress "installing TPM"
-    if [[ "$(id -u)" == "0" ]]; then
+    if _is_root; then
       run_as "$USERNAME" git clone https://github.com/tmux-plugins/tpm "$tpm_path" >&2
     else
       git clone https://github.com/tmux-plugins/tpm "$tpm_path" >&2
@@ -53,7 +53,7 @@ do_run() {
   local install_script="$tpm_path/bin/install_plugins"
   if [[ -x "$install_script" ]]; then
     json_progress "installing TPM plugins"
-    if [[ "$(id -u)" == "0" ]]; then
+    if _is_root; then
       run_as "$USERNAME" "$install_script" >&2 || true
     else
       "$install_script" >&2 || true

--- a/cli/src/lib/context.ts
+++ b/cli/src/lib/context.ts
@@ -15,9 +15,10 @@ export function resolveInvokingUser(): [username: string, homeDir: string] {
   const sudoUser = process.env.SUDO_USER;
   if (sudoUser && sudoUser !== "root" && VALID_USERNAME_RE.test(sudoUser)) {
     // SUDO_HOME is non-standard; only honor it when it points to a conventional
-    // user home for the same name. Otherwise derive /home/<user>.
+    // user home for the same name. Otherwise derive the platform default.
     const claimed = process.env.SUDO_HOME;
-    const home = claimed && isSafeHome(claimed, sudoUser) ? claimed : `/home/${sudoUser}`;
+    const defaultHome = process.platform === "darwin" ? `/Users/${sudoUser}` : `/home/${sudoUser}`;
+    const home = claimed && isSafeHome(claimed, sudoUser) ? claimed : defaultHome;
     return [sudoUser, home];
   }
   const info = userInfo({ encoding: "utf8" });

--- a/cli/src/lib/context.ts
+++ b/cli/src/lib/context.ts
@@ -8,7 +8,7 @@ import type { ModuleContext, Platform } from "./types.js";
 const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/;
 
 function isSafeHome(path: string, username: string): boolean {
-  return path === `/home/${username}` || path === `/Users/${username}`;
+  return path === (process.platform === "darwin" ? `/Users/${username}` : `/home/${username}`);
 }
 
 export function resolveInvokingUser(): [username: string, homeDir: string] {

--- a/cli/src/lib/modules.ts
+++ b/cli/src/lib/modules.ts
@@ -39,9 +39,9 @@ function spec(
 
 export const MODULE_SPECS: readonly ModuleSpec[] = [
   spec("system", "System update", "core", { platforms: ["linux", "wsl", "macos"] }),
-  spec("timezone", "Timezone", "core", { platforms: ["linux", "macos"] }),
+  spec("timezone", "Timezone", "core", { platforms: ["linux"] }),
   spec("tailscale", "Tailscale", "network", { defaultOn: ["linux"] }),
-  spec("ssh", "SSH", "network", { deps: ["tailscale"], platforms: ["linux", "macos"] }),
+  spec("ssh", "SSH", "network", { deps: ["tailscale"], platforms: ["linux"] }),
   spec("firewall", "Firewall + Fail2Ban", "network", { deps: ["ssh"], platforms: ["linux"] }),
   spec("zsh", "Zsh + Dracula", "core", { reapply: true, platforms: ["linux", "wsl", "macos"] }),
   spec("tmux", "tmux", "coding", { reapply: true, platforms: ["linux", "wsl", "macos"] }),

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -111,9 +111,11 @@ describe("resolveOrder", () => {
     const macosSpecs = resolveOrder(undefined, "macos");
     const macosKeys = macosSpecs.map((s) => s.key);
     expect(macosKeys).toContain("system");
-    expect(macosKeys).toContain("ssh");
-    expect(macosKeys).toContain("timezone");
-    // Linux/WSL-only modules are excluded
+    expect(macosKeys).toContain("zsh");
+    expect(macosKeys).toContain("devtools");
+    // Linux-only modules are excluded on macOS
+    expect(macosKeys).not.toContain("ssh");
+    expect(macosKeys).not.toContain("timezone");
     expect(macosKeys).not.toContain("firewall");
     expect(macosKeys).not.toContain("gnome_terminal");
   });


### PR DESCRIPTION
## Summary

- `_lib.sh`: `brew_install`, `brew_ensure`, `_run_as_user` now check `id -u` and drop to `sudo -u $USERNAME` when running as root — fixes "Don't run this as root!" from Homebrew under `sudo devlair init`
- `github.sh` / `tmux.sh`: all privilege-dropping and chown calls changed from platform-aware (`$PLATFORM == macos`) to root-aware (`id -u == 0`)
- `context.ts`: home dir fallback is now `/Users/<user>` on Darwin instead of `/home/<user>` when `SUDO_HOME` is not set
- `modules.ts`: remove `"macos"` from `ssh` and `timezone` platforms — both require Full Disk Access privileges that devlair cannot reliably obtain on macOS 13+

Closes #185

## Test plan

- [ ] `sudo devlair init` on macOS no longer shows "Don't run this as root!" during system, zsh, tmux, devtools modules <!-- needs-manual: requires macOS + sudo environment -->
- [x] Home dir resolves to `/Users/<user>` (not `/home/<user>`) when running under sudo on macOS (`context.ts:20` — `process.platform === "darwin" ? /Users/${sudoUser} : /home/${sudoUser}`)
- [x] SSH and Timezone modules are hidden on macOS (not shown in wizard, not run non-interactively) (`modules.ts:42,44` — both specs now have `platforms: ["linux"]` only)
- [x] `bun run lint` passes (biome)
- [x] `bun run typecheck` passes (tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
