### PR TITLE
fix(ci): bump bun to 1.3.12 and stabilise pruneOldRuns sort

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.17'
+          bun-version: '1.3.12'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.17'
+          bun-version: '1.3.12'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.2.17'
+          bun-version: '1.3.12'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/cli/src/lib/logs.ts
+++ b/cli/src/lib/logs.ts
@@ -93,7 +93,7 @@ function pruneOldRuns(logsRoot: string, keep: number): void {
     return;
   }
   if (entries.length <= keep) return;
-  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name));
   for (const stale of entries.slice(keep)) {
     const path = join(logsRoot, stale.name);
     try {


### PR DESCRIPTION
## Summary

- Bump CI bun from `1.2.17` to `1.3.12` (matches local; bun 1.2.17 has a regression where `utimesSync` does not reliably persist mtime on directories)
- Add name tiebreaker to `pruneOldRuns` sort (`|| b.name.localeCompare(a.name)`) so pruning is deterministic even when two entries share the same `mtimeMs` — guards against filesystem mtime coarseness or future bun regressions

The release-please CI (PR #187) was failing on `createInitLogDir > prunes older runs` because bun 1.2.17's `utimesSync` silently no-ops on directories, making the mtime-based sort indeterminate and leaving the oldest entry un-pruned.

Closes #190

## Test plan

- [ ] CI passes on this PR (bun 1.3.12 test job green)
- [x] `createInitLogDir > prunes older runs, keeping the 10 most recent` passes <!-- code-verified: logs.ts:96 tiebreaker makes sort deterministic; 3/3 local runs pass -->
- [ ] Release-please PR #187 CI goes green after this merges to main <!-- needs-manual: post-merge verification -->
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun test` passes (169/169)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
