### PR TITLE
fix(init): skip sudo elevation on macOS, fix chown group format

### DIFF
--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -195,10 +195,11 @@ download_script() {
 
 # chown_user FILE -- chown a file to the module's target user.
 # Reads USERNAME from the caller's scope (set after read_context).
-chown_user() { chown "${USERNAME:?USERNAME not set}:${USERNAME}" "$1"; }
+# Owner only (no group): macOS primary group is "staff", not the username.
+chown_user() { chown "${USERNAME:?USERNAME not set}" "$1"; }
 
 # chown_user_r DIR -- recursive chown to the target user.
-chown_user_r() { chown -R "${USERNAME:?USERNAME not set}:${USERNAME}" "$1"; }
+chown_user_r() { chown -R "${USERNAME:?USERNAME not set}" "$1"; }
 
 # update_json FILE PATCH_JSON -- shallow-merge a JSON patch into a file.
 # Creates the file with the patch content if it does not exist.

--- a/cli/src/lib/elevate.ts
+++ b/cli/src/lib/elevate.ts
@@ -7,6 +7,9 @@
 import { spawnSync } from "node:child_process";
 
 export function elevateIfNeeded(): void {
+  // macOS: Homebrew refuses to run as root, and all macOS modules install to
+  // user space via brew/curl. Elevation is neither needed nor safe on macOS.
+  if (process.platform === "darwin") return;
   if (process.getuid?.() === 0) return;
 
   // Preserve only the env vars we need — blanket -E would forward secrets


### PR DESCRIPTION
## Summary

- Skip `sudo` re-exec in `elevateIfNeeded()` when `process.platform === "darwin"` — Homebrew explicitly refuses to run as root, and all macOS modules install to user space via brew/curl. Elevation causes failures, not prevented.
- Drop the group component from `chown_user`/`chown_user_r`: macOS has no user-named group (primary group is `staff`), so `chown user:user` fails with "illegal group name". Owner-only chown is correct on both Linux and macOS.

Closes #192

## Test plan

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun test` passes (169/169)
- [ ] `devlair init` (without sudo) runs successfully on macOS — homebrew, zsh, tmux, devtools, shell, claude modules all complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)