### PR TITLE
fix(macos): run Homebrew pre-flight before Ink starts for TTY access

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,12 @@ devlair hooks into Claude Code to track session usage and display a dashboard:
 
 ## What gets installed
 
-`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. macOS-only modules (auto-skipped on Linux/WSL): `homebrew` (Homebrew preamble — installed automatically as a dependency of `zsh`, `tmux`, and `devtools` on macOS). Linux-only modules (auto-skipped elsewhere): `firewall`, `gnome_terminal`, `ssh`, `timezone`.
+`devlair init` runs these modules in order. Some modules are **opt-in** and not included in a default run — use `devlair init --only <module>` or `--group` to enable them. Opt-in modules: `claude`; `tailscale` is opt-in on WSL and macOS. Portable modules (supported on Linux, WSL, and macOS): `system`, `tailscale`, `zsh`, `tmux`, `rclone`, `github`, `shell`, `claude`, `devtools`. macOS-only modules (auto-skipped on Linux/WSL): `homebrew` (Homebrew preamble — on macOS, `ensureHomebrew()` runs before the Ink UI starts so the installer has full TTY access for sudo prompts; the `homebrew` module is a dependency of `system`, `zsh`, `tmux`, and `devtools` on macOS). Linux-only modules (auto-skipped elsewhere): `firewall`, `gnome_terminal`, `ssh`, `timezone`.
 
 <details>
 <summary><b>System</b> — OS packages and essentials</summary>
 
-Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `htop`, `tmux`, `zsh`, `bat`, `fzf`, `build-essential`, and more. On bare Linux it also installs `openssh-server`, `ufw`, `fail2ban`, and `avahi-daemon`; these are skipped on WSL because they ship systemd-managed postinst scripts that don't work under WSL's systemd-less default (the dedicated `ssh` and `firewall` modules are also Linux-only). On macOS, the module ensures Homebrew is installed, runs `brew update && brew upgrade`, and installs a set of macOS essentials via `brew install` (`git`, `curl`, `wget`, `vim`, `htop`, `tmux`, `unzip`, `jq`, `tree`, `rsync`, `zsh`, `bat`, `fzf`, `gnupg`).
+Runs `apt update && upgrade` and installs core packages: `git`, `curl`, `vim`, `htop`, `tmux`, `zsh`, `bat`, `fzf`, `build-essential`, and more. On bare Linux it also installs `openssh-server`, `ufw`, `fail2ban`, and `avahi-daemon`; these are skipped on WSL because they ship systemd-managed postinst scripts that don't work under WSL's systemd-less default (the dedicated `ssh` and `firewall` modules are also Linux-only). On macOS, Homebrew is guaranteed to be on PATH before this module runs (installed by the pre-flight `ensureHomebrew()` call in `index.tsx`). The module runs `brew update && brew upgrade` and installs a set of macOS essentials via `brew install` (`git`, `curl`, `wget`, `vim`, `htop`, `tmux`, `unzip`, `jq`, `tree`, `rsync`, `zsh`, `bat`, `fzf`, `gnupg`).
 
 </details>
 
@@ -421,7 +421,7 @@ cli/                    # v2 TypeScript CLI (stable)
     components/         # Ink UI components (Logo, Help, Progress, Summary)
     wizard/             # interactive wizard (GroupSelect, ModuleSelect, Confirmation, GithubConfig)
     lib/                # theme, types, runner, modules, platform detection,
-                        # args, selection, profiles, jsonConfig, elevate
+                        # args, selection, profiles, jsonConfig, elevate, homebrew
   modules/              # shell modules executed by the v2 binary
                         # (packaged into modules.tar.gz on release)
 assets/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-devlair automates the setup of a fresh Ubuntu server, workstation, or WSL instance — installing tools,
+devlair automates the setup of a fresh Ubuntu server, workstation, WSL instance, or macOS machine — installing tools,
 hardening security, configuring shell and terminal with the [Dracula](https://draculatheme.com) theme,
 and wiring up dev toolchains. Run it once on a fresh machine or re-run anytime to converge.
 

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -34,8 +34,6 @@ MACOS_ESSENTIALS=( git curl wget vim htop tmux unzip jq tree rsync zsh bat fzf g
 
 do_run() {
   if [[ "$PLATFORM" == "macos" ]]; then
-    # brew is guaranteed by the pre-flight in index.tsx (ensureHomebrew) and
-    # the homebrew module which runs before system. brew_ensure configures PATH.
     brew_ensure
     json_progress "updating Homebrew"
     brew update --quiet >&2

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -34,6 +34,8 @@ MACOS_ESSENTIALS=( git curl wget vim htop tmux unzip jq tree rsync zsh bat fzf g
 
 do_run() {
   if [[ "$PLATFORM" == "macos" ]]; then
+    # brew is guaranteed by the pre-flight in index.tsx (ensureHomebrew) and
+    # the homebrew module which runs before system. brew_ensure configures PATH.
     brew_ensure
     json_progress "updating Homebrew"
     brew update --quiet >&2

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -20,6 +20,7 @@ import {
   parseUpgradeFlags,
 } from "./lib/args.js";
 import { elevateIfNeeded } from "./lib/elevate.js";
+import { ensureHomebrew } from "./lib/homebrew.js";
 import { D_FG } from "./lib/theme.js";
 
 const VERSION = pkg.version;
@@ -88,6 +89,12 @@ async function main() {
 
   if (ELEVATED_COMMANDS.has(command.type)) {
     elevateIfNeeded();
+    // macOS: install Homebrew before Ink starts so the installer has full TTY
+    // access for its sudo password prompt. All subsequent brew calls in modules
+    // assume brew is on PATH — this is the single point of installation.
+    if (process.platform === "darwin") {
+      ensureHomebrew();
+    }
   }
 
   if (command.type === "help" || command.type === "version") {

--- a/cli/src/lib/homebrew.ts
+++ b/cli/src/lib/homebrew.ts
@@ -65,8 +65,7 @@ export function ensureHomebrew(): void {
 
   if (install.status !== 0) {
     process.stderr.write(
-      "\nError: Homebrew installation failed.\n" +
-        "Visit https://brew.sh for manual installation instructions.\n",
+      "\nError: Homebrew installation failed.\n" + "Visit https://brew.sh for manual installation instructions.\n",
     );
     process.exit(1);
   }

--- a/cli/src/lib/homebrew.ts
+++ b/cli/src/lib/homebrew.ts
@@ -15,13 +15,17 @@ import { execSync, spawnSync } from "node:child_process";
 const BREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
 const INSTALL_URL = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh";
 
+function brewBinDir(brewBin: string): string {
+  return brewBin.replace(/\/brew$/, "");
+}
+
 function brewPath(): string | null {
   for (const p of BREW_PATHS) {
     try {
       execSync(`test -x "${p}"`, { stdio: "ignore" });
       return p;
     } catch {
-      // not found at this path
+      // ignore
     }
   }
   return null;
@@ -34,16 +38,15 @@ export function ensureHomebrew(): void {
     // module scripts inherit it via the environment.
     try {
       const shellenv = execSync(`"${existing}" shellenv`, { encoding: "utf8" });
-      // Parse and apply each export line into process.env
+      const SAFE_BREW_VARS = new Set(["PATH", "HOMEBREW_PREFIX", "HOMEBREW_CELLAR", "HOMEBREW_REPOSITORY"]);
       for (const line of shellenv.split("\n")) {
         const m = line.match(/^export ([A-Z_]+)="(.*)"/);
-        if (m) process.env[m[1]] = m[2];
+        if (m && SAFE_BREW_VARS.has(m[1])) process.env[m[1]] = m[2];
       }
     } catch {
       // Non-fatal: brew shellenv failure means PATH may be incomplete, but
       // brew itself is usable if the caller found it at a known path.
-      const dir = existing.replace(/\/brew$/, "");
-      process.env.PATH = `${dir}:${process.env.PATH ?? ""}`;
+      process.env.PATH = `${brewBinDir(existing)}:${process.env.PATH ?? ""}`;
     }
     return;
   }
@@ -53,6 +56,10 @@ export function ensureHomebrew(): void {
   process.stdout.write("You may be prompted for your password.\n\n");
 
   const tmp = spawnSync("mktemp", { encoding: "utf8" }).stdout.trim();
+  if (!tmp) {
+    process.stderr.write("Error: could not create temp file.\n");
+    process.exit(1);
+  }
   const dl = spawnSync("curl", ["-fsSL", INSTALL_URL, "-o", tmp], { stdio: "inherit" });
   if (dl.status !== 0) {
     process.stderr.write("Error: failed to download the Homebrew installer.\n");
@@ -70,12 +77,10 @@ export function ensureHomebrew(): void {
     process.exit(1);
   }
 
-  // Add brew to PATH for this process and all child module scripts.
   const installed = brewPath();
   if (!installed) {
     process.stderr.write("Error: Homebrew installed but brew not found at expected paths.\n");
     process.exit(1);
   }
-  const dir = installed.replace(/\/brew$/, "");
-  process.env.PATH = `${dir}:${process.env.PATH ?? ""}`;
+  process.env.PATH = `${brewBinDir(installed)}:${process.env.PATH ?? ""}`;
 }

--- a/cli/src/lib/homebrew.ts
+++ b/cli/src/lib/homebrew.ts
@@ -1,0 +1,82 @@
+/**
+ * Homebrew pre-flight for macOS.
+ *
+ * Must be called BEFORE Ink rendering starts — the Homebrew installer needs
+ * full TTY access so it can prompt for a sudo password when creating
+ * /opt/homebrew (Apple Silicon) or /usr/local (Intel). Module subprocesses
+ * run with piped stdin (JSON context) and cannot receive sudo prompts.
+ *
+ * After this function returns, brew is guaranteed to be on PATH. If
+ * installation fails, the process exits with a human-readable error.
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+
+const BREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
+const INSTALL_URL = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh";
+
+function brewPath(): string | null {
+  for (const p of BREW_PATHS) {
+    try {
+      execSync(`test -x "${p}"`, { stdio: "ignore" });
+      return p;
+    } catch {
+      // not found at this path
+    }
+  }
+  return null;
+}
+
+export function ensureHomebrew(): void {
+  const existing = brewPath();
+  if (existing) {
+    // Already installed — add to PATH for the current process so child
+    // module scripts inherit it via the environment.
+    try {
+      const shellenv = execSync(`"${existing}" shellenv`, { encoding: "utf8" });
+      // Parse and apply each export line into process.env
+      for (const line of shellenv.split("\n")) {
+        const m = line.match(/^export ([A-Z_]+)="(.*)"/);
+        if (m) process.env[m[1]] = m[2];
+      }
+    } catch {
+      // Non-fatal: brew shellenv failure means PATH may be incomplete, but
+      // brew itself is usable if the caller found it at a known path.
+      const dir = existing.replace(/\/brew$/, "");
+      process.env.PATH = `${dir}:${process.env.PATH ?? ""}`;
+    }
+    return;
+  }
+
+  // Homebrew not installed — run the installer with full TTY access.
+  process.stdout.write("\nHomebrew is not installed. Installing now...\n");
+  process.stdout.write("You may be prompted for your password.\n\n");
+
+  const tmp = spawnSync("mktemp", { encoding: "utf8" }).stdout.trim();
+  const dl = spawnSync("curl", ["-fsSL", INSTALL_URL, "-o", tmp], { stdio: "inherit" });
+  if (dl.status !== 0) {
+    process.stderr.write("Error: failed to download the Homebrew installer.\n");
+    process.exit(1);
+  }
+
+  // stdio: "inherit" gives the installer full TTY access for sudo prompts.
+  const install = spawnSync("bash", [tmp], { stdio: "inherit" });
+  spawnSync("rm", ["-f", tmp]);
+
+  if (install.status !== 0) {
+    process.stderr.write(
+      "\nError: Homebrew installation failed.\n" +
+        "Visit https://brew.sh for manual installation instructions.\n",
+    );
+    process.exit(1);
+  }
+
+  // Add brew to PATH for this process and all child module scripts.
+  const installed = brewPath();
+  if (!installed) {
+    process.stderr.write("Error: Homebrew installed but brew not found at expected paths.\n");
+    process.exit(1);
+  }
+  const dir = installed.replace(/\/brew$/, "");
+  process.env.PATH = `${dir}:${process.env.PATH ?? ""}`;
+}

--- a/cli/src/lib/modules.ts
+++ b/cli/src/lib/modules.ts
@@ -38,12 +38,12 @@ function spec(
 }
 
 export const MODULE_SPECS: readonly ModuleSpec[] = [
-  spec("system", "System update", "core", { platforms: ["linux", "wsl", "macos"] }),
+  spec("homebrew", "Homebrew", "core", { platforms: ["macos"] }),
+  spec("system", "System update", "core", { deps: ["homebrew"], platforms: ["linux", "wsl", "macos"] }),
   spec("timezone", "Timezone", "core", { platforms: ["linux"] }),
   spec("tailscale", "Tailscale", "network", { defaultOn: ["linux"] }),
   spec("ssh", "SSH server", "network", { deps: ["tailscale"], platforms: ["linux"] }),
   spec("firewall", "Firewall + Fail2Ban", "network", { deps: ["ssh"], platforms: ["linux"] }),
-  spec("homebrew", "Homebrew", "core", { platforms: ["macos"] }),
   spec("zsh", "Zsh + Dracula", "core", { reapply: true, deps: ["homebrew"], platforms: ["linux", "wsl", "macos"] }),
   spec("tmux", "tmux", "coding", { reapply: true, deps: ["homebrew"], platforms: ["linux", "wsl", "macos"] }),
   spec("devtools", "Dev tools", "coding", { reapply: true, deps: ["homebrew"], platforms: ["linux", "wsl", "macos"] }),

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -139,12 +139,12 @@ describe("resolveOrder", () => {
 
   test("produces correct topological ordering", () => {
     const expectedOrder = [
+      "homebrew",
       "system",
       "timezone",
       "tailscale",
       "ssh",
       "firewall",
-      "homebrew",
       "zsh",
       "tmux",
       "devtools",


### PR DESCRIPTION
## Summary

- Add `src/lib/homebrew.ts`: `ensureHomebrew()` runs before Ink rendering on macOS so the Homebrew installer has full TTY access for its sudo password prompt (module subprocesses run with piped stdin and cannot receive prompts).
- Wire `ensureHomebrew()` into `index.tsx` for all elevated commands on macOS (`init`, `doctor`, `upgrade`, `disable-password`).
- Fix `MODULE_SPECS` ordering: move `homebrew` before `system` — `system` declares `deps: ["homebrew"]`, so the DAG validator requires homebrew to appear first in the array.
- Add clarifying comment to `system.sh`: `brew_ensure` configures PATH only; installation is the pre-flight's responsibility.

Closes #198

## Test plan

- [ ] On a fresh macOS machine, `devlair init` prompts for Homebrew installation with full TTY (password prompt visible) before any module runs. <!-- needs-manual: requires a fresh macOS machine without Homebrew -->
- [ ] On a macOS machine with Homebrew already installed, `devlair init` proceeds without reinstalling — `ensureHomebrew()` configures PATH and returns immediately. <!-- needs-manual: requires macOS environment -->
- [x] On Linux/WSL, `devlair init` is unaffected — the `ensureHomebrew()` call is gated on `process.platform === "darwin"`. (verified: `index.tsx:95` wraps call in `if (process.platform === "darwin")`)
- [x] `bun run typecheck` passes (new `homebrew.ts` is correctly typed). (automated: exit 0)
- [x] `bun run lint` passes. (automated: exit 0)
- [x] `bun test` passes. (automated: 169 pass, 0 fail)
- [x] DAG validator (`validateDag()`) no longer throws on macOS init — `homebrew` precedes `system` in `MODULE_SPECS`. (verified: `modules.ts:41` homebrew is first entry, system at line 42 with `deps: ["homebrew"]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
