### PR TITLE
fix(macos): fix claude module for non-root macOS operation

### DIFF
--- a/cli/modules/claude.sh
+++ b/cli/modules/claude.sh
@@ -141,7 +141,7 @@ do_check() {
   # telegram plugin installed
   if cmd_exists claude; then
     local plugins
-    plugins=$(run_as "$USERNAME" claude plugin list --json 2>/dev/null || echo "[]")
+    plugins=$(_run_as_user "claude plugin list --json 2>/dev/null || echo '[]'")
     if echo "$plugins" | jq -e '.[] | select(.name=="telegram" and .marketplace=="claude-plugins-official")' >/dev/null 2>&1; then
       json_check "telegram plugin installed" "ok"
     else

--- a/cli/modules/claude.sh
+++ b/cli/modules/claude.sh
@@ -20,30 +20,30 @@ _install_script() {
   mkdir -p "$bin_dir"
   cp "$src" "$bin_dir/$name"
   chmod 755 "$bin_dir/$name"
-  chown_user "$bin_dir/$name"
-  chown_user "$bin_dir"
+  _is_root && chown_user "$bin_dir/$name"
+  _is_root && chown_user "$bin_dir"
 }
 
 _ensure_telegram_plugin() {
   # Add marketplace if not present
   local marketplaces
-  marketplaces=$(run_as "$USERNAME" claude plugin marketplace list --json 2>/dev/null || echo "[]")
+  marketplaces=$(_run_as_user "claude plugin marketplace list --json 2>/dev/null || echo '[]'")
   if ! echo "$marketplaces" | jq -e '.[] | select(.name=="claude-plugins-official")' >/dev/null 2>&1; then
-    run_as "$USERNAME" claude plugin marketplace add "$TELEGRAM_MARKETPLACE" >&2 || true
+    _run_as_user "claude plugin marketplace add \"$TELEGRAM_MARKETPLACE\"" >&2 || true
   fi
 
   # Install plugin if not present
   local plugins
-  plugins=$(run_as "$USERNAME" claude plugin list --json 2>/dev/null || echo "[]")
+  plugins=$(_run_as_user "claude plugin list --json 2>/dev/null || echo '[]'")
   if ! echo "$plugins" | jq -e '.[] | select(.name=="telegram" and .marketplace=="claude-plugins-official")' >/dev/null 2>&1; then
-    run_as "$USERNAME" claude plugin install "$TELEGRAM_PLUGIN" >&2 || true
+    _run_as_user "claude plugin install \"$TELEGRAM_PLUGIN\"" >&2 || true
   fi
 }
 
 do_run() {
   local claude_dir="$USER_HOME/.claude"
   mkdir -p "$claude_dir"
-  chown_user "$claude_dir"
+  _is_root && chown_user "$claude_dir"
 
   # Install Claude Code CLI if not present
   local install_detail=""
@@ -51,7 +51,7 @@ do_run() {
     json_progress "installing claude code"
     local script
     script=$(download_script "https://claude.ai/install.sh")
-    run_shell_as "$USERNAME" "bash \"$script\"" >&2
+    _run_as_user "bash \"$script\"" >&2
     rm -f "$script"
     json_install "claude" "claude.ai" false
     install_detail="claude code installed"
@@ -63,7 +63,7 @@ do_run() {
   local patch
   patch=$(cat "$SCRIPT_DIR/configs/claude-settings.json")
   update_json "$settings_path" "$patch"
-  chown_user "$settings_path"
+  _is_root && chown_user "$settings_path"
 
   # Install helper scripts
   local bin_dir="$USER_HOME/.devlair/bin"


### PR DESCRIPTION
## Summary

- Guard `chown_user` calls with `_is_root &&` — `chown` fails with EPERM for non-root users even on files they own.
- Replace `run_shell_as "$USERNAME"` with `_run_as_user` — the former always expands to `sudo -u $USERNAME bash`, which fails without root.
- Replace `run_as "$USERNAME"` in `_ensure_telegram_plugin` with `_run_as_user` — same issue for all `claude plugin` subcommands.

`_run_as_user` already handles the root/non-root split correctly for all other modules — this brings `claude.sh` in line.

Closes #201

## Test plan

- [ ] `devlair init --only claude` on macOS runs without EPERM or sudo errors. <!-- needs-manual: requires macOS environment -->
- [ ] Claude Code is installed and `~/.claude/settings.json` is written correctly. <!-- needs-manual: requires macOS environment -->
- [x] On Linux/WSL (root context), `chown_user` and `run_shell_as` still execute — `_is_root` is true so behavior is unchanged. (verified: `_is_root &&` short-circuits to run `chown_user`; `_run_as_user` calls `run_shell_as` when root — `_lib.sh:179-180`)
- [x] `bun test` passes. (automated: 169 pass, 0 fail)
- [x] `bun run lint` passes. (automated: exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
