### PR TITLE
feat(cli): full interactive devlair uninstall

### DIFF
--- a/.github/workflows/e2e-uninstall.yml
+++ b/.github/workflows/e2e-uninstall.yml
@@ -1,0 +1,32 @@
+name: E2E uninstall
+
+# Full teardown end-to-end test: installs devlair the way install.sh does
+# (compiled binary + staged modules), runs `init` for a systemd-free module
+# subset, then `uninstall` and asserts the machine is back to a clean state —
+# login shell restored, packages purged, dotfiles and binary removed, and a
+# second run is idempotent. ubuntu-latest is a real VM (systemd, apt, sudo),
+# so this exercises the privileged teardown paths unit tests can't.
+
+on:
+  pull_request:
+    paths:
+      - "cli/modules/**"
+      - "cli/src/commands/uninstall.tsx"
+      - "cli/src/lib/**"
+      - "cli/test/e2e/**"
+      - ".github/workflows/e2e-uninstall.yml"
+  workflow_dispatch:
+
+jobs:
+  uninstall:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
+      # The harness builds + stages the CLI, creates a throwaway `dev` user,
+      # runs init/uninstall as `sudo devlair`, and asserts. REPO_SRC points at
+      # the checkout so the script finds cli/.
+      - name: Run uninstall E2E
+        run: sudo REPO_SRC="$GITHUB_WORKSPACE" bash cli/test/e2e/uninstall.sh

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ SSH hardening, UFW firewall, Fail2Ban, and Tailscale VPN are set up out of the b
     doctor [--fix]                      Check system health & fix drift
     upgrade [--no-self]                 Upgrade tools & re-apply configs
     disable-password                    Lock SSH to key-only auth
-    uninstall [--yes]                   Remove everything devlair installed
+    uninstall [--yes] [--purge]         Remove everything devlair installed
+      [--keep-packages]
 
   AI Agents
     claude [--plan TIER] [--1m on|off]  Usage dashboard & config
@@ -370,7 +371,7 @@ The installer downloads the latest `devlair-cli-{os}-{arch}` binary and places i
 |---------|-------|
 | `devlair disable-password [--yes]` | Linux-only, auto-elevates via sudo. `--yes` skips the interactive confirmation. |
 | `devlair claude [--plan TIER\|--1m on\|off]` | Configures the local Claude Code install. No dashboard (see above). |
-| `devlair uninstall [--yes]` | Removes the devlair binary, share directory, `~/.devlair/`, `~/.zim/`, `~/.zimrc`, `~/.zshenv` (if managed), the devlair block from `~/.zshrc`, `~/.tmux.conf`, and `~/.tmux/plugins/`. Auto-elevates via sudo. `--yes` skips the interactive confirmation. |
+| `devlair uninstall [--yes] [--purge] [--keep-packages]` | Full teardown. Runs each module's reverse step in reverse dependency order — removes installed tools (pyenv, nvm, bun, fzf, uv, and with default package removal: docker, gh, aws, tailscale, tmux, ufw/fail2ban), reverts system state (firewall, sshd hardening, default shell back to the recorded original, docker group, Gnome Terminal profile), strips devlair config blocks, and removes the binary + `~/.devlair/`. Sensitive items (GitHub SSH key, git identity, `~/.ssh/authorized_keys`, Tailscale auth) are kept by default and you're asked per-category whether to destroy each. Never purges `openssh-server` (lockout-safe) or Homebrew. `--yes` keeps all sensitive items non-interactively; `--purge` destroys them all; `--keep-packages` skips apt/brew package removal. Auto-elevates via sudo. |
 
 **v2 wizard behavior notes:**
 

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -223,3 +223,44 @@ update_json() {
     printf '%s\n' "$patch" | jq '.' > "$file"
   fi
 }
+
+# ── Uninstall helpers ──────────────────────────────────────────────────────────
+
+# cfg_bool KEY DEFAULT -- echo a boolean config value ("true"/"false"),
+# falling back to DEFAULT when the key is unset. Used by do_uninstall to read
+# the keep/destroy decisions passed in ModuleContext.config.
+cfg_bool() {
+  local v
+  v=$(ctx_get_config "$1")
+  [[ -z "$v" ]] && v=$2
+  echo "$v"
+}
+
+# apt_purge PKG... -- purge packages quietly with a progress event (best-effort;
+# never aborts uninstall if a package is already gone or apt is unhappy).
+apt_purge() {
+  json_progress "removing $*"
+  apt-get purge -y -qq "$@" >&2 2>&1 || true
+  apt-get autoremove -y -qq >&2 2>&1 || true
+}
+
+# brew_uninstall PKG... -- uninstall Homebrew packages (best-effort). Drops to
+# the target user when running as root, since brew refuses to run as root.
+brew_uninstall() {
+  json_progress "removing $*"
+  if _is_root; then
+    sudo -u "${USERNAME:?USERNAME not set}" brew uninstall "$@" >&2 2>&1 || true
+  else
+    brew uninstall "$@" >&2 2>&1 || true
+  fi
+}
+
+# rm_user_path PATH -- rm -rf a path (best-effort). Appends the basename to the
+# caller's `removed` array when the path existed. Caller must declare `removed`.
+rm_user_path() {
+  local p=$1
+  if [[ -e "$p" || -L "$p" ]]; then
+    rm -rf "$p" 2>/dev/null || true
+    removed+=("$(basename "$p")")
+  fi
+}

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -241,7 +241,6 @@ cfg_bool() {
 apt_purge() {
   json_progress "removing $*"
   apt-get purge -y -qq "$@" >&2 2>&1 || true
-  apt-get autoremove -y -qq >&2 2>&1 || true
 }
 
 # brew_uninstall PKG... -- uninstall Homebrew packages (best-effort). Drops to

--- a/cli/modules/claude.sh
+++ b/cli/modules/claude.sh
@@ -96,8 +96,51 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=()
+  local claude_dir="$USER_HOME/.claude"
+  local settings_path="$claude_dir/settings.json"
+  local bin_dir="$USER_HOME/.devlair/bin"
+
+  # Strip devlair-managed keys from settings.json (current + legacy channel keys).
+  if [[ -f "$settings_path" ]]; then
+    json_progress "cleaning settings.json"
+    local cleaned
+    cleaned=$(jq 'del(.model, .effortLevel, .channelsEnabled, .allowedChannelPlugins, .hooks)' \
+      "$settings_path" 2>/dev/null || echo "")
+    if [[ -z "$cleaned" || "$cleaned" == "{}" ]]; then
+      rm -f "$settings_path"
+      removed+=("settings.json")
+    else
+      printf '%s\n' "$cleaned" > "$settings_path"
+      chown_user "$settings_path"
+      removed+=("settings.json keys")
+    fi
+  fi
+
+  # Remove devlair helper scripts and legacy channel/session-tracking artifacts.
+  rm_user_path "$bin_dir/tmx-new"
+  rm_user_path "$bin_dir/claude-status.sh"
+  rm_user_path "$bin_dir/claude-telegram"
+  rm_user_path "$claude_dir/channels"
+  rm_user_path "$claude_dir/devlair-active"
+  rm_user_path "$claude_dir/devlair-sessions.jsonl"
+
+  # The Claude Code CLI itself is removed only when packages are being purged.
+  if [[ "$(cfg_bool remove_packages false)" == "true" ]]; then
+    rm_user_path "$USER_HOME/.local/bin/claude"
+  fi
+
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/devtools.sh
+++ b/cli/modules/devtools.sh
@@ -254,8 +254,47 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=()
+  local remove_packages
+  remove_packages=$(cfg_bool remove_packages false)
+
+  # ── User-level version managers (always removed) ──────────────────────────
+  rm_user_path "$USER_HOME/.pyenv"
+  rm_user_path "$USER_HOME/.nvm"
+  rm_user_path "$USER_HOME/.bun"
+  rm_user_path "$USER_HOME/.fzf"
+  rm_user_path "$USER_HOME/.local/bin/uv"
+  rm_user_path "$USER_HOME/.local/bin/uvx"
+
+  if [[ "$remove_packages" == "true" ]]; then
+    if [[ "$PLATFORM" == "macos" ]]; then
+      brew_uninstall uv pyenv fzf gh awscli bun
+      removed+=("brew dev tools")
+    else
+      # Drop the user from the docker group, then purge docker + repos.
+      if id -nG "$USERNAME" 2>/dev/null | grep -qw docker; then
+        gpasswd -d "$USERNAME" docker >&2 2>&1 || true
+      fi
+      apt_purge docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-buildx-plugin gh
+      rm -f /etc/apt/keyrings/docker.gpg /etc/apt/sources.list.d/docker.list 2>/dev/null || true
+      rm -f /usr/share/keyrings/githubcli-archive-keyring.gpg /etc/apt/sources.list.d/github-cli.list 2>/dev/null || true
+      # AWS CLI v2 installs to /usr/local (not apt-managed).
+      rm -rf /usr/local/aws-cli /usr/local/bin/aws /usr/local/bin/aws_completer 2>/dev/null || true
+      removed+=("docker, gh, aws + apt repos")
+    fi
+  fi
+
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/firewall.sh
+++ b/cli/modules/firewall.sh
@@ -56,8 +56,39 @@ do_check() {
 
 }
 
+do_uninstall() {
+  local removed=()
+
+  if cmd_exists ufw; then
+    json_progress "disabling firewall"
+    ufw --force disable >&2 2>&1 || true
+    removed+=("ufw disabled")
+  fi
+
+  if systemctl list-unit-files fail2ban.service >/dev/null 2>&1; then
+    json_progress "stopping fail2ban"
+    systemctl stop fail2ban >&2 2>&1 || true
+    systemctl disable fail2ban >&2 2>&1 || true
+    removed+=("fail2ban stopped")
+  fi
+
+  rm_user_path "$FAIL2BAN_JAIL"
+
+  if [[ "$(cfg_bool remove_packages false)" == "true" ]]; then
+    apt_purge ufw fail2ban
+    removed+=("ufw + fail2ban packages")
+  fi
+
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/github.sh
+++ b/cli/modules/github.sh
@@ -132,8 +132,65 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=() kept=()
+  local gh_key="$USER_HOME/.ssh/id_ed25519_github"
+  local ssh_conf="$USER_HOME/.ssh/config"
+
+  # GitHub SSH key — sensitive, default keep.
+  if [[ "$(cfg_bool keep_github_key true)" == "true" ]]; then
+    [[ -f "$gh_key" ]] && kept+=("github ssh key")
+  else
+    rm_user_path "$gh_key"
+    rm_user_path "${gh_key}.pub"
+    # Drop the "Host github.com" block we appended to ~/.ssh/config.
+    if [[ -f "$ssh_conf" ]] && grep -q "Host github.com" "$ssh_conf"; then
+      json_progress "removing github host from ssh config"
+      # Delete the "# GitHub" comment + the Host github.com stanza (until the
+      # next blank line or EOF).
+      awk '
+        /^# GitHub$/ { skip=1; next }
+        skip && /^Host github\.com$/ { skip=2; next }
+        skip==2 && (/^$/ || /^Host /) { skip=0 }
+        skip==2 { next }
+        skip==1 { skip=0 }
+        { print }
+      ' "$ssh_conf" > "${ssh_conf}.tmp" && mv "${ssh_conf}.tmp" "$ssh_conf"
+      chown_user "$ssh_conf"
+      removed+=("ssh config github host")
+    fi
+    if [[ "$PLATFORM" == "macos" ]]; then
+      run_shell_as "$USERNAME" "ssh-add -d \"$gh_key\" 2>/dev/null" >&2 || true
+    fi
+  fi
+
+  # git identity — sensitive, default keep.
+  if [[ "$(cfg_bool keep_git_identity true)" == "true" ]]; then
+    kept+=("git identity")
+  else
+    json_progress "unsetting git identity"
+    run_shell_as "$USERNAME" "
+      git config --global --unset user.email 2>/dev/null
+      git config --global --unset user.name 2>/dev/null
+      git config --global --unset init.defaultBranch 2>/dev/null
+      true
+    " >&2 || true
+    removed+=("git identity")
+  fi
+
+  local parts=()
+  [[ ${#removed[@]} -gt 0 ]] && parts+=("removed: $(IFS=', '; echo "${removed[*]}")")
+  [[ ${#kept[@]} -gt 0 ]] && parts+=("kept: $(IFS=', '; echo "${kept[*]}")")
+  if [[ ${#parts[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "$(IFS=' | '; echo "${parts[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/gnome-terminal.sh
+++ b/cli/modules/gnome-terminal.sh
@@ -90,6 +90,7 @@ do_uninstall() {
     json_result "skip" "no default terminal profile found"
     exit 2
   }
+  [[ "$path" =~ ^/org/gnome/terminal/legacy/profiles:/:[-a-f0-9]+/$ ]] || { json_result "skip" "unexpected profile path"; exit 2; }
 
   json_progress "resetting Gnome Terminal profile"
   local dbus_export
@@ -98,7 +99,7 @@ do_uninstall() {
   # stock GNOME Terminal colors / theme behavior.
   run_shell_as "$USERNAME" "
     $dbus_export
-    dconf reset -f ${path}
+    dconf reset -f \"${path}\"
   " >&2 || true
 
   json_result "ok" "Gnome Terminal profile reset to defaults"

--- a/cli/modules/gnome-terminal.sh
+++ b/cli/modules/gnome-terminal.sh
@@ -79,8 +79,34 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  if ! cmd_exists gsettings; then
+    json_result "skip" "gsettings not available"
+    exit 2
+  fi
+
+  local path
+  path=$(_default_profile_path) || {
+    json_result "skip" "no default terminal profile found"
+    exit 2
+  }
+
+  json_progress "resetting Gnome Terminal profile"
+  local dbus_export
+  dbus_export=$(_dbus_env "$USERNAME")
+  # `dconf reset -f` drops the keys back to their defaults, restoring the
+  # stock GNOME Terminal colors / theme behavior.
+  run_shell_as "$USERNAME" "
+    $dbus_export
+    dconf reset -f ${path}
+  " >&2 || true
+
+  json_result "ok" "Gnome Terminal profile reset to defaults"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/homebrew.sh
+++ b/cli/modules/homebrew.sh
@@ -29,8 +29,16 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  # Homebrew is shared infrastructure used by software well beyond devlair;
+  # uninstalling it would be destructive and surprising. Never touch it.
+  json_result "skip" "Homebrew left installed"
+  exit 2
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/shell.sh
+++ b/cli/modules/shell.sh
@@ -85,8 +85,38 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=()
+  local zshrc="$USER_HOME/.zshrc"
+
+  # Strip the devlair aliases block (from MARKER to EOF) from .zshrc.
+  if [[ -f "$zshrc" ]] && grep -qF "$MARKER" "$zshrc"; then
+    json_progress "removing aliases from .zshrc"
+    local before
+    before="$(awk -v marker="$MARKER" 'index($0, marker){exit} {print}' "$zshrc")"
+    # Trim trailing blank lines, then write back (empty file if nothing remains).
+    before="${before%$'\n'}"
+    if [[ -n "${before//[$'\n\t ']/}" ]]; then
+      printf '%s\n' "$before" > "$zshrc"
+    else
+      : > "$zshrc"
+    fi
+    chown_user "$zshrc"
+    removed+=("aliases block")
+  fi
+
+  rm_user_path "$USER_HOME/.devlair/brand"
+
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    json_result "skip" "no devlair block found"
+    exit 2
+  fi
+  json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/shell.sh
+++ b/cli/modules/shell.sh
@@ -108,7 +108,7 @@ do_uninstall() {
   rm_user_path "$USER_HOME/.devlair/brand"
 
   if [[ ${#removed[@]} -eq 0 ]]; then
-    json_result "skip" "no devlair block found"
+    json_result "skip" "nothing to remove"
     exit 2
   fi
   json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"

--- a/cli/modules/ssh.sh
+++ b/cli/modules/ssh.sh
@@ -124,8 +124,59 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=() kept=()
+
+  # Remove the hardened drop-in.
+  if [[ -f "$SSHD_CONF" ]]; then
+    rm -f "$SSHD_CONF"
+    removed+=("99-hardened.conf")
+  fi
+
+  # Restore the original sshd_config from the backup we made at install time.
+  # The backup predates the macOS `Include` line, so restoring it also undoes that.
+  if [[ -f /etc/ssh/sshd_config.bak ]]; then
+    json_progress "restoring sshd_config from backup"
+    mv /etc/ssh/sshd_config.bak /etc/ssh/sshd_config
+    chmod 644 /etc/ssh/sshd_config
+    removed+=("sshd_config restored")
+  fi
+
+  # authorized_keys — sensitive, default keep (may contain keys devlair didn't add).
+  local auth_keys="$USER_HOME/.ssh/authorized_keys"
+  if [[ "$(cfg_bool keep_authorized_keys true)" == "true" ]]; then
+    [[ -f "$auth_keys" ]] && kept+=("authorized_keys")
+  else
+    rm_user_path "$auth_keys"
+  fi
+
+  # Restart / disable remote login so the relaxed config takes effect.
+  json_progress "restarting sshd"
+  if [[ "$PLATFORM" == "macos" ]]; then
+    systemsetup -setremotelogin off >&2 2>&1 || true
+  else
+    systemctl restart ssh >&2 2>&1 || true
+  fi
+
+  # NOTE: openssh-server is intentionally never purged, even with --remove
+  # packages — doing so on a remote machine would lock the operator out.
+  if [[ "$(cfg_bool remove_packages false)" == "true" ]]; then
+    kept+=("openssh-server (lockout-safe)")
+  fi
+
+  local parts=()
+  [[ ${#removed[@]} -gt 0 ]] && parts+=("removed: $(IFS=', '; echo "${removed[*]}")")
+  [[ ${#kept[@]} -gt 0 ]] && parts+=("kept: $(IFS=', '; echo "${kept[*]}")")
+  if [[ ${#parts[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "$(IFS=' | '; echo "${parts[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -85,8 +85,32 @@ do_check() {
   done
 }
 
+# Packages safe to purge on uninstall — clearly "extra" tooling devlair adds.
+# Deliberately conservative: base packages (curl, git, ca-certificates, gnupg,
+# build-essential, jq, openssh-server, …) are PROTECTED and never purged, since
+# apt and the uninstall process itself depend on them.
+SAFE_PURGE=( htop tree bat net-tools )
+MACOS_SAFE_PURGE=( htop tree bat )
+
+do_uninstall() {
+  if [[ "$(cfg_bool remove_packages false)" != "true" ]]; then
+    json_result "skip" "base packages left installed (protected)"
+    exit 2
+  fi
+
+  if [[ "$PLATFORM" == "macos" ]]; then
+    brew_uninstall "${MACOS_SAFE_PURGE[@]}"
+  else
+    apt_purge "${SAFE_PURGE[@]}"
+    [[ "$PLATFORM" == "wsl" ]] && apt_purge wslu
+  fi
+
+  json_result "ok" "removed extra packages (base packages preserved)"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/system.sh
+++ b/cli/modules/system.sh
@@ -103,6 +103,7 @@ do_uninstall() {
   else
     apt_purge "${SAFE_PURGE[@]}"
     [[ "$PLATFORM" == "wsl" ]] && apt_purge wslu
+    apt-get autoremove -y -qq >&2 2>&1 || true
   fi
 
   json_result "ok" "removed extra packages (base packages preserved)"

--- a/cli/modules/tailscale.sh
+++ b/cli/modules/tailscale.sh
@@ -8,6 +8,8 @@ source "$SCRIPT_DIR/_lib.sh"
 
 read_context
 
+USERNAME=$(ctx_get username)
+PLATFORM=$(ctx_get platform)
 MODE=${1:-run}
 
 # `tailscale up` without an auth key blocks until the user completes browser
@@ -126,8 +128,45 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=()
+
+  if ! cmd_exists tailscale; then
+    json_result "skip" "tailscale not installed"
+    exit 2
+  fi
+
+  # Auth state — sensitive, default keep. Destroy => logout (drops node key);
+  # keep => just bring the link down so it stops routing.
+  if [[ "$(cfg_bool keep_tailscale_auth true)" == "true" ]]; then
+    json_progress "bringing tailscale down"
+    tailscale down >&2 2>&1 || true
+    removed+=("tailscale down (auth kept)")
+  else
+    json_progress "logging out of tailscale"
+    tailscale logout >&2 2>&1 || true
+    removed+=("tailscale logout")
+  fi
+
+  if [[ "$(cfg_bool remove_packages false)" == "true" ]]; then
+    if [[ "$PLATFORM" == "macos" ]]; then
+      brew_uninstall tailscale
+    else
+      systemctl stop tailscaled >&2 2>&1 || true
+      systemctl disable tailscaled >&2 2>&1 || true
+      apt_purge tailscale
+      rm -f /usr/share/keyrings/tailscale-archive-keyring.gpg \
+            /etc/apt/sources.list.d/tailscale.list 2>/dev/null || true
+    fi
+    removed+=("tailscale package")
+  fi
+
+  json_result "ok" "$(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/timezone.sh
+++ b/cli/modules/timezone.sh
@@ -42,8 +42,16 @@ do_check() {
   json_check "timezone" "$status" "$tz"
 }
 
+do_uninstall() {
+  # Timezone is a benign system setting; reverting it (to what?) is riskier than
+  # leaving it. No-op.
+  json_result "skip" "timezone left unchanged"
+  exit 2
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/tmux.sh
+++ b/cli/modules/tmux.sh
@@ -97,8 +97,31 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=()
+  rm_user_path "$USER_HOME/.tmux.conf"
+  rm_user_path "$USER_HOME/.tmux/plugins"
+  rm_user_path "$USER_HOME/.tmux"
+
+  if [[ "$(cfg_bool remove_packages false)" == "true" ]]; then
+    if [[ "$PLATFORM" == "macos" ]]; then
+      brew_uninstall tmux
+    else
+      apt_purge tmux wl-clipboard
+    fi
+    removed+=("tmux package")
+  fi
+
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/zsh.sh
+++ b/cli/modules/zsh.sh
@@ -35,6 +35,18 @@ do_run() {
   else
     current_shell=$(getent passwd "$USERNAME" | cut -d: -f7)
   fi
+  # Record the original login shell (once) so `devlair uninstall` can restore it.
+  if [[ "$current_shell" != "$zsh_bin" ]]; then
+    local state_dir="$USER_HOME/.devlair"
+    local state_file="$state_dir/state.json"
+    mkdir -p "$state_dir"
+    chown_user "$state_dir"
+    if [[ ! -f "$state_file" ]] || ! jq -e '.original_shell' "$state_file" >/dev/null 2>&1; then
+      update_json "$state_file" "$(jq -n --arg s "$current_shell" '{original_shell:$s}')"
+      chown_user "$state_file"
+    fi
+  fi
+
   if [[ "$current_shell" != "$zsh_bin" ]]; then
     json_progress "setting zsh as default shell"
     if [[ "$PLATFORM" == "macos" ]]; then
@@ -109,8 +121,82 @@ do_check() {
   fi
 }
 
+do_uninstall() {
+  local removed=()
+  local zshrc="$USER_HOME/.zshrc"
+
+  # Restore the original login shell BEFORE removing zsh, so the user is never
+  # left with a missing login shell. Prefer the recorded original; fall back to
+  # /bin/bash on Linux. On macOS, only act when we have a recorded value.
+  local orig_shell=""
+  local state_file="$USER_HOME/.devlair/state.json"
+  [[ -f "$state_file" ]] && orig_shell=$(jq -r '.original_shell // empty' "$state_file" 2>/dev/null || true)
+
+  local target_shell=""
+  if [[ -n "$orig_shell" && -x "$orig_shell" ]]; then
+    target_shell="$orig_shell"
+  elif [[ "$PLATFORM" != "macos" && -x /bin/bash ]]; then
+    target_shell="/bin/bash"
+  fi
+
+  if [[ -n "$target_shell" ]]; then
+    json_progress "restoring login shell to $target_shell"
+    if [[ "$PLATFORM" == "macos" ]]; then
+      if _is_root; then
+        dscl . -create "/Users/$USERNAME" UserShell "$target_shell" >&2 2>&1 || true
+      else
+        sudo -n dscl . -create "/Users/$USERNAME" UserShell "$target_shell" >&2 2>&1 || true
+      fi
+    else
+      chsh -s "$target_shell" "$USERNAME" >&2 2>&1 || true
+    fi
+    removed+=("login shell → $target_shell")
+  fi
+
+  # Strip the devlair-managed header block from .zshrc (re-downloads zimfw and
+  # sources ~/.zim/init.zsh, which we are about to delete). Only touch it when
+  # the distinctive devlair header is present.
+  if [[ -f "$zshrc" ]] && head -1 "$zshrc" | grep -q "devlair — managed zsh config"; then
+    json_progress "removing devlair header from .zshrc"
+    # Drop lines from the header marker through the final `source "$ZIM_HOME/init.zsh"`.
+    awk '
+      /devlair — managed zsh config/ { skip=1; next }
+      skip && /source "\$ZIM_HOME\/init\.zsh"/ { skip=0; next }
+      skip { next }
+      { print }
+    ' "$zshrc" > "${zshrc}.tmp" && mv "${zshrc}.tmp" "$zshrc"
+    chown_user "$zshrc"
+    # If nothing meaningful remains, drop the file entirely.
+    [[ -n "$(tr -d '[:space:]' < "$zshrc")" ]] || rm -f "$zshrc"
+    removed+=("zsh header")
+  fi
+
+  rm_user_path "$USER_HOME/.zim"
+  rm_user_path "$USER_HOME/.zimrc"
+  # Only remove .zshenv if it's the devlair-managed one.
+  if [[ -f "$USER_HOME/.zshenv" ]] && grep -q "skip_global_compinit" "$USER_HOME/.zshenv"; then
+    rm_user_path "$USER_HOME/.zshenv"
+  fi
+
+  if [[ "$(cfg_bool remove_packages false)" == "true" ]]; then
+    if [[ "$PLATFORM" == "macos" ]]; then
+      brew_uninstall zsh
+    else
+      apt_purge zsh
+    fi
+    removed+=("zsh package")
+  fi
+
+  if [[ ${#removed[@]} -eq 0 ]]; then
+    json_result "skip" "nothing to remove"
+    exit 2
+  fi
+  json_result "ok" "removed: $(IFS=', '; echo "${removed[*]}")"
+}
+
 case "$MODE" in
-  run)   do_run ;;
-  check) do_check ;;
-  *)     json_result "fail" "unknown mode: $MODE"; exit 1 ;;
+  run)       do_run ;;
+  check)     do_check ;;
+  uninstall) do_uninstall ;;
+  *)         json_result "fail" "unknown mode: $MODE"; exit 1 ;;
 esac

--- a/cli/modules/zsh.sh
+++ b/cli/modules/zsh.sh
@@ -132,6 +132,10 @@ do_uninstall() {
   local state_file="$USER_HOME/.devlair/state.json"
   [[ -f "$state_file" ]] && orig_shell=$(jq -r '.original_shell // empty' "$state_file" 2>/dev/null || true)
 
+  # Validate that the recorded shell is listed in /etc/shells to prevent an
+  # attacker-controlled state.json from pointing chsh/dscl at an arbitrary binary.
+  if [[ -n "$orig_shell" ]] && ! grep -qxF "$orig_shell" /etc/shells 2>/dev/null; then orig_shell=""; fi
+
   local target_shell=""
   if [[ -n "$orig_shell" && -x "$orig_shell" ]]; then
     target_shell="$orig_shell"

--- a/cli/src/commands/uninstall.tsx
+++ b/cli/src/commands/uninstall.tsx
@@ -1,206 +1,324 @@
 /**
- * devlair uninstall — remove everything devlair installed and configured.
+ * devlair uninstall — reverse everything devlair installed and configured,
+ * returning the machine to a state where a fresh install can run cleanly.
+ *
+ * Each module owns its own teardown (the `uninstall` mode in cli/modules/<key>.sh);
+ * this command orchestrates them in reverse dependency order, then removes the
+ * devlair-core artifacts (binary, share dir, ~/.devlair) that no module owns.
+ *
+ * Sensitive items (SSH keys, git identity, authorized_keys, tailscale auth) are
+ * kept by default. Interactively, the user is asked per-category whether to
+ * destroy each. `--yes` keeps all of them non-interactively; `--purge` destroys
+ * all of them non-interactively.
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, rmSync, statSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { Box, Text, useApp, useInput } from "ink";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type ModuleRun, Progress } from "../components/Progress.js";
 import type { UninstallFlags } from "../lib/args.js";
-import { resolveInvokingUser } from "../lib/context.js";
+import { buildModuleContext, resolveInvokingUser } from "../lib/context.js";
+import { createInitLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
+import { resolveTeardownOrder } from "../lib/modules.js";
+import { moduleScriptPath } from "../lib/paths.js";
+import { detectPlatform, detectWslVersion } from "../lib/platform.js";
+import { runModule } from "../lib/runner.js";
 import { D_COMMENT, D_FG, D_GREEN, D_ORANGE, D_PURPLE, D_RED } from "../lib/theme.js";
+import type { ModuleContext, Status } from "../lib/types.js";
 
-const ZSHRC_MARKER = "# ── devlair aliases ─";
-const ZSHENV_MARKER = "skip_global_compinit";
+// ── Sensitive categories (default keep) ────────────────────────────────────
 
-type ItemStatus = "pending" | "ok" | "skip" | "fail";
-
-interface RemovalItem {
+interface SensitiveCategory {
+  /** Config key passed to module scripts (read via ctx_get_config). */
+  configKey: string;
   label: string;
-  path: string;
-  type: "file" | "dir" | "zshrc-strip";
-  /** True when the path needs root to remove (binary / modules dir). */
-  privileged?: boolean;
-  status: ItemStatus;
-  detail: string;
+  /** What gets destroyed if the user opts in. */
+  destroys: string;
+  present: (home: string) => boolean;
 }
 
-function buildItems(userHome: string): RemovalItem[] {
+function commandExists(cmd: string): boolean {
+  return spawnSync("command", ["-v", cmd], { shell: "/bin/bash", stdio: "ignore" }).status === 0;
+}
+
+function nonEmptyFile(path: string): boolean {
+  try {
+    return statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+const SENSITIVE: SensitiveCategory[] = [
+  {
+    configKey: "keep_github_key",
+    label: "GitHub SSH key",
+    destroys: "~/.ssh/id_ed25519_github + its ~/.ssh/config entry",
+    present: (home) => existsSync(join(home, ".ssh", "id_ed25519_github")),
+  },
+  {
+    configKey: "keep_git_identity",
+    label: "git identity",
+    destroys: "git config --global user.email / user.name / init.defaultBranch",
+    present: (home) => existsSync(join(home, ".gitconfig")),
+  },
+  {
+    configKey: "keep_authorized_keys",
+    label: "~/.ssh/authorized_keys",
+    destroys: "~/.ssh/authorized_keys (may contain keys devlair didn't add)",
+    present: (home) => nonEmptyFile(join(home, ".ssh", "authorized_keys")),
+  },
+  {
+    configKey: "keep_tailscale_auth",
+    label: "Tailscale auth",
+    destroys: "tailscale logout (drops this node from your tailnet)",
+    present: () => commandExists("tailscale"),
+  },
+];
+
+// ── devlair-core artifacts (owned by no module; removed last) ───────────────
+
+interface CoreItem {
+  label: string;
+  path: string;
+  privileged: boolean;
+}
+
+function coreItems(home: string): CoreItem[] {
   return [
-    {
-      label: "devlair binary",
-      path: "/usr/local/bin/devlair",
-      type: "file",
-      privileged: true,
-      status: "pending",
-      detail: "",
-    },
-    {
-      label: "devlair modules",
-      path: "/usr/local/share/devlair",
-      type: "dir",
-      privileged: true,
-      status: "pending",
-      detail: "",
-    },
-    { label: "~/.devlair/", path: join(userHome, ".devlair"), type: "dir", status: "pending", detail: "" },
-    { label: "~/.zim/", path: join(userHome, ".zim"), type: "dir", status: "pending", detail: "" },
-    { label: "~/.zimrc", path: join(userHome, ".zimrc"), type: "file", status: "pending", detail: "" },
-    { label: "~/.zshenv", path: join(userHome, ".zshenv"), type: "file", status: "pending", detail: "" },
-    {
-      label: "~/.zshrc (devlair block)",
-      path: join(userHome, ".zshrc"),
-      type: "zshrc-strip",
-      status: "pending",
-      detail: "",
-    },
-    { label: "~/.tmux.conf", path: join(userHome, ".tmux.conf"), type: "file", status: "pending", detail: "" },
-    { label: "~/.tmux/plugins/", path: join(userHome, ".tmux", "plugins"), type: "dir", status: "pending", detail: "" },
+    { label: "devlair binary", path: "/usr/local/bin/devlair", privileged: true },
+    { label: "devlair modules", path: "/usr/local/share/devlair", privileged: true },
+    { label: "~/.devlair/", path: join(home, ".devlair"), privileged: false },
   ];
 }
 
-function isDevlairZshenv(p: string): boolean {
+function removePrivileged(p: string): boolean {
   try {
-    return readFileSync(p, "utf8").includes(ZSHENV_MARKER);
+    if (statSync(p).isDirectory()) rmSync(p, { recursive: true, force: true });
+    else unlinkSync(p);
+    return true;
   } catch {
-    return false;
+    return spawnSync("sudo", ["-n", "rm", "-rf", p], { stdio: "ignore" }).status === 0;
   }
 }
 
-function hasDevlairZshrcBlock(p: string): boolean {
+function removeCoreItem(item: CoreItem): Status {
+  if (!existsSync(item.path)) return "skip";
+  if (item.privileged) return removePrivileged(item.path) ? "ok" : "fail";
   try {
-    return readFileSync(p, "utf8").includes(ZSHRC_MARKER);
+    rmSync(item.path, { recursive: true, force: true });
+    return "ok";
   } catch {
-    return false;
+    return "fail";
   }
 }
 
-function stripZshrcBlock(p: string): { ok: boolean; detail: string } {
-  try {
-    const content = readFileSync(p, "utf8");
-    const idx = content.indexOf(ZSHRC_MARKER);
-    if (idx === -1) return { ok: true, detail: "no devlair block found" };
-    const before = content.slice(0, idx).trimEnd();
-    writeFileSync(p, before ? `${before}\n` : "", "utf8");
-    return { ok: true, detail: "block removed" };
-  } catch (err) {
-    return { ok: false, detail: (err as Error).message };
-  }
+/** True when devlair appears to be installed at all. */
+function anythingInstalled(home: string): boolean {
+  return (
+    existsSync("/usr/local/bin/devlair") ||
+    existsSync(join(home, ".devlair")) ||
+    existsSync(join(home, ".zim")) ||
+    existsSync(join(home, ".tmux.conf"))
+  );
 }
 
-function removePrivileged(p: string): { ok: boolean; detail: string } {
-  try {
-    const stat = statSync(p);
-    if (stat.isDirectory()) {
-      rmSync(p, { recursive: true, force: true });
-    } else {
-      unlinkSync(p);
-    }
-    return { ok: true, detail: "removed" };
-  } catch {
-    const r = spawnSync("sudo", ["-n", "rm", "-rf", p], { stdio: "ignore" });
-    if (r.status === 0) return { ok: true, detail: "removed" };
-    return { ok: false, detail: "permission denied (try: sudo devlair uninstall)" };
-  }
-}
+const CORE_KEY = "__devlair_core__";
 
-function removeItem(item: RemovalItem): Pick<RemovalItem, "status" | "detail"> {
-  if (!existsSync(item.path)) {
-    return { status: "skip", detail: "not found" };
-  }
+// ── Phases ──────────────────────────────────────────────────────────────────
 
-  if (item.type === "zshrc-strip") {
-    if (!hasDevlairZshrcBlock(item.path)) {
-      return { status: "skip", detail: "no devlair block" };
-    }
-    const r = stripZshrcBlock(item.path);
-    return { status: r.ok ? "ok" : "fail", detail: r.detail };
-  }
-
-  if (item.type === "file" && item.path.endsWith(".zshenv") && !isDevlairZshenv(item.path)) {
-    return { status: "skip", detail: "not devlair-managed" };
-  }
-
-  if (item.privileged) {
-    const r = removePrivileged(item.path);
-    return { status: r.ok ? "ok" : "fail", detail: r.detail };
-  }
-
-  try {
-    if (item.type === "dir") {
-      rmSync(item.path, { recursive: true, force: true });
-    } else {
-      unlinkSync(item.path);
-    }
-    return { status: "ok", detail: "removed" };
-  } catch (err) {
-    return { status: "fail", detail: (err as Error).message };
-  }
-}
-
-function statusIcon(status: ItemStatus): { char: string; color: string } {
-  switch (status) {
-    case "ok":
-      return { char: "✓", color: D_GREEN };
-    case "skip":
-      return { char: "–", color: D_COMMENT };
-    case "fail":
-      return { char: "✗", color: D_RED };
-    default:
-      return { char: " ", color: D_COMMENT };
-  }
-}
-
-type Phase = "confirm" | "running" | "done";
+type Phase = "prompt" | "confirm" | "running" | "done";
 
 export function UninstallView({ flags }: { flags: UninstallFlags }) {
   const { exit } = useApp();
+  const exitRef = useRef(exit);
+
   const [[username, userHome]] = useState(() => resolveInvokingUser());
-  const [phase, setPhase] = useState<Phase>("confirm");
-  const [items, setItems] = useState<RemovalItem[]>(() => buildItems(userHome));
+  const [platform] = useState(() => detectPlatform());
+
+  // Sensitive categories present on this machine, in order.
+  const [categories] = useState(() => SENSITIVE.filter((c) => c.present(userHome)));
+  // keep[i] === true means keep (default); false means destroy.
+  const [keep, setKeep] = useState<boolean[]>(() => categories.map(() => !flags.purge));
+
+  const installed = anythingInstalled(userHome);
+
+  // --yes / --purge skip prompts; otherwise ask per present category, then confirm.
+  const initialPhase: Phase = !installed
+    ? "done"
+    : flags.yes || flags.purge || categories.length === 0
+      ? "confirm"
+      : "prompt";
+  const [phase, setPhase] = useState<Phase>(initialPhase);
+  const [promptIdx, setPromptIdx] = useState(0);
   const [aborted, setAborted] = useState(false);
 
-  const runRemoval = useCallback(() => {
-    setPhase("running");
+  const teardown = useState(() => resolveTeardownOrder(platform))[0];
 
-    const results = items.map((item) => {
-      const update = removeItem(item);
-      return { ...item, ...update };
+  const [modules, setModules] = useState<ModuleRun[]>(() =>
+    [...teardown.map((s) => ({ key: s.key, label: s.label })), { key: CORE_KEY, label: "devlair files" }].map((m) => ({
+      key: m.key,
+      label: m.label,
+      status: "pending" as const,
+      detail: "",
+      progressMsg: "",
+      progressHistory: [],
+    })),
+  );
+
+  const buildContext = useCallback((): ModuleContext => {
+    const wslVersion = detectWslVersion(platform);
+    const config: Record<string, string> = {
+      // jq's `// empty` treats JSON false as empty, so pass strings, not booleans.
+      remove_packages: flags.keepPackages ? "false" : "true",
+    };
+    categories.forEach((c, i) => {
+      config[c.configKey] = keep[i] ? "true" : "false";
     });
+    return buildModuleContext(platform, wslVersion, config);
+  }, [platform, flags.keepPackages, categories, keep]);
 
-    setItems(results);
-    setPhase("done");
+  const runTeardown = useCallback(() => {
+    setPhase("running");
+    const context = buildContext();
+    const abort = new AbortController();
+    let logDir: string | null = null;
+    try {
+      logDir = createInitLogDir(userHome);
+    } catch {
+      // best-effort logging
+    }
 
-    const anyFail = results.some((r) => r.status === "fail");
-    if (anyFail) process.exitCode = 1;
-    setTimeout(() => exit(), 0);
-  }, [items, exit]);
+    (async () => {
+      for (let i = 0; i < teardown.length; i++) {
+        const spec = teardown[i];
+        setModules((prev) => prev.map((m) => (m.key === spec.key ? { ...m, status: "running" } : m)));
 
-  // Auto-run when --yes is passed
+        let status: Status = "fail";
+        let detail = "";
+        let resultEmitted = false;
+        try {
+          const ownership = invokerOwnership();
+          const iter = runModule(moduleScriptPath(spec.key), context, "uninstall", {
+            signal: abort.signal,
+            logFile: logDir ? moduleLogPath(logDir, spec.key) : undefined,
+            chownUidGid: ownership ?? undefined,
+          });
+          while (true) {
+            const { value, done } = await iter.next();
+            if (done) {
+              if (!resultEmitted) status = value.status;
+              break;
+            }
+            if (value.type === "progress") {
+              setModules((prev) =>
+                prev.map((m) =>
+                  m.key === spec.key
+                    ? {
+                        ...m,
+                        progressMsg: value.message,
+                        progressHistory: m.progressMsg ? [...m.progressHistory, m.progressMsg] : m.progressHistory,
+                      }
+                    : m,
+                ),
+              );
+            } else if (value.type === "result") {
+              status = value.status;
+              detail = value.detail;
+              resultEmitted = true;
+            }
+          }
+        } catch (err) {
+          status = "fail";
+          detail = err instanceof Error ? err.message : String(err);
+        }
+
+        setModules((prev) =>
+          prev.map((m) => (m.key === spec.key ? { ...m, status, detail, progressMsg: "", progressHistory: [] } : m)),
+        );
+      }
+
+      // devlair-core removal — runs after every module, last (modules read state
+      // from ~/.devlair while they run).
+      setModules((prev) => prev.map((m) => (m.key === CORE_KEY ? { ...m, status: "running" } : m)));
+      const results = coreItems(userHome).map((item) => ({ item, status: removeCoreItem(item) }));
+      const coreFail = results.some((r) => r.status === "fail");
+      const coreRemoved = results.filter((r) => r.status === "ok").map((r) => r.item.label);
+      setModules((prev) =>
+        prev.map((m) =>
+          m.key === CORE_KEY
+            ? {
+                ...m,
+                status: coreFail ? "fail" : coreRemoved.length > 0 ? "ok" : "skip",
+                detail: coreFail
+                  ? "some files need root (try: sudo devlair uninstall)"
+                  : coreRemoved.length > 0
+                    ? `removed: ${coreRemoved.join(", ")}`
+                    : "nothing to remove",
+                progressMsg: "",
+              }
+            : m,
+        ),
+      );
+
+      setPhase("done");
+      if (coreFail) process.exitCode = 1;
+      setTimeout(() => exitRef.current(), 0);
+    })();
+
+    return abort;
+  }, [buildContext, teardown]);
+
+  // Auto-start for non-interactive paths handled via initialPhase + this effect.
+  const startedRef = useRef(false);
   useEffect(() => {
-    if (flags.yes && phase === "confirm") runRemoval();
-  }, [flags.yes, phase, runRemoval]);
+    if (!installed && phase === "done") {
+      setTimeout(() => exitRef.current(), 0);
+      return;
+    }
+    if ((flags.yes || flags.purge) && phase === "confirm" && !startedRef.current) {
+      startedRef.current = true;
+      const abort = runTeardown();
+      return () => abort.abort();
+    }
+  }, [flags.yes, flags.purge, phase, installed, runTeardown]);
 
+  // Prompt-phase input: y = destroy, n/Enter = keep (default).
+  useInput(
+    (input, key) => {
+      const destroy = input === "y" || input === "Y";
+      const keepIt = key.return || input === "n" || input === "N";
+      if (!destroy && !keepIt) return;
+      setKeep((prev) => {
+        const next = [...prev];
+        next[promptIdx] = !destroy;
+        return next;
+      });
+      const nextIdx = promptIdx + 1;
+      if (nextIdx >= categories.length) setPhase("confirm");
+      else setPromptIdx(nextIdx);
+    },
+    { isActive: phase === "prompt" },
+  );
+
+  // Confirm-phase input (interactive only).
   useInput(
     (input, key) => {
       if (key.return || input === "y" || input === "Y") {
-        runRemoval();
+        const abort = runTeardown();
+        // Abort handler is wired through the component lifecycle via runTeardown's
+        // own AbortController; nothing else to do here.
+        void abort;
       } else if (key.escape || input === "n" || input === "N" || input === "q") {
         setAborted(true);
         setPhase("done");
-        setTimeout(() => exit(), 0);
+        setTimeout(() => exitRef.current(), 0);
       }
     },
-    { isActive: phase === "confirm" && !flags.yes },
+    { isActive: phase === "confirm" && !flags.yes && !flags.purge },
   );
-
-  const presentItems = items.filter((item) => {
-    if (!existsSync(item.path)) return false;
-    if (item.type === "zshrc-strip") return hasDevlairZshrcBlock(item.path);
-    if (item.type === "file" && item.path.endsWith(".zshenv")) return isDevlairZshenv(item.path);
-    return true;
-  });
 
   return (
     <Box flexDirection="column">
@@ -217,73 +335,66 @@ export function UninstallView({ flags }: { flags: UninstallFlags }) {
         </Text>
       </Box>
 
-      {phase === "confirm" && (
-        <Box flexDirection="column">
-          {presentItems.length === 0 ? (
-            <Box marginBottom={1}>
-              <Text color={D_COMMENT}>{"  Nothing to remove — devlair does not appear to be installed."}</Text>
-            </Box>
-          ) : (
-            <Box flexDirection="column" marginBottom={1}>
-              <Text color={D_ORANGE}>{"  The following will be permanently deleted:"}</Text>
-              {presentItems.map((item) => (
-                <Text key={item.path} color={D_COMMENT}>
-                  {"    · "}
-                  <Text color={D_FG}>{item.label}</Text>
-                </Text>
-              ))}
-            </Box>
-          )}
+      {!installed && phase === "done" && (
+        <Text color={D_COMMENT}>{"  Nothing to remove — devlair does not appear to be installed."}</Text>
+      )}
 
-          {presentItems.length > 0 && !flags.yes && (
-            <Box>
-              <Text>{"  "}</Text>
-              <Text color={D_PURPLE}>Remove everything listed above? </Text>
-              <Text color={D_COMMENT}>(y/N)</Text>
-            </Box>
-          )}
+      {phase === "prompt" && categories[promptIdx] && (
+        <Box flexDirection="column">
+          <Text color={D_ORANGE}>{"  Keep or destroy sensitive items? (default: keep)"}</Text>
+          <Box marginTop={1}>
+            <Text color={D_COMMENT}>{`  [${promptIdx + 1}/${categories.length}] `}</Text>
+            <Text>{"Destroy "}</Text>
+            <Text color={D_FG} bold>
+              {categories[promptIdx].label}
+            </Text>
+            <Text color={D_COMMENT}>{"?  (y / N)"}</Text>
+          </Box>
+          <Text color={D_COMMENT}>{`        ${categories[promptIdx].destroys}`}</Text>
         </Box>
       )}
 
-      {(phase === "running" || phase === "done") && (
+      {phase === "confirm" && !flags.yes && !flags.purge && (
         <Box flexDirection="column">
-          {items.map((item) => {
-            if (item.status === "pending") return null;
-            const icon = statusIcon(item.status);
-            return (
-              <Box key={item.path}>
-                <Text color={icon.color}>
-                  {"  "}
-                  {icon.char}
-                </Text>
-                <Text>
-                  {"  "}
-                  {item.label}
-                </Text>
-                {item.detail && (
-                  <Text color={D_COMMENT}>
-                    {"  "}
-                    {item.detail}
-                  </Text>
-                )}
-              </Box>
-            );
-          })}
+          <Text color={D_ORANGE}>{"  About to remove devlair, its tools, and configuration."}</Text>
+          <Box flexDirection="column" marginTop={1}>
+            <Text color={D_COMMENT}>
+              {"    packages: "}
+              <Text color={D_FG}>{flags.keepPackages ? "kept" : "removed"}</Text>
+            </Text>
+            {categories.map((c, i) => (
+              <Text key={c.configKey} color={D_COMMENT}>
+                {"    "}
+                {c.label}
+                {": "}
+                <Text color={keep[i] ? D_GREEN : D_RED}>{keep[i] ? "kept" : "destroyed"}</Text>
+              </Text>
+            ))}
+          </Box>
+          <Box marginTop={1}>
+            <Text color={D_PURPLE}>{"  Proceed? "}</Text>
+            <Text color={D_COMMENT}>{"(y/N)"}</Text>
+          </Box>
         </Box>
       )}
 
-      {phase === "done" && !aborted && (
+      {(phase === "running" || (phase === "done" && installed && !aborted)) && (
+        <Progress modules={modules} total={modules.length} />
+      )}
+
+      {phase === "done" && !aborted && installed && (
         <Box marginTop={1} flexDirection="column">
-          {items.some((r) => r.status === "fail") ? (
+          {modules.some((m) => m.status === "fail") ? (
             <Text color={D_ORANGE}>{"  Some items could not be removed. See errors above."}</Text>
           ) : (
             <>
               <Text color={D_GREEN}>{"  ✓ devlair uninstalled."}</Text>
               <Text color={D_COMMENT}>
                 {
-                  "  Run the installer again for a clean install: curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | bash"
+                  "  Fresh install: curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | bash"
                 }
               </Text>
+              <Text color={D_COMMENT}>{"  Open a new shell for the restored login shell to take effect."}</Text>
             </>
           )}
         </Box>

--- a/cli/src/commands/uninstall.tsx
+++ b/cli/src/commands/uninstall.tsx
@@ -268,19 +268,29 @@ export function UninstallView({ flags }: { flags: UninstallFlags }) {
     return abort;
   }, [buildContext, teardown]);
 
-  // Auto-start for non-interactive paths handled via initialPhase + this effect.
+  // Start the teardown exactly once. The AbortController is kept in a ref and
+  // only fired on real unmount — NOT tied to a phase-dependent effect, because
+  // runTeardown() calls setPhase("running"), and an effect that re-ran on
+  // `phase` would fire its cleanup and SIGTERM the in-flight run immediately.
   const startedRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const start = useCallback(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    abortRef.current = runTeardown();
+  }, [runTeardown]);
+
+  // Nothing-to-remove fast path, and non-interactive auto-start (--yes/--purge).
   useEffect(() => {
-    if (!installed && phase === "done") {
+    if (!installed) {
       setTimeout(() => exitRef.current(), 0);
       return;
     }
-    if ((flags.yes || flags.purge) && phase === "confirm" && !startedRef.current) {
-      startedRef.current = true;
-      const abort = runTeardown();
-      return () => abort.abort();
-    }
-  }, [flags.yes, flags.purge, phase, installed, runTeardown]);
+    if (flags.yes || flags.purge) start();
+  }, [installed, flags.yes, flags.purge, start]);
+
+  // Abort the run only when the component truly unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
 
   // Prompt-phase input: y = destroy, n/Enter = keep (default).
   useInput(
@@ -304,10 +314,7 @@ export function UninstallView({ flags }: { flags: UninstallFlags }) {
   useInput(
     (input, key) => {
       if (key.return || input === "y" || input === "Y") {
-        const abort = runTeardown();
-        // Abort handler is wired through the component lifecycle via runTeardown's
-        // own AbortController; nothing else to do here.
-        void abort;
+        start();
       } else if (key.escape || input === "n" || input === "N" || input === "q") {
         setAborted(true);
         setPhase("done");

--- a/cli/src/commands/uninstall.tsx
+++ b/cli/src/commands/uninstall.tsx
@@ -146,12 +146,9 @@ export function UninstallView({ flags }: { flags: UninstallFlags }) {
   const installed = anythingInstalled(userHome);
 
   // --yes / --purge skip prompts; otherwise ask per present category, then confirm.
-  const initialPhase: Phase = !installed
-    ? "done"
-    : flags.yes || flags.purge || categories.length === 0
-      ? "confirm"
-      : "prompt";
-  const [phase, setPhase] = useState<Phase>(initialPhase);
+  const [phase, setPhase] = useState<Phase>(() =>
+    !installed ? "done" : flags.yes || flags.purge || categories.length === 0 ? "confirm" : "prompt",
+  );
   const [promptIdx, setPromptIdx] = useState(0);
   const [aborted, setAborted] = useState(false);
 

--- a/cli/src/components/Help.tsx
+++ b/cli/src/components/Help.tsx
@@ -20,7 +20,7 @@ const HELP_SECTIONS: HelpSection[] = [
       { cmd: "doctor [--fix]", desc: "Check system health & fix drift" },
       { cmd: "upgrade [--no-self]", desc: "Upgrade tools & re-apply configs" },
       { cmd: "disable-password [--yes]", desc: "Lock SSH to key-only auth" },
-      { cmd: "uninstall [--yes]", desc: "Remove everything devlair installed" },
+      { cmd: "uninstall [--yes] [--purge] [--keep-packages]", desc: "Remove everything devlair installed" },
     ],
   },
   {

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -102,7 +102,8 @@ async function main() {
     // macOS: install Homebrew before Ink starts so the installer has full TTY
     // access for its sudo password prompt. All subsequent brew calls in modules
     // assume brew is on PATH — this is the single point of installation.
-    if (process.platform === "darwin") {
+    // Skip for uninstall — we must never *install* Homebrew while tearing down.
+    if (process.platform === "darwin" && command.type !== "uninstall") {
       macOsPreFlight();
     }
   }

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -113,10 +113,20 @@ export function parseDisablePasswordFlags(args: readonly string[]): DisablePassw
 }
 
 export interface UninstallFlags {
-  /** Skip the interactive confirmation prompt. */
+  /** Skip interactive prompts; keep all sensitive items, remove everything else. */
   yes: boolean;
+  /** Non-interactive; destroy ALL sensitive items too (keys, identity, auth). */
+  purge: boolean;
+  /** Skip removal of apt/brew packages devlair installed. */
+  keepPackages: boolean;
 }
 
 export function parseUninstallFlags(args: readonly string[]): UninstallFlags {
-  return { yes: args.includes("--yes") || args.includes("-y") };
+  const purge = args.includes("--purge");
+  return {
+    // --purge implies non-interactive, so it also satisfies --yes semantics.
+    yes: args.includes("--yes") || args.includes("-y") || purge,
+    purge,
+    keepPackages: args.includes("--keep-packages"),
+  };
 }

--- a/cli/src/lib/modules.ts
+++ b/cli/src/lib/modules.ts
@@ -114,3 +114,13 @@ export function resolveOrder(keys?: ReadonlySet<string>, platform?: Platform): M
 export function keysForGroups(groups: Set<string>): Set<string> {
   return new Set(MODULE_SPECS.filter((s) => groups.has(s.group)).map((s) => s.key));
 }
+
+/**
+ * Return ModuleSpecs in dependency-safe TEARDOWN order — the reverse of the
+ * install order, so dependents are removed before their dependencies
+ * (e.g. firewall→ssh→tailscale, shell→zsh). Modules incompatible with
+ * `platform` are excluded.
+ */
+export function resolveTeardownOrder(platform?: Platform): ModuleSpec[] {
+  return resolveOrder(undefined, platform).reverse();
+}

--- a/cli/src/lib/types.ts
+++ b/cli/src/lib/types.ts
@@ -28,7 +28,7 @@ export interface CheckItem {
   detail?: string;
 }
 
-export type ModuleMode = "run" | "check";
+export type ModuleMode = "run" | "check" | "uninstall";
 
 export const ModuleExitCode = {
   Success: 0,

--- a/cli/src/test/args.test.ts
+++ b/cli/src/test/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseInitFlags } from "../lib/args.js";
+import { parseInitFlags, parseUninstallFlags } from "../lib/args.js";
 
 describe("parseInitFlags", () => {
   test("returns defaults when no flags", () => {
@@ -46,5 +46,32 @@ describe("parseInitFlags", () => {
   test("filters empty strings from comma-separated values", () => {
     const flags = parseInitFlags(["--only", "system,,ssh,"]);
     expect(flags.only).toEqual(new Set(["system", "ssh"]));
+  });
+});
+
+describe("parseUninstallFlags", () => {
+  test("defaults to interactive, packages removed, sensitive kept", () => {
+    const f = parseUninstallFlags([]);
+    expect(f.yes).toBe(false);
+    expect(f.purge).toBe(false);
+    expect(f.keepPackages).toBe(false);
+  });
+
+  test("--yes / -y skip prompts", () => {
+    expect(parseUninstallFlags(["--yes"]).yes).toBe(true);
+    expect(parseUninstallFlags(["-y"]).yes).toBe(true);
+  });
+
+  test("--purge implies non-interactive (yes) and sets purge", () => {
+    const f = parseUninstallFlags(["--purge"]);
+    expect(f.purge).toBe(true);
+    expect(f.yes).toBe(true);
+  });
+
+  test("--keep-packages is independent", () => {
+    const f = parseUninstallFlags(["--keep-packages"]);
+    expect(f.keepPackages).toBe(true);
+    expect(f.yes).toBe(false);
+    expect(f.purge).toBe(false);
   });
 });

--- a/cli/src/test/modules.test.ts
+++ b/cli/src/test/modules.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { GROUPS, MODULE_SPECS, REAPPLY_KEYS, keysForGroups, resolveOrder, validateDag } from "../lib/modules.js";
+import {
+  GROUPS,
+  MODULE_SPECS,
+  REAPPLY_KEYS,
+  keysForGroups,
+  resolveOrder,
+  resolveTeardownOrder,
+  validateDag,
+} from "../lib/modules.js";
 
 describe("MODULE_SPECS", () => {
   test("has 13 modules", () => {
@@ -155,5 +163,29 @@ describe("resolveOrder", () => {
     ];
     const actualOrder = resolveOrder().map((s) => s.key);
     expect(actualOrder).toEqual(expectedOrder);
+  });
+});
+
+describe("resolveTeardownOrder", () => {
+  test("is the exact reverse of the install order", () => {
+    const install = resolveOrder().map((s) => s.key);
+    const teardown = resolveTeardownOrder().map((s) => s.key);
+    expect(teardown).toEqual([...install].reverse());
+  });
+
+  test("removes dependents before their dependencies", () => {
+    const order = resolveTeardownOrder().map((s) => s.key);
+    // firewall → ssh → tailscale, and shell → zsh
+    expect(order.indexOf("firewall")).toBeLessThan(order.indexOf("ssh"));
+    expect(order.indexOf("ssh")).toBeLessThan(order.indexOf("tailscale"));
+    expect(order.indexOf("shell")).toBeLessThan(order.indexOf("zsh"));
+    expect(order.indexOf("claude")).toBeLessThan(order.indexOf("devtools"));
+  });
+
+  test("filters by platform", () => {
+    const macos = resolveTeardownOrder("macos").map((s) => s.key);
+    expect(macos).not.toContain("firewall");
+    expect(macos).not.toContain("ssh");
+    expect(macos).toContain("homebrew");
   });
 });

--- a/cli/test/e2e/uninstall.sh
+++ b/cli/test/e2e/uninstall.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# End-to-end test for `devlair uninstall` on a real Linux box.
+#
+# Installs devlair the way install.sh does (compiled binary in /usr/local/bin,
+# modules in /usr/local/share/devlair/modules), runs `init` for a
+# systemd-free module subset, then `uninstall` and asserts the machine is back
+# to a clean state — including the restored login shell and purged packages.
+#
+# Designed to run as root in a throwaway Ubuntu container (see
+# .github/workflows/e2e-uninstall.yml). DO NOT run on a real machine.
+set -uo pipefail
+
+REPO_SRC=${REPO_SRC:-/src}      # read-only mount of the repo
+WORK=/work
+DEV_USER=dev
+DEV_HOME=/home/$DEV_USER
+MODULES="${MODULES:-zsh,tmux,shell}"
+
+FAILED=0
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗\033[0m %s\n' "$1"; FAILED=1; }
+hdr()  { printf '\n\033[1;35m== %s ==\033[0m\n' "$1"; }
+
+exists()  { [[ -e "$1" ]] && pass "exists: $1" || fail "missing: $1"; }
+absent()  { [[ ! -e "$1" ]] && pass "absent: $1" || fail "still present: $1"; }
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+dev_shell() { getent passwd "$DEV_USER" | cut -d: -f7; }
+run_dl()    { sudo -u "$DEV_USER" bash -lc "sudo -n /usr/local/bin/devlair $*"; }
+
+# ── Prereqs ────────────────────────────────────────────────────────────────
+hdr "Provisioning container"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq >/dev/null
+# Intentionally NOT installing zsh/tmux — init must apt-install them, so that
+# uninstall's apt-purge path is exercised on real packages.
+apt-get install -y -qq curl git unzip jq sudo ca-certificates xz-utils ncurses-bin >/dev/null
+
+# bun (for building the CLI from source)
+export BUN_INSTALL=/usr/local
+curl -fsSL https://bun.sh/install | bash >/dev/null 2>&1
+has_cmd bun && pass "bun installed: $(bun --version)" || { fail "bun install failed"; exit 1; }
+
+# Non-root user with passwordless sudo — mirrors `sudo devlair` real usage.
+useradd -m -s /bin/bash "$DEV_USER"
+echo "$DEV_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$DEV_USER
+ORIG_SHELL="$(dev_shell)"
+pass "created $DEV_USER (login shell: $ORIG_SHELL)"
+
+# ── Build + stage like a real install ────────────────────────────────────────
+hdr "Building + staging devlair"
+cp -r "$REPO_SRC/cli" "$WORK"
+chown -R "$DEV_USER:$DEV_USER" "$WORK"
+sudo -u "$DEV_USER" bash -lc "cd $WORK && bun install --frozen-lockfile && bun run compile" >/dev/null 2>&1
+[[ -x "$WORK/dist/devlair" ]] && pass "compiled dist/devlair" || { fail "compile failed"; exit 1; }
+
+stage() {
+  install -m 0755 "$WORK/dist/devlair" /usr/local/bin/devlair
+  rm -rf /usr/local/share/devlair
+  mkdir -p /usr/local/share/devlair
+  cp -r "$WORK/modules" /usr/local/share/devlair/modules
+}
+stage
+exists /usr/local/bin/devlair
+exists /usr/local/share/devlair/modules/_lib.sh
+
+# ── init ─────────────────────────────────────────────────────────────────────
+hdr "devlair init --only $MODULES"
+run_dl "init --only $MODULES" || fail "init exited non-zero"
+
+exists "$DEV_HOME/.zimrc"
+exists "$DEV_HOME/.zim"
+exists "$DEV_HOME/.tmux.conf"
+exists "$DEV_HOME/.tmux/plugins/tpm"
+exists "$DEV_HOME/.devlair/state.json"
+grep -q "skip_global_compinit" "$DEV_HOME/.zshenv" 2>/dev/null && pass ".zshenv managed" || fail ".zshenv not managed"
+grep -q "# ── devlair aliases ─" "$DEV_HOME/.zshrc" 2>/dev/null && pass ".zshrc has aliases block" || fail ".zshrc missing aliases block"
+[[ "$(dev_shell)" == *zsh ]] && pass "login shell switched to zsh ($(dev_shell))" || fail "login shell not zsh: $(dev_shell)"
+jq -e '.original_shell' "$DEV_HOME/.devlair/state.json" >/dev/null 2>&1 && pass "state.json recorded original_shell ($(jq -r .original_shell "$DEV_HOME/.devlair/state.json"))" || fail "original_shell not recorded"
+has_cmd zsh && pass "zsh package installed by init" || fail "zsh not installed"
+
+# ── uninstall (keep sensitive, remove packages) ──────────────────────────────
+hdr "devlair uninstall --yes"
+run_dl "uninstall --yes" || fail "uninstall exited non-zero"
+
+absent /usr/local/bin/devlair
+absent /usr/local/share/devlair
+absent "$DEV_HOME/.devlair"
+absent "$DEV_HOME/.zim"
+absent "$DEV_HOME/.zimrc"
+absent "$DEV_HOME/.zshenv"
+absent "$DEV_HOME/.tmux.conf"
+absent "$DEV_HOME/.tmux/plugins"
+if [[ -f "$DEV_HOME/.zshrc" ]]; then
+  grep -q "devlair" "$DEV_HOME/.zshrc" && fail ".zshrc still has devlair content" || pass ".zshrc cleaned (no devlair content)"
+else
+  pass ".zshrc removed (was devlair-only)"
+fi
+[[ "$(dev_shell)" == "$ORIG_SHELL" ]] && pass "login shell restored to $ORIG_SHELL" || fail "login shell not restored: $(dev_shell)"
+has_cmd zsh && fail "zsh still installed (apt purge didn't run)" || pass "zsh package purged"
+has_cmd tmux && fail "tmux still installed" || pass "tmux package purged"
+
+# ── idempotent re-run ────────────────────────────────────────────────────────
+hdr "idempotent re-run"
+stage   # restore binary + modules so we can invoke it again
+if run_dl "uninstall --yes"; then
+  pass "second uninstall exited 0 (idempotent)"
+else
+  fail "second uninstall errored"
+fi
+absent /usr/local/bin/devlair   # core removal still works on the re-run
+
+# ── Result ───────────────────────────────────────────────────────────────────
+hdr "Result"
+if [[ "$FAILED" -eq 0 ]]; then
+  printf '\033[1;32mALL E2E ASSERTIONS PASSED\033[0m\n'
+  exit 0
+else
+  printf '\033[1;31mE2E FAILURES — see above\033[0m\n'
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Turns `devlair uninstall` into a complete, reversible teardown that returns the machine to a clean state for a fresh install.

**Architecture** — add an `uninstall` ModuleMode and a `do_uninstall` to every module script, orchestrated by `uninstall.tsx` in reverse dependency order (`resolveTeardownOrder`) over the existing `runModule` JSON-Lines protocol. Per-module keep/destroy decisions pass through `ModuleContext.config`.

- Removes installed tools (pyenv, nvm, bun, fzf, uv; with package removal: docker, gh, aws, tailscale, tmux, ufw/fail2ban) and reverts system state (firewall, sshd hardening restored from `.bak`, default login shell restored from a recorded original, docker group, Gnome Terminal profile).
- Sensitive items (GitHub SSH key, git identity, `~/.ssh/authorized_keys`, Tailscale auth) default to **keep**, asked per-category interactively; destroyed only on opt-in or `--purge`.
- Safety: never purges `openssh-server` (lockout) or Homebrew; base packages protected by a denylist; all `do_uninstall` idempotent + existence-guarded.
- The `zsh` module now records the original login shell to `~/.devlair/state.json` so uninstall can `chsh` back (falls back to `/bin/bash`).
- Flags: `--yes` (keep sensitive), `--purge` (destroy sensitive), `--keep-packages`. Skips `macOsPreFlight` on uninstall so we never *install* Homebrew while removing.

> **Stacked on #215.** Base is `feat/retire-telegram-channels`; it will auto-retarget to `main` once that merges. Review the [Part B-only diff](https://github.com/ettoreaquino/devlair/compare/feat/retire-telegram-channels...feat/full-uninstall).

Closes #217

## Test plan
- [x] `bun run typecheck`, `bun run lint`, `bun test` (176 pass) — added `parseUninstallFlags` + `resolveTeardownOrder` tests
- [x] `bun run build` compiles
- [x] `bash -n` on all module scripts
- [x] Home-scoped reversals (claude, shell, zsh, devtools, tmux, github keep+destroy) exercised against a sandbox `$HOME` — verified config-key stripping, `.zshrc` block/header removal, ssh-config stanza removal, version-manager dir removal
- [x] End-to-end on Linux (Docker + CI `e2e-uninstall` workflow): init → uninstall → idempotent re-run → clean state, login shell restored, packages purged
- [x] Non-interactive `--yes` path covered by the E2E (caught + fixed a self-abort bug); `--purge` shares the same start path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

