### PR TITLE
fix(install): resolve latest non-v1 release so v3+ installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -152,8 +152,12 @@ if [[ "$CHANNEL" == "v1" ]]; then
   fi
 else
   ASSET_PREFIX="devlair-cli"
+  # Default channel = the latest non-v1 release (v2, v3, …). Don't hardcode a
+  # major here, or the installer silently pins to the previous line after a
+  # major bump (e.g. v3.0.0 ships but `v2\.` keeps resolving the old v2.x).
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
-    | grep -o '"tag_name": *"v2\.[^"]*"' \
+    | grep -oE '"tag_name": *"v[0-9]+\.[^"]*"' \
+    | grep -v '"tag_name": *"v1\.' \
     | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"')
   if [[ -n "${LATEST:-}" && ! "$LATEST" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then


### PR DESCRIPTION
## Summary

The installer's default channel hardcoded a `v2\.` tag match, so after the **v3.0.0** major bump `curl … install.sh | bash` silently pinned to the latest **v2.x** (2.12.1) and never served v3 — blocking v3 distribution and the new `devlair uninstall`.

Now resolves the latest **non-v1** release (v2, v3, … future-proof across major bumps); the `--v1` channel path is unchanged.

```diff
-    | grep -o '"tag_name": *"v2\.[^"]*"' \
+    | grep -oE '"tag_name": *"v[0-9]+\.[^"]*"' \
+    | grep -v '"tag_name": *"v1\.' \
     | head -1 \
     | grep -o '"v[^"]*"' | tr -d '"'
```

Closes #220

## Test plan
- [x] Live `releases` API: old regex resolves `v2.12.1`; new regex resolves `v3.0.0`
- [x] `bash -n install.sh` (syntax)
- [ ] `curl -fsSL …/main/install.sh | bash` on a clean macOS/Linux box installs `devlair 3.0.0` (manual, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)