### PR TITLE
fix(devtools): chown temp installer to target user

### DIFF
--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -186,19 +186,24 @@ _run_as_user() {
 # download_script URL -- download an installer script to a temp file.
 # Prints the temp file path; caller is responsible for cleanup.
 #
-# Under `sudo devlair init` the temp file is created root-owned 0600, but the
-# installers it feeds (uv/pyenv/nvm/bun via _run_as_user, Homebrew via
-# brew_ensure) execute it as the target user through `sudo -u`. Without the
-# chown the unprivileged user cannot read the script and bash reports
-# "Permission denied". chown_user is a no-op when not root (the normal macOS
-# path runs as the user and already owns the file), so this only takes effect
-# on the privileged path that needs it.
+# mktemp creates the file 0600. Under `sudo devlair init` it is root-owned,
+# but some installers run as the target user via `sudo -u` (uv/pyenv/nvm/bun
+# through _run_as_user, Homebrew through brew_ensure), and that user cannot
+# read a root-owned 0600 file — bash reports "Permission denied". Grant read
+# so the dropped-privilege user can source the script.
+#
+# Grant read only — do NOT chown it to the user. Other installers (e.g.
+# tailscale) execute the script as root via `bash "$script"`; a user-owned
+# file in the sticky /tmp would let an unprivileged process rewrite it before
+# root runs it (TOCTOU privilege escalation). Keeping root ownership + write
+# and adding only read closes that window. The scripts are public installers,
+# so world-readable leaks nothing.
 download_script() {
   local url=$1
   local tmp
   tmp=$(mktemp /tmp/devlair.XXXXXX.sh 2>/dev/null || mktemp)
   curl -fsSL "$url" -o "$tmp" >&2
-  chown_user "$tmp"
+  chmod a+r "$tmp"
   printf '%s' "$tmp"
 }
 

--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -185,11 +185,20 @@ _run_as_user() {
 
 # download_script URL -- download an installer script to a temp file.
 # Prints the temp file path; caller is responsible for cleanup.
+#
+# Under `sudo devlair init` the temp file is created root-owned 0600, but the
+# installers it feeds (uv/pyenv/nvm/bun via _run_as_user, Homebrew via
+# brew_ensure) execute it as the target user through `sudo -u`. Without the
+# chown the unprivileged user cannot read the script and bash reports
+# "Permission denied". chown_user is a no-op when not root (the normal macOS
+# path runs as the user and already owns the file), so this only takes effect
+# on the privileged path that needs it.
 download_script() {
   local url=$1
   local tmp
   tmp=$(mktemp /tmp/devlair.XXXXXX.sh 2>/dev/null || mktemp)
   curl -fsSL "$url" -o "$tmp" >&2
+  chown_user "$tmp"
   printf '%s' "$tmp"
 }
 


### PR DESCRIPTION
## Summary

- `download_script()` in `cli/modules/_lib.sh` created the installer temp file `0600` under `sudo devlair init`. When root-owned, the user-level installers it feeds (uv/pyenv/nvm/bun via `_run_as_user`, Homebrew via `brew_ensure`) execute it **as the target user** through `sudo -u`. The unprivileged user could not read the root-owned script, so bash aborted with `Permission denied` and the **Dev tools** (`[8/12]`) and **Claude Code** (`[12/12]`) modules failed.
- Fix: `chmod a+r "$tmp"` right after the download — grant **read** so the dropped-privilege user can source the script.
- **Security:** the fix grants read rather than transferring ownership. Other modules (e.g. `tailscale.sh:93`) execute the downloaded script **as root** via `bash "$script"`; chowning a root-executed file to the user in sticky `/tmp` would open a TOCTOU privilege-escalation window. Keeping root ownership + write and adding only read closes it. (Initial commit used `chown_user`; amended to `chmod a+r` after the security review — see `d8cf8cc`.)
- Affects **every v3 user** running `sudo devlair init` on Linux.

Closes #223

## Test plan

- [x] `bun run lint` (Biome) — clean
- [x] `bun run typecheck` (tsc) — clean
- [x] `bun test` — 183 pass / 0 fail
- [x] Manually verified on affected Linux host: re-running `devlair init` after patching the installed `_lib.sh` completes Dev tools + Claude Code (previously `Permission denied`)
- [x] macOS / non-sudo path unaffected — `chmod a+r` preserves owner read on the user-owned temp file, so same-user `bash "$tmp"` still works
- [x] No privilege regression for root-executed installers (tailscale) — file stays root-owned, user gains read only, not write

🤖 Generated with [Claude Code](https://claude.com/claude-code)
