### PR TITLE
fix(shell): preserve newline on .zshrc alias refresh

### DIFF
--- a/cli/modules/shell.sh
+++ b/cli/modules/shell.sh
@@ -63,7 +63,7 @@ do_run() {
     # The $(...) on $header strips its trailing newline, so the separator must
     # be restored explicitly — otherwise the aliases marker is glued onto the
     # last header line (e.g. `source ".../init.zsh"# ── devlair aliases ─`),
-    # producing a path zsh cannot source. Mirrors the first-time branch below.
+    # producing a path zsh cannot source.
     local header
     header="${existing%%${MARKER}*}"
     header=$(_clean_zshrc "$header")

--- a/cli/modules/shell.sh
+++ b/cli/modules/shell.sh
@@ -59,11 +59,15 @@ do_run() {
   fi
 
   if [[ "$existing" == *"$MARKER"* ]]; then
-    # Refresh: keep everything before the marker, clean it, then append aliases
+    # Refresh: keep everything before the marker, clean it, then append aliases.
+    # The $(...) on $header strips its trailing newline, so the separator must
+    # be restored explicitly — otherwise the aliases marker is glued onto the
+    # last header line (e.g. `source ".../init.zsh"# ── devlair aliases ─`),
+    # producing a path zsh cannot source. Mirrors the first-time branch below.
     local header
     header="${existing%%${MARKER}*}"
     header=$(_clean_zshrc "$header")
-    printf '%s%s\n' "$header" "$aliases" > "$zshrc"
+    printf '%s\n%s\n' "$header" "$aliases" > "$zshrc"
     chown_user "$zshrc"
     json_result "ok" "aliases refreshed in .zshrc"
   else

--- a/cli/src/test/shell-brand.test.ts
+++ b/cli/src/test/shell-brand.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
 import { runModule } from "../lib/runner.js";
@@ -61,5 +61,32 @@ describe("shell module brand persistence", () => {
     const zshrc = readFileSync(join(home, ".zshrc"), "utf8");
     expect(zshrc).toContain(".devlair/brand"); // read logic present
     expect(zshrc).toContain("d e v l a i r"); // default fallback retained
+  });
+});
+
+describe("shell module .zshrc alias refresh", () => {
+  const MARKER = "# ── devlair aliases ─";
+
+  test("refresh keeps a newline between the header and the aliases block", async () => {
+    const home = freshHome();
+    // Simulate a prior devlair-managed .zshrc: a zimfw header ending in the
+    // `source` line, followed by an existing aliases block. The marker being
+    // present forces shell.sh down the refresh path (the bug only triggered on
+    // re-runs, never on first install).
+    const seeded = `export ZIM_HOME="$HOME/.zim"
+source "$ZIM_HOME/init.zsh"
+${MARKER}──
+alias stale="echo old"
+`;
+    writeFileSync(join(home, ".zshrc"), seeded);
+
+    await runShell(home, {});
+
+    const zshrc = readFileSync(join(home, ".zshrc"), "utf8");
+    // Regression: the aliases header must not be glued onto the source line.
+    expect(zshrc).not.toContain('init.zsh"#');
+    expect(zshrc).toContain('source "$ZIM_HOME/init.zsh"\n');
+    // The refreshed block is still present.
+    expect(zshrc).toContain(MARKER);
   });
 });

--- a/cli/src/test/shell-brand.test.ts
+++ b/cli/src/test/shell-brand.test.ts
@@ -9,6 +9,14 @@ const SHELL_MODULE = join(import.meta.dir, "../../modules/shell.sh");
 // The module chowns files to USERNAME; use the real invoking user so the
 // chown succeeds for the unprivileged test process (chowning own files to self).
 const REAL_USER = userInfo({ encoding: "utf8" }).username;
+// Marker string is owned by shell.sh; derive it from the source so the refresh
+// test always drives the refresh branch even if the marker text changes (a
+// hardcoded copy would silently fall through to the first-install path).
+const ALIAS_MARKER = (() => {
+  const m = readFileSync(SHELL_MODULE, "utf8").match(/^MARKER="([^"]*)"/m);
+  if (!m) throw new Error("could not find MARKER definition in shell.sh");
+  return m[1];
+})();
 
 let root: string;
 let counter = 0;
@@ -65,8 +73,6 @@ describe("shell module brand persistence", () => {
 });
 
 describe("shell module .zshrc alias refresh", () => {
-  const MARKER = "# ── devlair aliases ─";
-
   test("refresh keeps a newline between the header and the aliases block", async () => {
     const home = freshHome();
     // Simulate a prior devlair-managed .zshrc: a zimfw header ending in the
@@ -75,7 +81,7 @@ describe("shell module .zshrc alias refresh", () => {
     // re-runs, never on first install).
     const seeded = `export ZIM_HOME="$HOME/.zim"
 source "$ZIM_HOME/init.zsh"
-${MARKER}──
+${ALIAS_MARKER}──
 alias stale="echo old"
 `;
     writeFileSync(join(home, ".zshrc"), seeded);
@@ -87,6 +93,6 @@ alias stale="echo old"
     expect(zshrc).not.toContain('init.zsh"#');
     expect(zshrc).toContain('source "$ZIM_HOME/init.zsh"\n');
     // The refreshed block is still present.
-    expect(zshrc).toContain(MARKER);
+    expect(zshrc).toContain(ALIAS_MARKER);
   });
 });


### PR DESCRIPTION
## Summary

- The refresh branch in `cli/modules/shell.sh` (taken whenever the devlair marker already exists — i.e. **every re-run** of `devlair init`) used `printf '%s%s\n'` with no separator between the header and the aliases block.
- `header=$(...)` strips its trailing newline via command substitution, so the aliases marker was glued onto the last header line: `source "$ZIM_HOME/init.zsh"# ── devlair aliases ─`. zsh then tried to `source` `.../init.zsh#` (nonexistent), breaking shell startup.
- Fix restores the separator (`printf '%s\n%s\n'`) to match the already-correct first-time branch.
- Added a regression test that drives the refresh path and asserts the source line keeps its own line (verified it fails before the fix, passes after).
- **macOS-safe:** pure `.zshrc` text logic, identical on both OSes (zsh is the macOS default shell); makes refresh behave like the first-add path that already works.
- Affects **every v3 user who re-runs `devlair init`**.

Closes #225

## Test plan

- [x] `bun run lint` (Biome) — clean
- [x] `bun run typecheck` (tsc) — clean
- [x] `bun test` — 184 pass / 0 fail (includes new regression test)
- [x] Regression test fails on the pre-fix code (`init.zsh"#` glue reproduced), passes after the fix
- [x] First-time install path unchanged (still hits the `printf '%s\n%s\n'` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)