### PR TITLE
fix(init): prune init logs by run name, not filesystem mtime

### DIFF
--- a/cli/src/lib/logs.ts
+++ b/cli/src/lib/logs.ts
@@ -2,7 +2,7 @@
 // to its own file so failures can be diagnosed without re-running with extra
 // flags.
 
-import { chmodSync, chownSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, chownSync, lstatSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const KEEP_RUNS = 10;
@@ -76,26 +76,22 @@ export function createInitLogDir(userHome: string, now: Date = new Date()): stri
 }
 
 function pruneOldRuns(logsRoot: string, keep: number): void {
-  let entries: { name: string; mtimeMs: number }[];
+  let names: string[];
   try {
-    entries = readdirSync(logsRoot)
-      .filter((name) => name.startsWith(LOG_DIR_PREFIX))
-      .map((name) => {
-        const full = join(logsRoot, name);
-        try {
-          return { name, mtimeMs: statSync(full).mtimeMs };
-        } catch {
-          return null;
-        }
-      })
-      .filter((e): e is { name: string; mtimeMs: number } => e !== null);
+    names = readdirSync(logsRoot).filter((name) => name.startsWith(LOG_DIR_PREFIX));
   } catch {
     return;
   }
-  if (entries.length <= keep) return;
-  entries.sort((a, b) => b.mtimeMs - a.mtimeMs || b.name.localeCompare(a.name));
-  for (const stale of entries.slice(keep)) {
-    const path = join(logsRoot, stale.name);
+  if (names.length <= keep) return;
+  // Sort by directory name, which is the run's ISO-8601 UTC timestamp from
+  // runDirName(). The format is fixed-width, so a plain code-unit sort (default,
+  // locale-independent) orders chronologically. The name is the canonical run
+  // identity; sorting by it avoids depending on filesystem mtime, whose
+  // granularity made an mtime-based sort flaky on CI.
+  names.sort(); // ascending: oldest first
+  const stale = names.slice(0, names.length - keep);
+  for (const name of stale) {
+    const path = join(logsRoot, name);
     try {
       // Re-lstat to guard against a TOCTOU race where the entry was replaced
       // with a symlink between readdirSync and now — never rmSync a symlink target.

--- a/cli/src/test/logs.test.ts
+++ b/cli/src/test/logs.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -28,24 +28,25 @@ describe("createInitLogDir", () => {
   test("prunes older runs, keeping the 10 most recent", () => {
     const logsRoot = join(home, ".devlair", "logs");
     mkdirSync(logsRoot, { recursive: true });
-    // Seed 12 fake older runs, mtimes spaced 1s apart so sort order is stable.
+    // Seed 12 fake older runs. Pruning sorts by directory name (the ISO-8601
+    // run timestamp), so recency is encoded in the name alone — no mtime needed.
     for (let i = 0; i < 12; i++) {
-      const name = `init-2025-01-01T00-00-${i.toString().padStart(2, "0")}Z`;
-      const path = join(logsRoot, name);
-      mkdirSync(path);
-      writeFileSync(join(path, "marker"), name);
-      const t = new Date(2025, 0, 1, 0, 0, i).getTime() / 1000;
-      utimesSync(path, t, t);
+      mkdirSync(join(logsRoot, `init-2025-01-01T00-00-${i.toString().padStart(2, "0")}Z`));
     }
-    createInitLogDir(home);
+    // Explicit `now` newer than every seed (00..11) so the result is
+    // deterministic regardless of the wall clock.
+    createInitLogDir(home, new Date(Date.UTC(2025, 0, 1, 0, 0, 30)));
     const remaining = readdirSync(logsRoot)
       .filter((n) => n.startsWith("init-"))
       .sort();
     // 10 retained including the just-created one.
     expect(remaining.length).toBe(10);
-    // The oldest seeded entries (00, 01) should be gone.
+    // The three oldest seeds (00, 01, 02) should be pruned.
     expect(remaining.some((n) => n.endsWith("-00Z"))).toBe(false);
     expect(remaining.some((n) => n.endsWith("-01Z"))).toBe(false);
+    expect(remaining.some((n) => n.endsWith("-02Z"))).toBe(false);
+    // The just-created run is retained.
+    expect(remaining.some((n) => n.endsWith("-30Z"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- The v3 CI test `createInitLogDir > prunes older runs, keeping the 10 most recent` flaked, failing on the **release 3.0.1** CI (PR #227) and blocking the release.
- Root cause: `pruneOldRuns` (`cli/src/lib/logs.ts`) sorted by `statSync().mtimeMs`. The earlier `localeCompare` tiebreaker (877174c) only fires when mtimes are *exactly equal*; when the CI filesystem returns the seeded mtimes as distinct-but-misordered, the mtime sort wins and prunes the wrong runs.
- Fix: sort by the run directory **name**, which is already the canonical fixed-width ISO-8601 UTC timestamp from `runDirName()` (lexicographic == chronological). Drop `mtime`/`statSync` entirely — deterministic and immune to filesystem timestamp granularity.
- Made the test deterministic: explicit `now` newer than all seeds, seed by name only (no `utimesSync`), and assert both the pruned oldest and the retained new run.

Closes #228

## Test plan

- [x] `bun run lint` (Biome) — clean
- [x] `bun run typecheck` (tsc) — clean
- [x] `bun test` — 183 pass / 0 fail
- [x] Stress: prune test run 50× consecutively — 0 failures (was intermittently failing on CI)
- [x] Pruning semantics unchanged — still keeps the 10 newest runs; name sort == chronological for the fixed ISO format

🤖 Generated with [Claude Code](https://claude.com/claude-code)