### PR TITLE
fix(upgrade): guard v1 self-update against cross-major 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Verifies every component without making changes — checks installed tools, conf
 devlair upgrade
 ```
 
-Checks for a new devlair binary first — if a new version is available, it downloads, replaces, and re-execs so the rest of the upgrade runs new code. Then upgrades system packages and any tools that were installed during init (Docker, GitHub CLI, AWS CLI, pyenv/Python, nvm/Node, Bun). After upgrading, automatically re-applies module configurations (hooks, settings, shell aliases) so new config shapes take effect immediately. Use `--no-self` to skip the binary update.
+Checks for a new devlair binary first — if a newer release of the same major version is available, it downloads, replaces, and re-execs so the rest of the upgrade runs new code. When a newer major version exists (e.g. v3.x while running v1), the self-update is skipped and devlair prints guidance to reinstall via `install.sh` instead (cross-major binaries have a different asset name and runtime and cannot be swapped in place). Then upgrades system packages and any tools that were installed during init (Docker, GitHub CLI, AWS CLI, pyenv/Python, nvm/Node, Bun). After upgrading, automatically re-applies module configurations (hooks, settings, shell aliases) so new config shapes take effect immediately. Use `--no-self` to skip the binary update.
 
 ## Requirements
 

--- a/devlair/features/upgrade.py
+++ b/devlair/features/upgrade.py
@@ -177,6 +177,55 @@ def _installed_version() -> str:
     return __version__
 
 
+INSTALL_CMD = "curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash"
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Parse a dotted version into a tuple of ints, stopping at the first
+    non-numeric component (so '1.2.0-rc1' -> (1, 2, 0))."""
+    parts: list[int] = []
+    for component in version.split("."):
+        num = component.split("-")[0]
+        if not num.isdigit():
+            break
+        parts.append(int(num))
+    return tuple(parts)
+
+
+def _pick_update(releases: list[dict], current: str) -> tuple[str | None, bool]:
+    """Choose the best self-update from a GitHub releases list.
+
+    Returns (latest_same_major_version, newer_major_exists), versions stripped of
+    the leading 'v'. Drafts and prereleases are ignored.
+
+    The self-updater can only swap a same-major binary in place: v1 release
+    assets are named ``devlair-<arch>`` whereas v2+ ship ``devlair-cli-<arch>``
+    (a different runtime entirely), so a v1 binary fetching the absolute-latest
+    release 404s. Resolving the latest *same-major* release fixes in-major
+    updates; the newer-major flag lets the caller redirect to install.sh.
+    """
+    current_t = _version_tuple(current)
+    if not current_t:
+        return None, False
+    current_major = current_t[0]
+
+    best_same: str | None = None
+    newer_major = False
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        tag = str(release.get("tag_name", "")).removeprefix("v")
+        version_t = _version_tuple(tag)
+        if not version_t:
+            continue
+        if version_t[0] == current_major:
+            if best_same is None or version_t > _version_tuple(best_same):
+                best_same = tag
+        elif version_t[0] > current_major:
+            newer_major = True
+    return best_same, newer_major
+
+
 def _self_update() -> Path | None:
     """Check for and install a newer devlair binary.
 
@@ -191,16 +240,26 @@ def _self_update() -> Path | None:
     with console.status("[step]Checking for devlair updates...[/step]", spinner="dots", spinner_style=D_PURPLE):
         try:
             resp = httpx.get(
-                "https://api.github.com/repos/ettoreaquino/devlair/releases/latest",
+                "https://api.github.com/repos/ettoreaquino/devlair/releases?per_page=30",
                 timeout=10,
             )
             resp.raise_for_status()
-            latest = resp.json()["tag_name"].removeprefix("v")
+            latest, newer_major = _pick_update(resp.json(), current)
         except Exception as exc:
             console.print(f"  [warning]Could not check for updates: {exc}[/warning]")
             return None
 
-    if latest == current:
+    # A newer major ships as a separate binary with a different asset name and
+    # runtime — it cannot be swapped in place, so point the user at install.sh
+    # instead of attempting a download that would 404.
+    if newer_major:
+        console.print("  [warning]A newer major version of devlair is available.[/warning]")
+        console.print("  [muted]New majors ship as a separate binary and can't be self-updated in place.[/muted]")
+        console.print("  [info]Upgrade with:[/info]")
+        console.print(f"    [accent]{INSTALL_CMD}[/accent]")
+        return None
+
+    if not latest or latest == current:
         console.print(f"  [muted]devlair {current} is already up to date.[/muted]")
         return None
 

--- a/devlair/features/upgrade.py
+++ b/devlair/features/upgrade.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 
 import httpx
@@ -177,12 +178,19 @@ def _installed_version() -> str:
     return __version__
 
 
+# Display-only: printed as upgrade guidance, never executed. Do not pass to a
+# shell/subprocess.
 INSTALL_CMD = "curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | sudo bash"
+
+# A real devlair release tag is canonical MAJOR.MINOR.PATCH (release-please).
+# Anything else is rejected before its tag can flow into a download URL.
+_CANONICAL_VERSION = re.compile(r"\d+\.\d+\.\d+")
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:
-    """Parse a dotted version into a tuple of ints, stopping at the first
-    non-numeric component (so '1.2.0-rc1' -> (1, 2, 0))."""
+    """Parse a dotted version into a tuple of ints. Each component is split on
+    '-' to drop a pre-release suffix, and parsing stops at the first component
+    that is not purely numeric (so '1.2.0-rc1' -> (1, 2, 0); '1.x.0' -> (1,))."""
     parts: list[int] = []
     for component in version.split("."):
         num = component.split("-")[0]
@@ -196,13 +204,16 @@ def _pick_update(releases: list[dict], current: str) -> tuple[str | None, bool]:
     """Choose the best self-update from a GitHub releases list.
 
     Returns (latest_same_major_version, newer_major_exists), versions stripped of
-    the leading 'v'. Drafts and prereleases are ignored.
+    the leading 'v'. Drafts, prereleases, and non-canonical tags are ignored.
 
     The self-updater can only swap a same-major binary in place: v1 release
     assets are named ``devlair-<arch>`` whereas v2+ ship ``devlair-cli-<arch>``
     (a different runtime entirely), so a v1 binary fetching the absolute-latest
     release 404s. Resolving the latest *same-major* release fixes in-major
     updates; the newer-major flag lets the caller redirect to install.sh.
+
+    Only canonical MAJOR.MINOR.PATCH tags are considered, so the returned
+    version is always safe to interpolate into the binary download URL.
     """
     current_t = _version_tuple(current)
     if not current_t:
@@ -210,17 +221,18 @@ def _pick_update(releases: list[dict], current: str) -> tuple[str | None, bool]:
     current_major = current_t[0]
 
     best_same: str | None = None
+    best_same_t: tuple[int, ...] = ()
     newer_major = False
     for release in releases:
         if release.get("draft") or release.get("prerelease"):
             continue
         tag = str(release.get("tag_name", "")).removeprefix("v")
-        version_t = _version_tuple(tag)
-        if not version_t:
+        if not _CANONICAL_VERSION.fullmatch(tag):
             continue
+        version_t = _version_tuple(tag)
         if version_t[0] == current_major:
-            if best_same is None or version_t > _version_tuple(best_same):
-                best_same = tag
+            if version_t > best_same_t:
+                best_same, best_same_t = tag, version_t
         elif version_t[0] > current_major:
             newer_major = True
     return best_same, newer_major

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -73,3 +73,17 @@ def test_pick_update_unparseable_current_is_safe():
 
     assert latest_same_major is None
     assert newer_major is False
+
+
+def test_pick_update_rejects_noncanonical_tags():
+    # Only canonical MAJOR.MINOR.PATCH tags may be selected — a crafted tag must
+    # never flow into the binary download URL (e.g. `v{latest}/devlair-<arch>`).
+    releases = [
+        _rel("v1.foo/../evil"),  # would parse to (1,) but is not canonical
+        _rel("v1.2"),  # two-part, not canonical
+        _rel("v1.3.0"),  # the only real same-major release
+    ]
+    latest_same_major, newer_major = upgrade._pick_update(releases, "1.1.0")
+
+    assert latest_same_major == "1.3.0"
+    assert newer_major is False

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,0 +1,75 @@
+"""Tests for the self-update release resolution in features/upgrade.
+
+Regression coverage for the v1 -> v3 upgrade 404: a v1 binary resolved the
+absolute-latest release (now v3) and tried to download the old `devlair-<arch>`
+asset, which no longer exists on v2+ releases (renamed `devlair-cli-<arch>`).
+"""
+
+from devlair.features import upgrade
+
+
+def _rel(tag: str, *, draft: bool = False, prerelease: bool = False) -> dict:
+    return {"tag_name": tag, "draft": draft, "prerelease": prerelease}
+
+
+def test_version_tuple_parses_and_stops_at_nonnumeric():
+    assert upgrade._version_tuple("1.8.0") == (1, 8, 0)
+    assert upgrade._version_tuple("v3.0.0".removeprefix("v")) == (3, 0, 0)
+    assert upgrade._version_tuple("1.2.0-rc1") == (1, 2, 0)  # suffix stripped from patch
+    assert upgrade._version_tuple("1.x.0") == (1,)  # stops at first non-numeric component
+    assert upgrade._version_tuple("garbage") == ()
+
+
+def test_pick_update_flags_newer_major_for_v1_install():
+    # The exact scenario that 404'd: on v1.1.0 with v3 released.
+    releases = [_rel("v3.0.0"), _rel("v2.12.1"), _rel("v1.8.0"), _rel("v1.1.0")]
+    latest_same_major, newer_major = upgrade._pick_update(releases, "1.1.0")
+
+    assert newer_major is True
+    # The latest same-major (v1) release is still resolved, but the caller
+    # redirects to install.sh because a newer major exists.
+    assert latest_same_major == "1.8.0"
+
+
+def test_pick_update_in_major_only():
+    releases = [_rel("v1.8.0"), _rel("v1.2.0"), _rel("v1.1.0")]
+    latest_same_major, newer_major = upgrade._pick_update(releases, "1.1.0")
+
+    assert newer_major is False
+    assert latest_same_major == "1.8.0"
+
+
+def test_pick_update_already_latest_in_major():
+    releases = [_rel("v1.8.0"), _rel("v1.1.0")]
+    latest_same_major, newer_major = upgrade._pick_update(releases, "1.8.0")
+
+    assert newer_major is False
+    assert latest_same_major == "1.8.0"
+
+
+def test_pick_update_picks_highest_regardless_of_list_order():
+    # GitHub usually returns newest-first, but don't rely on it.
+    releases = [_rel("v1.1.0"), _rel("v1.8.0"), _rel("v1.2.0")]
+    latest_same_major, _ = upgrade._pick_update(releases, "1.1.0")
+
+    assert latest_same_major == "1.8.0"
+
+
+def test_pick_update_ignores_drafts_and_prereleases():
+    releases = [
+        _rel("v2.0.0-rc1", prerelease=True),
+        _rel("v1.9.0", draft=True),
+        _rel("v1.8.0"),
+    ]
+    latest_same_major, newer_major = upgrade._pick_update(releases, "1.1.0")
+
+    assert newer_major is False  # the only v2 entry is a prerelease
+    assert latest_same_major == "1.8.0"  # the v1.9.0 draft is ignored
+
+
+def test_pick_update_unparseable_current_is_safe():
+    releases = [_rel("v3.0.0")]
+    latest_same_major, newer_major = upgrade._pick_update(releases, "dev")
+
+    assert latest_same_major is None
+    assert newer_major is False


### PR DESCRIPTION
## Summary

- v1's `devlair upgrade` self-updater (`devlair/features/upgrade.py` `_self_update`) queried `releases/latest` — now `v3.0.0` — and built a `devlair-<arch>` asset URL. v2+ renamed the asset to `devlair-cli-<arch>` (a different runtime), so a v1 binary 404s: `404 Not Found for .../releases/download/v3.0.0/devlair-linux-x86_64`. The v1 in-place self-update can never cross into v2+.
- Fix: resolve the latest **same-major** release for in-place updates (v1.x → v1.y still works), and when a **newer major** exists, print actionable `install.sh` guidance and return cleanly instead of attempting an impossible binary swap.
- Factored release selection into a pure, unit-tested `_pick_update` helper.
- **Security (review):** `_pick_update` only accepts canonical `MAJOR.MINOR.PATCH` tags, so a crafted/non-canonical `tag_name` can't flow into the binary download URL. `INSTALL_CMD` documented as display-only.
- v1 Python (`devlair/` tree); no macOS build affected.

Closes #230

## Test plan

- [x] `uv run ruff check devlair/ tests/` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest tests/unit/test_upgrade.py` — 8 pass (v1→v3 guard, in-major update, already-latest, ordering, draft/prerelease, unparseable current, non-canonical-tag rejection)
- [x] Cross-major path returns `install.sh` guidance instead of a 404 download (code-verified: the `newer_major` branch returns `None` before the download block)
- [x] Crafted tag rejected before URL construction (code-verified + `test_pick_update_rejects_noncanonical_tags`)

> Note: the full `tests/unit/` suite has one **pre-existing, unrelated** failure (`test_sync.py::test_remove_by_name_not_found`, a Rich ANSI-color rendering artifact) that also fails on `main` and is not exercised by this PR. No CI workflow runs pytest (v1 Python tests are a manual gate per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
