### PR TITLE
feat(devtools): install VS Code + Terminal.app Dracula on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ SSH hardening, UFW firewall, Fail2Ban, and Tailscale VPN are set up out of the b
 
 **Composable**
 
-13 modules you can run individually with `--only` or skip with `--skip`. Each module is self-contained and does one thing well.
+14 modules you can run individually with `--only` or skip with `--skip`. Each module is self-contained and does one thing well.
 
 </td>
 </tr>
@@ -204,6 +204,7 @@ devlair  claude  max5x
 | `github` — SSH key + git config | ✓ | ✓ | ✓ |
 | `shell` — aliases + login banner | ✓ | ✓ | ✓ |
 | `gnome_terminal` — Dracula palette | ✓ | — | — |
+| `macos_terminal` — Terminal.app Dracula | — | — | ✓ |
 | `claude` — Claude Code | ○ | ○ | ○ |
 
 Legend: ✓ runs by default · ○ available, opt-in (`--only`) · — not applicable
@@ -214,7 +215,7 @@ Packages install via `apt`. Core essentials (`git`, `curl`, `vim`, `htop`, `tmux
 
 ### On macOS
 
-Before the wizard UI starts, a pre-flight verifies you're a local admin and installs Homebrew if it's missing — running Homebrew's official installer interactively (it prompts for your password over the terminal). This is the single point of Homebrew installation; all packages then install via `brew`. Linux-only modules (`timezone`, `ssh`, `firewall`, `gnome_terminal`) are skipped. In `devtools`, `uv`, `pyenv`, `fzf`, `gh`, `aws`, and `bun` install via `brew` (with pyenv's build deps), while `nvm` uses its official install script. **Docker is not installed** — the module prints guidance to install Docker Desktop for Mac and continues without error.
+Before the wizard UI starts, a pre-flight verifies you're a local admin and installs Homebrew if it's missing — running Homebrew's official installer interactively (it prompts for your password over the terminal). This is the single point of Homebrew installation; all packages then install via `brew`. Linux-only modules (`timezone`, `ssh`, `firewall`, `gnome_terminal`) are skipped. In `devtools`, `uv`, `pyenv`, `fzf`, `gh`, `aws`, `bun`, and **VS Code** install via `brew` (with pyenv's build deps), while `nvm` uses its official install script. **Docker is not installed** — the module prints guidance to install Docker Desktop for Mac and continues without error. The `macos_terminal` module applies the Dracula color scheme and font to Terminal.app. The `shell` module adds a `code` alias when VS Code.app is present but the `code` binary is not yet on `PATH`.
 
 <details>
 <summary><b>Homebrew</b> — package-manager bootstrap (macOS)</summary>
@@ -297,8 +298,9 @@ Installs (skipping any that already exist):
 | [gh](https://cli.github.com/) | GitHub CLI |
 | [aws](https://aws.amazon.com/cli/) | AWS CLI v2 |
 | [Bun](https://bun.sh/) | JavaScript runtime |
+| [VS Code](https://code.visualstudio.com/) | Code editor (macOS + Linux only) |
 
-On Linux/WSL these install via apt/curl/git (AWS CLI v2 is GPG-verified). On macOS, `uv`, `pyenv`, `fzf`, `gh`, `aws`, and `bun` install via `brew` (plus pyenv's build deps), while `nvm` uses its official install script. **Docker is not installed on WSL or macOS** — the module prints guidance to install Docker Desktop and continues without error.
+On Linux/WSL these install via apt/curl/git (AWS CLI v2 is GPG-verified; VS Code installs via the Microsoft apt repository with GPG key verification on Linux and is skipped on WSL). On macOS, `uv`, `pyenv`, `fzf`, `gh`, `aws`, `bun`, and `VS Code` install via `brew` (plus pyenv's build deps), while `nvm` uses its official install script. **Docker is not installed on WSL or macOS** — the module prints guidance to install Docker Desktop and continues without error.
 
 </details>
 
@@ -312,7 +314,7 @@ Generates an `ed25519` SSH key for GitHub, configures `~/.ssh/config`, tests the
 <details>
 <summary><b>Shell</b> — aliases + login banner</summary>
 
-Appends aliases to `.zshrc` and a `tmx` command for session management. Aliases are platform-aware: `ll`, `ports`, and `update` expand differently on macOS (`ls -G`, `lsof`, `brew`) vs Linux/WSL (`ls --color`, `ss`, `apt`). The `BROWSER` env var is set to `wslview` on WSL. The login banner title defaults to `devlair` but reflects the `--brand NAME` value when one is set (persisted to `~/.devlair/brand` and reused automatically on subsequent runs). The banner shows live tmux sessions:
+Appends aliases to `.zshrc` and a `tmx` command for session management. Aliases are platform-aware: `ll`, `ports`, and `update` expand differently on macOS (`ls -G`, `lsof`, `brew`) vs Linux/WSL (`ls --color`, `ss`, `apt`). On macOS, a `code` alias pointing to `Visual Studio Code.app` is added when VS Code is installed but the `code` binary is not yet on `PATH`. The `BROWSER` env var is set to `wslview` on WSL. The login banner title defaults to `devlair` but reflects the `--brand NAME` value when one is set (persisted to `~/.devlair/brand` and reused automatically on subsequent runs). The banner shows live tmux sessions:
 
 ```
 ╭─ myhost ──────────────────────────────────────╮
@@ -330,6 +332,13 @@ Appends aliases to `.zshrc` and a `tmx` command for session management. Aliases 
 <summary><b>GNOME Terminal</b> — Dracula color scheme</summary>
 
 Applies the full 16-color Dracula palette to your default GNOME Terminal profile. Linux-only — auto-skipped on WSL and macOS.
+
+</details>
+
+<details>
+<summary><b>Terminal.app</b> — Dracula color scheme (macOS)</summary>
+
+Downloads the official [Dracula theme for Terminal.app](https://draculatheme.com/terminal) from the `dracula/terminal-app` release, imports it via `open`, sets it as the default profile, and applies it as the startup (on-open) window profile. macOS-only — auto-skipped on Linux and WSL. The `reapply` flag ensures the theme is re-applied during `devlair upgrade` if it has drifted.
 
 </details>
 
@@ -385,7 +394,7 @@ bun run lint         # biome check
 bun run compile      # standalone binary → dist/devlair
 ```
 
-Open the repo in your editor of choice. devlair does not install VS Code or define a `code` alias — the `code` command comes from VS Code's own shell integration (on macOS, "Shell Command: Install 'code' command in PATH"; on Linux it ships with the apt/snap package).
+Open the repo in your editor of choice. devlair installs VS Code via the `devtools` module on macOS (brew cask) and Linux (Microsoft apt repository with GPG verification) — WSL is skipped. The `shell` module adds a `code` alias on macOS when VS Code.app is present but the `code` binary is not yet on `PATH`.
 
 ### Releasing
 

--- a/devlair/modules/__init__.py
+++ b/devlair/modules/__init__.py
@@ -7,6 +7,7 @@ from devlair.modules import (
     firewall,
     github,
     gnome_terminal,
+    macos_terminal,
     rclone,
     shell,
     ssh,
@@ -41,11 +42,12 @@ MODULE_SPECS: list[ModuleSpec] = [
     ModuleSpec("firewall",       "Firewall + Fail2Ban",    firewall,       "network",     deps=["ssh"],              platforms={"linux"}),
     ModuleSpec("zsh",            "Zsh + Dracula",          zsh,            "core",        reapply=True,              platforms={"linux", "wsl", "macos"}),
     ModuleSpec("tmux",           "tmux",                   tmux,           "coding",      reapply=True,              platforms={"linux", "wsl", "macos"}),
-    ModuleSpec("devtools",       "Dev tools",              devtools,       "coding",      reapply=True),
+    ModuleSpec("devtools",       "Dev tools",              devtools,       "coding",      reapply=True,              platforms={"linux", "wsl", "macos"}),
     ModuleSpec("rclone",         "rclone sync",            rclone,         "cloud-sync",                              default_on=set(),                              platforms={"linux", "wsl", "macos"}),
     ModuleSpec("github",         "GitHub SSH key",         github,         "coding",                                 platforms={"linux", "wsl", "macos"}),
     ModuleSpec("shell",          "Shell aliases",          shell,          "core",        deps=["zsh"], reapply=True, platforms={"linux", "wsl", "macos"}),
     ModuleSpec("gnome_terminal", "Gnome Terminal Dracula", gnome_terminal, "desktop",     reapply=True,              platforms={"linux"}),
+    ModuleSpec("macos_terminal", "Terminal.app Dracula",  macos_terminal, "desktop",     reapply=True,              platforms={"macos"}),
     ModuleSpec("claude",         "Claude Code",            claude,         "ai",          deps=["devtools"], reapply=True, default_on=set(),                         platforms={"linux", "wsl", "macos"}),
 ]
 # fmt: on

--- a/devlair/modules/devtools.py
+++ b/devlair/modules/devtools.py
@@ -12,6 +12,8 @@ TOOLS = ["uv", "pyenv", "nvm", "fzf", "docker", "gh", "aws", "bun"]
 # AWS CLI v2 public GPG key ID used to sign release bundles.
 _AWS_CLI_GPG_KEY_URL = "https://awscli.amazonaws.com/awscli-exe-linux-public-key.asc"
 
+_VSCODE_APP = Path("/Applications/Visual Studio Code.app")
+
 
 def _bun_exists(user_home: Path) -> bool:
     return runner.cmd_exists("bun") or (user_home / ".bun" / "bin" / "bun").exists()
@@ -233,8 +235,7 @@ def run(ctx: SetupContext) -> ModuleResult:
         installed.append("bun")
 
     # ── VS Code ───────────────────────────────────────────────────────────────
-    _vscode_app = Path("/Applications/Visual Studio Code.app")
-    if runner.cmd_exists("code") or (ctx.platform == "macos" and _vscode_app.exists()):
+    if runner.cmd_exists("code") or (ctx.platform == "macos" and _VSCODE_APP.exists()):
         skipped.append("vscode")
     elif ctx.platform == "macos":
         console.print("    [muted]VS Code...[/muted]")
@@ -276,12 +277,8 @@ def run(ctx: SetupContext) -> ModuleResult:
 
 
 def check() -> list[CheckItem]:
-    import sys
-
     user_home = Path("~").expanduser()
-    vscode_ok = runner.cmd_exists("code") or (
-        sys.platform == "darwin" and Path("/Applications/Visual Studio Code.app").exists()
-    )
+    vscode_ok = runner.cmd_exists("code") or _VSCODE_APP.exists()
     return [
         CheckItem(
             label=t,

--- a/devlair/modules/devtools.py
+++ b/devlair/modules/devtools.py
@@ -232,6 +232,41 @@ def run(ctx: SetupContext) -> ModuleResult:
         safe_log_install(ctx.user_home, tool="bun", source="bun.sh")
         installed.append("bun")
 
+    # ── VS Code ───────────────────────────────────────────────────────────────
+    _vscode_app = Path("/Applications/Visual Studio Code.app")
+    if runner.cmd_exists("code") or (ctx.platform == "macos" and _vscode_app.exists()):
+        skipped.append("vscode")
+    elif ctx.platform == "macos":
+        console.print("    [muted]VS Code...[/muted]")
+        runner.run_shell_as(
+            ctx.username,
+            "brew install --cask --quiet visual-studio-code",
+            quiet=True,
+        )
+        safe_log_install(ctx.user_home, tool="vscode", source="brew:cask:visual-studio-code", verified=True)
+        installed.append("vscode")
+    elif ctx.platform == "linux":
+        console.print("    [muted]VS Code...[/muted]")
+        runner.run_shell(
+            """
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+                | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+            chmod a+r /etc/apt/keyrings/microsoft.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] \
+                https://packages.microsoft.com/repos/code stable main" \
+                > /etc/apt/sources.list.d/vscode.list
+            apt-get update -qq
+            apt-get install -y -qq code
+            """,
+            quiet=True,
+        )
+        safe_log_install(ctx.user_home, tool="vscode", source="apt:packages.microsoft.com", verified=True)
+        installed.append("vscode")
+    else:
+        # WSL: VS Code is installed on the Windows side with Remote WSL extension
+        skipped.append("vscode")
+
     parts = []
     if installed:
         parts.append(f"installed: {', '.join(installed)}")
@@ -241,7 +276,12 @@ def run(ctx: SetupContext) -> ModuleResult:
 
 
 def check() -> list[CheckItem]:
+    import sys
+
     user_home = Path("~").expanduser()
+    vscode_ok = runner.cmd_exists("code") or (
+        sys.platform == "darwin" and Path("/Applications/Visual Studio Code.app").exists()
+    )
     return [
         CheckItem(
             label=t,
@@ -262,5 +302,10 @@ def check() -> list[CheckItem]:
             label="bun",
             status="ok" if _bun_exists(user_home) else "warn",
             detail="installed" if _bun_exists(user_home) else "missing — required for Claude Code channels",
+        ),
+        CheckItem(
+            label="vscode",
+            status="ok" if vscode_ok else "warn",
+            detail="installed" if vscode_ok else "missing",
         ),
     ]

--- a/devlair/modules/macos_terminal.py
+++ b/devlair/modules/macos_terminal.py
@@ -1,0 +1,68 @@
+import os
+import pwd
+from pathlib import Path
+
+from devlair import runner
+from devlair.context import CheckItem, ModuleResult, SetupContext
+
+LABEL = "Terminal.app Dracula"
+
+_DRACULA_URL = "https://raw.githubusercontent.com/dracula/terminal-app/master/Dracula.terminal"
+
+
+def _open_terminal_file(username: str, filepath: Path) -> None:
+    """Open a .terminal file so Terminal.app imports the profile.
+
+    Uses launchctl asuser when running as root so the open command reaches
+    the user's Aqua session; falls back to sudo -u otherwise.
+    """
+    uid = pwd.getpwnam(username).pw_uid
+    if os.geteuid() == 0:
+        runner.run_shell(f'launchctl asuser {uid} /usr/bin/open "{filepath}"', quiet=True)
+    else:
+        runner.run_shell_as(username, f'open "{filepath}"', quiet=True)
+
+
+def _default_profile(username: str) -> str:
+    return runner.get_output(
+        f'sudo -u "{username}" defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || true'
+        if os.geteuid() == 0
+        else 'defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || true'
+    ).strip()
+
+
+def run(ctx: SetupContext) -> ModuleResult:
+    if _default_profile(ctx.username) == "Dracula":
+        return ModuleResult(status="ok", detail="Dracula already default")
+
+    theme_file = runner.safe_tempfile(suffix=".terminal")
+    try:
+        runner.run_shell(f'curl -fsSL "{_DRACULA_URL}" -o "{theme_file}"', quiet=True)
+        _open_terminal_file(ctx.username, theme_file)
+        runner.run_shell_as(
+            ctx.username,
+            """
+            sleep 1
+            defaults write com.apple.Terminal "Default Window Settings" "Dracula"
+            defaults write com.apple.Terminal "Startup Window Settings" "Dracula"
+            """,
+            quiet=True,
+        )
+    finally:
+        theme_file.unlink(missing_ok=True)
+
+    return ModuleResult(status="ok", detail="Dracula theme imported and set as default")
+
+
+def check() -> list[CheckItem]:
+    current = runner.get_output(
+        "defaults read com.apple.Terminal 'Default Window Settings' 2>/dev/null || true"
+    ).strip()
+    ok = current == "Dracula"
+    return [
+        CheckItem(
+            label="Terminal.app Dracula",
+            status="ok" if ok else "warn",
+            detail="Dracula is default" if ok else f"current: {current or 'none'}",
+        )
+    ]

--- a/devlair/modules/macos_terminal.py
+++ b/devlair/modules/macos_terminal.py
@@ -11,9 +11,7 @@ _DRACULA_URL = "https://raw.githubusercontent.com/dracula/terminal-app/master/Dr
 
 
 def _open_terminal_file(username: str, filepath: Path) -> None:
-    """Open a .terminal file so Terminal.app imports the profile.
-
-    Uses launchctl asuser when running as root so the open command reaches
+    """Uses launchctl asuser when running as root so the open command reaches
     the user's Aqua session; falls back to sudo -u otherwise.
     """
     uid = pwd.getpwnam(username).pw_uid

--- a/devlair/modules/macos_terminal.py
+++ b/devlair/modules/macos_terminal.py
@@ -7,7 +7,12 @@ from devlair.context import CheckItem, ModuleResult, SetupContext
 
 LABEL = "Terminal.app Dracula"
 
-_DRACULA_URL = "https://raw.githubusercontent.com/dracula/terminal-app/master/Dracula.terminal"
+# Pinned to commit 9ca4acf (2018-10-05 "Update font to SF Mono (macOS Mojave)").
+# To update: fetch the new commit SHA from dracula/terminal-app, download the file,
+# recompute the SHA-256, and update both constants.
+_DRACULA_COMMIT = "9ca4acf67fa43c51b21248a243407fd1549f4268"
+_DRACULA_URL = f"https://raw.githubusercontent.com/dracula/terminal-app/{_DRACULA_COMMIT}/Dracula.terminal"
+_DRACULA_SHA256 = "2d29ed73a31c343098cb405f12fdb48462382b37eb793300c2109e4a281b794d"
 
 
 def _open_terminal_file(username: str, filepath: Path) -> None:
@@ -36,6 +41,7 @@ def run(ctx: SetupContext) -> ModuleResult:
     theme_file = runner.safe_tempfile(suffix=".terminal")
     try:
         runner.run_shell(f'curl -fsSL "{_DRACULA_URL}" -o "{theme_file}"', quiet=True)
+        runner.verify_checksum(theme_file, _DRACULA_SHA256)
         _open_terminal_file(ctx.username, theme_file)
         runner.run_shell_as(
             ctx.username,

--- a/devlair/modules/shell.py
+++ b/devlair/modules/shell.py
@@ -22,6 +22,9 @@ alias dps='docker ps --format "table {{.Names}}\\t{{.Status}}\\t{{.Ports}}"'
 alias ts='tailscale status'
 alias t='tmux new-session -A -s dev'
 alias bcat='bat --paging=never'
+if [[ "$(uname)" == "Darwin" ]] && [ -d "/Applications/Visual Studio Code.app" ] && ! command -v code &>/dev/null; then
+  alias code='/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
+fi
 tmx() {
   if [ "$1" = "new" ]; then
     shift

--- a/tests/unit/test_module_registry.py
+++ b/tests/unit/test_module_registry.py
@@ -36,7 +36,7 @@ class TestModuleSpecs:
         assert REAPPLY_KEYS == {s.key for s in MODULE_SPECS if s.reapply}
 
     def test_spec_count(self):
-        assert len(MODULE_SPECS) == 13
+        assert len(MODULE_SPECS) == 14
 
     def test_all_specs_have_valid_platforms(self):
         valid = {"linux", "wsl", "macos"}
@@ -52,7 +52,7 @@ class TestModuleSpecs:
 class TestResolveOrder:
     def test_all_modules_when_none(self):
         result = resolve_order(None)
-        assert len(result) == 13
+        assert len(result) == 14
         assert result == MODULE_SPECS
 
     def test_single_module_no_deps(self):
@@ -102,7 +102,7 @@ class TestResolveOrder:
 
     def test_no_platform_returns_all(self):
         result = resolve_order(platform=None)
-        assert len(result) == 13
+        assert len(result) == 14
 
     def test_platform_filtered_deps_not_pulled_in(self):
         """Requesting firewall on WSL returns empty — firewall is excluded."""


### PR DESCRIPTION
## Summary

- Add VS Code installation to `devtools` module: `brew install --cask` on macOS, Microsoft apt repo (GPG-verified) on Linux, intentionally skipped on WSL (Windows-side install + Remote WSL extension)
- Add `code` alias to `.zshrc` via `shell` module for macOS when the app bundle exists but `code` is not yet on PATH
- New `macos_terminal` module (desktop group, `platforms={"macos"}`): downloads `Dracula.terminal` from the official `dracula/terminal-app` repo, imports via `launchctl asuser`/`open`, and sets Dracula as the default and startup profile
- Expand `devtools` platforms to `{linux, wsl, macos}` (the code already handled macOS branches; the spec was behind)
- Update module count assertions in registry tests (13 → 14)

All three changes are fully idempotent — skip guards fire on `cmd_exists`, app bundle check, and `Default Window Settings == "Dracula"` respectively.

Closes #250

## Test plan

- [ ] `devlair init` on clean macOS: VS Code installed, `code` alias works in new shell, Terminal.app defaults to Dracula
- [ ] Re-run `devlair init`: VS Code skipped, Terminal.app skipped (already default)
- [ ] `devlair init` on Linux: VS Code installed via apt, `code` in PATH (no alias needed)
- [ ] `devlair init` on WSL: VS Code listed as skipped (expected)
- [ ] `devlair doctor`: reports `vscode ok` and `Terminal.app Dracula ok` on macOS
- [ ] `devlair upgrade` on existing macOS install: picks up changes without reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)