### PR TITLE
fix(upgrade): correct asset name for self-update binary download

### DIFF
--- a/cli/src/commands/upgrade.tsx
+++ b/cli/src/commands/upgrade.tsx
@@ -136,8 +136,9 @@ async function checkSelfUpdate(currentVersion: string): Promise<SelfUpdateResult
     }
 
     // Download the new binary
+    const os = process.platform === "darwin" ? "darwin" : "linux";
     const arch = process.arch === "x64" ? "x86_64" : "aarch64";
-    const url = `https://github.com/ettoreaquino/devlair/releases/download/v${latest}/devlair-linux-${arch}`;
+    const url = `https://github.com/ettoreaquino/devlair/releases/download/v${latest}/devlair-cli-${os}-${arch}`;
 
     const binResp = await fetch(url, { signal: AbortSignal.timeout(60_000), redirect: "follow" });
     if (!binResp.ok) throw new Error(`Download failed: HTTP ${binResp.status}`);

--- a/cli/src/commands/upgrade.tsx
+++ b/cli/src/commands/upgrade.tsx
@@ -6,8 +6,8 @@
  * 3. Re-apply: re-run REAPPLY_KEYS modules to refresh configs.
  */
 
-import { chmodSync, renameSync, writeFileSync } from "node:fs";
-import { hostname } from "node:os";
+import { chmodSync, mkdtempSync, renameSync, writeFileSync } from "node:fs";
+import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
 import { useApp } from "ink";
 import { Box, Text } from "ink";
@@ -130,13 +130,15 @@ async function checkSelfUpdate(currentVersion: string): Promise<SelfUpdateResult
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const data = (await resp.json()) as { tag_name: string };
     const latest = data.tag_name.replace(/^v/, "");
+    if (!/^\d+\.\d+\.\d+$/.test(latest)) throw new Error(`Invalid version format: ${latest}`);
 
     if (latest === currentVersion) {
       return { status: "up-to-date", detail: `devlair ${currentVersion} is already up to date.` };
     }
 
     // Download the new binary
-    const os = process.platform === "darwin" ? "darwin" : "linux";
+    const detectedPlatform = detectPlatform();
+    const os = detectedPlatform === "macos" ? "darwin" : "linux";
     const arch = process.arch === "x64" ? "x86_64" : "aarch64";
     const url = `https://github.com/ettoreaquino/devlair/releases/download/v${latest}/devlair-cli-${os}-${arch}`;
 
@@ -146,7 +148,8 @@ async function checkSelfUpdate(currentVersion: string): Promise<SelfUpdateResult
 
     // Write to /usr/local/bin/devlair
     const installPath = "/usr/local/bin/devlair";
-    const tmpPath = join("/tmp", `devlair-update-${Date.now()}`);
+    const tmpDir = mkdtempSync(join(tmpdir(), "devlair-update-"));
+    const tmpPath = join(tmpDir, "devlair");
     writeFileSync(tmpPath, buffer);
     chmodSync(tmpPath, 0o755);
 


### PR DESCRIPTION
## Summary

- Self-update in `devlair upgrade` was constructing the wrong GitHub release asset URL, causing HTTP 404 for all update checks where a newer version is available
- Asset prefix was `devlair-` instead of `devlair-cli-` (what release CI publishes)
- OS component was hardcoded to `linux`, breaking macOS self-updates entirely
- Fix: detect OS via `process.platform` and use the correct `devlair-cli-{os}-{arch}` naming

Closes #255

## Test plan

- [ ] `devlair upgrade` on macOS (aarch64): downloads `devlair-cli-darwin-aarch64` from the correct URL <!-- needs-manual: requires macOS environment with a newer release available -->
- [ ] `devlair upgrade` on Linux (x86_64): downloads `devlair-cli-linux-x86_64` from the correct URL <!-- needs-manual: requires Linux environment with a newer release available -->
- [x] When already on the latest version: prints "up to date" without hitting the binary URL <!-- code-verified: upgrade.tsx:134 returns early before URL is constructed -->
- [x] typecheck passes <!-- automated: tsc --noEmit exits 0 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
