### PR TITLE
fix(macos-terminal): name temp file Dracula.terminal so profile registers correctly

### DIFF
--- a/cli/modules/macos-terminal.sh
+++ b/cli/modules/macos-terminal.sh
@@ -26,6 +26,19 @@ _defaults_read_profile() {
   fi
 }
 
+# Returns 0 if the Dracula profile is actually registered in Terminal.app's Window Settings.
+# Terminal.app names imported profiles after the filename stem, not the plist name key, so
+# a temp-file import can register under the wrong name even when Default Window Settings = Dracula.
+_dracula_profile_registered() {
+  local prefs
+  if _is_root; then
+    prefs="/Users/$USERNAME/Library/Preferences/com.apple.Terminal.plist"
+  else
+    prefs="$HOME/Library/Preferences/com.apple.Terminal.plist"
+  fi
+  /usr/libexec/PlistBuddy -c "Print :'Window Settings':Dracula" "$prefs" > /dev/null 2>&1
+}
+
 _open_terminal_file() {
   local path=$1
   if _is_root; then
@@ -42,14 +55,17 @@ _open_terminal_file() {
 do_run() {
   local current
   current=$(_defaults_read_profile | tr -d '[:space:]')
-  if [[ "$current" == "Dracula" ]]; then
+  if [[ "$current" == "Dracula" ]] && _dracula_profile_registered; then
     json_result "ok" "Dracula already default"
     return
   fi
 
   json_progress "downloading Dracula.terminal"
-  local tmp
-  tmp=$(mktemp /tmp/devlair.XXXXXX.terminal 2>/dev/null || mktemp)
+  # The file must be named Dracula.terminal — Terminal.app uses the filename stem
+  # as the registered profile name, ignoring the name key inside the plist.
+  local tmpdir tmp
+  tmpdir=$(mktemp -d)
+  tmp="$tmpdir/Dracula.terminal"
 
   curl -fsSL "$_DRACULA_URL" -o "$tmp" >&2
 
@@ -58,7 +74,7 @@ do_run() {
   local actual
   actual=$(shasum -a 256 "$tmp" | awk '{print $1}')
   if [[ "$actual" != "$_DRACULA_SHA256" ]]; then
-    rm -f "$tmp"
+    rm -rf "$tmpdir"
     json_result "fail" "Dracula.terminal checksum mismatch (got $actual)"
     exit 1
   fi
@@ -73,14 +89,14 @@ do_run() {
     defaults write com.apple.Terminal 'Startup Window Settings' 'Dracula'
   " >&2
 
-  rm -f "$tmp"
+  rm -rf "$tmpdir"
   json_result "ok" "Dracula theme imported and set as default"
 }
 
 do_check() {
   local current
   current=$(_defaults_read_profile | tr -d '[:space:]')
-  if [[ "$current" == "Dracula" ]]; then
+  if [[ "$current" == "Dracula" ]] && _dracula_profile_registered; then
     json_check "Terminal.app Dracula" "ok" "Dracula is default"
   else
     json_check "Terminal.app Dracula" "warn" "current: ${current:-none}"

--- a/cli/modules/macos-terminal.sh
+++ b/cli/modules/macos-terminal.sh
@@ -26,17 +26,17 @@ _defaults_read_profile() {
   fi
 }
 
-# Returns 0 if the Dracula profile is actually registered in Terminal.app's Window Settings.
-# Terminal.app names imported profiles after the filename stem, not the plist name key, so
-# a temp-file import can register under the wrong name even when Default Window Settings = Dracula.
-_dracula_profile_registered() {
-  local prefs
+# Terminal.app registers profiles by filename stem, not the plist name key.
+_terminal_prefs_path() {
   if _is_root; then
-    prefs="/Users/$USERNAME/Library/Preferences/com.apple.Terminal.plist"
+    echo "/Users/$USERNAME/Library/Preferences/com.apple.Terminal.plist"
   else
-    prefs="$HOME/Library/Preferences/com.apple.Terminal.plist"
+    echo "$HOME/Library/Preferences/com.apple.Terminal.plist"
   fi
-  /usr/libexec/PlistBuddy -c "Print :'Window Settings':Dracula" "$prefs" > /dev/null 2>&1
+}
+
+_dracula_profile_registered() {
+  /usr/libexec/PlistBuddy -c "Print :'Window Settings':Dracula" "$(_terminal_prefs_path)" > /dev/null 2>&1
 }
 
 _open_terminal_file() {


### PR DESCRIPTION
## Summary

- Terminal.app uses the filename stem as the registered profile name, not the `name` key inside the plist. The temp file `devlair.XXXXXX.terminal` was imported as profile `"devlair.XXXXXX"` while `defaults write` pointed `Default Window Settings` at `"Dracula"` (non-existent) → Terminal.app fell back to a built-in grey theme.
- Replaces `mktemp /tmp/devlair.XXXXXX.terminal` with `mktemp -d` + `$tmpdir/Dracula.terminal` so the imported profile name matches.
- Adds `_dracula_profile_registered()` (PlistBuddy) to verify the profile actually exists in `Window Settings`, not just that `Default Window Settings == "Dracula"`.
- Gates idempotency check and `do_check` on both conditions so a broken state re-triggers the import instead of reporting OK.

Closes #258

## Test plan

- [ ] Run `devlair init --only macos_terminal` — Terminal.app should show the Dracula dark theme (dark purple background, vibrant colours) <!-- needs-manual: visual check requires macOS + Terminal.app -->
- [ ] Verify `defaults read com.apple.Terminal "Default Window Settings"` returns `Dracula` <!-- needs-manual: requires running devlair on macOS -->
- [ ] Verify `devlair doctor` reports `Terminal.app Dracula` as `ok` <!-- needs-manual: requires running devlair on macOS -->
- [x] Re-run `devlair init --only macos_terminal` — should return "Dracula already default" (idempotent) <!-- code-verified: cli/modules/macos-terminal.sh:58 — both `_defaults_read_profile == "Dracula"` AND `_dracula_profile_registered` (PlistBuddy) must pass for early exit -->
- [x] On a machine with the broken state (`Default Window Settings = Dracula` but no Dracula profile in `Window Settings`) — re-run should re-import the profile and fix the terminal <!-- code-verified: cli/modules/macos-terminal.sh:58 — `_dracula_profile_registered` returns non-zero when profile missing → early exit skipped → import proceeds -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
