### PR TITLE
fix(brand): upgrade/doctor banners ignore custom --brand

### DIFF
--- a/cli/src/commands/doctor.tsx
+++ b/cli/src/commands/doctor.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { Logo } from "../components/Logo.js";
 import type { DoctorFlags } from "../lib/args.js";
+import { resolveBrand } from "../lib/brand.js";
 import { buildModuleContext } from "../lib/context.js";
 import { MODULE_SPECS, REAPPLY_KEYS, resolveOrder } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
@@ -38,12 +39,22 @@ const STATUS_ICON: Record<Status, { char: string; color: string }> = {
   fail: { char: "✗", color: D_RED },
 };
 
-function DoctorHeader({ username, host, platform }: { username: string; host: string; platform: string }) {
+function DoctorHeader({
+  username,
+  host,
+  platform,
+  brand,
+}: {
+  username: string;
+  host: string;
+  platform: string;
+  brand: string;
+}) {
   const suffix = platform === "wsl" ? " (WSL)" : platform === "macos" ? " (macOS)" : "";
 
   return (
     <Box flexDirection="column">
-      <Logo />
+      <Logo brand={brand} />
       <Box marginBottom={1}>
         <Text>{"  "}</Text>
         <Text color={D_PURPLE} bold>
@@ -321,7 +332,12 @@ export function DoctorView({ flags }: { flags: DoctorFlags }) {
 
   return (
     <Box flexDirection="column">
-      <DoctorHeader username={context.username} host={hostname()} platform={platform} />
+      <DoctorHeader
+        username={context.username}
+        host={hostname()}
+        platform={platform}
+        brand={resolveBrand(undefined, context.userHome)}
+      />
 
       {phase === "checking" && (
         <Box>

--- a/cli/src/commands/doctor.tsx
+++ b/cli/src/commands/doctor.tsx
@@ -205,10 +205,11 @@ export function DoctorView({ flags }: { flags: DoctorFlags }) {
     const platform = detectPlatform();
     const wslVersion = detectWslVersion(platform);
     const context = buildModuleContext(platform, wslVersion);
-    return { platform, wslVersion, context };
+    const brand = resolveBrand(undefined, context.userHome);
+    return { platform, wslVersion, context, brand };
   });
 
-  const { platform, context } = envState;
+  const { platform, context, brand } = envState;
 
   const [phase, setPhase] = useState<Phase>("checking");
   const [checkingModule, setCheckingModule] = useState("");
@@ -332,12 +333,7 @@ export function DoctorView({ flags }: { flags: DoctorFlags }) {
 
   return (
     <Box flexDirection="column">
-      <DoctorHeader
-        username={context.username}
-        host={hostname()}
-        platform={platform}
-        brand={resolveBrand(undefined, context.userHome)}
-      />
+      <DoctorHeader username={context.username} host={hostname()} platform={platform} brand={brand} />
 
       {phase === "checking" && (
         <Box>

--- a/cli/src/commands/upgrade.tsx
+++ b/cli/src/commands/upgrade.tsx
@@ -18,6 +18,7 @@ import { useEffect, useRef, useState } from "react";
 import { Logo } from "../components/Logo.js";
 import { type ModuleRun, Progress } from "../components/Progress.js";
 import type { UpgradeFlags } from "../lib/args.js";
+import { resolveBrand } from "../lib/brand.js";
 import { buildModuleContext } from "../lib/context.js";
 import { REAPPLY_KEYS, resolveOrder } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
@@ -33,12 +34,22 @@ interface SelfUpdateResult {
   detail: string;
 }
 
-function UpgradeHeader({ username, host, platform }: { username: string; host: string; platform: string }) {
+function UpgradeHeader({
+  username,
+  host,
+  platform,
+  brand,
+}: {
+  username: string;
+  host: string;
+  platform: string;
+  brand: string;
+}) {
   const suffix = platform === "wsl" ? " (WSL)" : platform === "macos" ? " (macOS)" : "";
 
   return (
     <Box flexDirection="column">
-      <Logo />
+      <Logo brand={brand} />
       <Box marginBottom={1}>
         <Text>{"  "}</Text>
         <Text color={D_PURPLE} bold>
@@ -339,7 +350,12 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
 
   return (
     <Box flexDirection="column">
-      <UpgradeHeader username={context.username} host={hostname()} platform={platform} />
+      <UpgradeHeader
+        username={context.username}
+        host={hostname()}
+        platform={platform}
+        brand={resolveBrand(undefined, context.userHome)}
+      />
 
       {phase === "self-update" && !selfResult && (
         <Box marginBottom={1}>

--- a/cli/src/commands/upgrade.tsx
+++ b/cli/src/commands/upgrade.tsx
@@ -186,10 +186,11 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
     const platform = detectPlatform();
     const wslVersion = detectWslVersion(platform);
     const context = buildModuleContext(platform, wslVersion);
-    return { platform, wslVersion, context };
+    const brand = resolveBrand(undefined, context.userHome);
+    return { platform, wslVersion, context, brand };
   });
 
-  const { platform, context } = envState;
+  const { platform, context, brand } = envState;
 
   const [phase, setPhase] = useState<Phase>(flags.noSelf ? "tools" : "self-update");
   const [selfResult, setSelfResult] = useState<SelfUpdateResult | null>(
@@ -350,12 +351,7 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
 
   return (
     <Box flexDirection="column">
-      <UpgradeHeader
-        username={context.username}
-        host={hostname()}
-        platform={platform}
-        brand={resolveBrand(undefined, context.userHome)}
-      />
+      <UpgradeHeader username={context.username} host={hostname()} platform={platform} brand={brand} />
 
       {phase === "self-update" && !selfResult && (
         <Box marginBottom={1}>


### PR DESCRIPTION
## Summary
- `DoctorHeader`/`UpgradeHeader` rendered `<Logo />` with no `brand` prop, so both `devlair doctor` and `devlair upgrade` always showed the default "d e v l a i r" banner even when `init --brand serena` had persisted a custom brand to `~/.devlair/brand`.
- Resolve the persisted brand via `resolveBrand(undefined, context.userHome)` and pass it through to `<Logo brand={brand} />` in both commands, matching what `init.tsx` already does.

Closes #264

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (193 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)