### PR TITLE
fix(upgrade): install binary to user-owned ~/.devlair/bin, no root needed

### DIFF
--- a/cli/src/commands/upgrade.tsx
+++ b/cli/src/commands/upgrade.tsx
@@ -7,9 +7,9 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { hostname, tmpdir } from "node:os";
-import { join } from "node:path";
+import { chmodSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { dirname, join } from "node:path";
 import { useApp } from "ink";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
@@ -24,6 +24,7 @@ import { REAPPLY_KEYS, resolveOrder } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
 import { runModule } from "../lib/runner.js";
+import { isWritableDir, resolveInstallTarget } from "../lib/self-update.js";
 import { D_COMMENT, D_CYAN, D_FG, D_GREEN, D_ORANGE, D_PINK, D_PURPLE, D_RED } from "../lib/theme.js";
 import type { Status } from "../lib/types.js";
 
@@ -32,6 +33,8 @@ type Phase = "self-update" | "tools" | "reapply" | "done";
 interface SelfUpdateResult {
   status: "up-to-date" | "updated" | "skipped" | "error";
   detail: string;
+  /** Where the new binary was installed — the re-exec target after an update. */
+  installPath?: string;
 }
 
 function UpgradeHeader({
@@ -158,21 +161,63 @@ async function checkSelfUpdate(currentVersion: string): Promise<SelfUpdateResult
     if (!binResp.ok) throw new Error(`Download failed: HTTP ${binResp.status}`);
     const buffer = Buffer.from(await binResp.arrayBuffer());
 
-    // Write to a temp file, then install into /usr/local/bin/ via sudo -n
-    const installPath = "/usr/local/bin/devlair";
-    const tmpDir = mkdtempSync(join(tmpdir(), "devlair-update-"));
-    const tmpPath = join(tmpDir, "devlair");
+    // Decide where the new binary goes — prefer a user-owned location so the
+    // install needs no root at all (see lib/self-update.ts).
+    const target = resolveInstallTarget({
+      platform: process.platform,
+      execPath: process.execPath,
+      home: homedir(),
+      pathEnv: process.env.PATH ?? "",
+      isWritableDir,
+    });
+    const targetDir = dirname(target.path);
+    mkdirSync(targetDir, { recursive: true });
+
+    // Stage the download inside the target directory so the final swap is an
+    // atomic same-filesystem rename (a cross-device rename raises EACCES even
+    // with permission — the root cause of the historical upgrade failures).
+    const tmpPath = join(targetDir, `.devlair-update-${process.pid}`);
     writeFileSync(tmpPath, buffer, { mode: 0o755 });
 
-    // Atomic replace — requires root on macOS; use cached sudo credentials.
-    const mv = spawnSync("sudo", ["-n", "mv", tmpPath, installPath]);
-    if (mv.error || mv.status !== 0) {
-      throw new Error(`Permission denied installing to ${installPath} — run: sudo devlair upgrade`);
+    let installed = false;
+    try {
+      renameSync(tmpPath, target.path);
+      chmodSync(target.path, 0o755);
+      installed = true;
+    } catch {
+      // Direct write failed (root-owned legacy location). Try a privileged move
+      // only when allowed and sudo credentials are already cached.
+      if (target.allowSudo) {
+        const mv = spawnSync("sudo", ["-n", "mv", tmpPath, target.path]);
+        const ch = mv.status === 0 ? spawnSync("sudo", ["-n", "chmod", "755", target.path]) : null;
+        installed = mv.status === 0 && ch?.status === 0;
+      }
     }
-    const ch = spawnSync("sudo", ["-n", "chmod", "755", installPath]);
-    if (ch.error || ch.status !== 0) throw new Error("chmod failed on installed binary");
 
-    return { status: "updated", detail: `devlair updated to v${latest}` };
+    if (!installed) {
+      rmSync(tmpPath, { force: true });
+      return {
+        status: "skipped",
+        detail: `Update to v${latest} available — could not install to ${target.path}. Re-run \`devlair init\` then \`devlair upgrade\`, or reinstall.`,
+      };
+    }
+
+    // Retire a shadowed legacy binary so `devlair --version` is unambiguous.
+    // Best-effort: ~/.devlair/bin is ahead on PATH, so the new copy wins even if
+    // the old root-owned one can't be removed without cached credentials.
+    if (target.migrateFrom && target.migrateFrom !== target.path) {
+      try {
+        rmSync(target.migrateFrom, { force: true });
+      } catch {
+        spawnSync("sudo", ["-n", "rm", "-f", target.migrateFrom], { stdio: "ignore" });
+      }
+    }
+
+    return {
+      status: "updated",
+      detail: `devlair updated to v${latest}${target.note ? ` — ${target.note}` : ""}`,
+      installPath: target.path,
+    };
   } catch (err) {
     return { status: "error", detail: `Could not check for updates: ${err instanceof Error ? err.message : err}` };
   }
@@ -209,10 +254,11 @@ export function UpgradeView({ flags, version }: { flags: UpgradeFlags; version: 
       setSelfResult(result);
 
       if (result.status === "updated") {
-        // Re-exec with --no-self so the new binary runs the rest
+        // Re-exec the freshly installed binary with --no-self so it runs the rest.
         const { execFileSync } = await import("node:child_process");
+        const newBinary = result.installPath ?? process.execPath;
         try {
-          execFileSync("/usr/local/bin/devlair", ["upgrade", "--no-self"], { stdio: "inherit" });
+          execFileSync(newBinary, ["upgrade", "--no-self"], { stdio: "inherit" });
         } catch {
           // The new binary will handle output
         }

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { Text, render } from "ink";
 import pkg from "../package.json" with { type: "json" };
 import { ClaudeView } from "./commands/claude.js";
@@ -25,6 +26,7 @@ import {
 } from "./lib/args.js";
 import { elevateIfNeeded, primeSudoForRootArtifacts } from "./lib/elevate.js";
 import { macOsPreFlight, macOsPurgeHomebrew } from "./lib/homebrew.js";
+import { isWritableDir, resolveInstallTarget } from "./lib/self-update.js";
 import { D_FG } from "./lib/theme.js";
 
 const VERSION = pkg.version;
@@ -128,7 +130,18 @@ async function main() {
         // no confirmation AND left brew gone before the modules could use it to
         // uninstall their packages. It must come last.
       } else if (command.type === "upgrade" && !command.flags.noSelf) {
-        primeSudoForRootArtifacts(["/usr/local/bin/devlair"]);
+        // Only cache sudo credentials when the self-update genuinely needs root
+        // (a legacy /usr/local/bin install that can't relocate). The common case
+        // installs into user-owned ~/.devlair/bin, so we no longer prompt for a
+        // password on every upgrade.
+        const target = resolveInstallTarget({
+          platform: process.platform,
+          execPath: process.execPath,
+          home: homedir(),
+          pathEnv: process.env.PATH ?? "",
+          isWritableDir,
+        });
+        if (target.allowSudo) primeSudoForRootArtifacts([target.path]);
         macOsPreFlight();
       } else {
         macOsPreFlight();

--- a/cli/src/lib/self-update.test.ts
+++ b/cli/src/lib/self-update.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveInstallTarget } from "./self-update.js";
+
+const HOME = "/Users/dev";
+const USER_BIN = "/Users/dev/.devlair/bin";
+
+describe("resolveInstallTarget", () => {
+  it("updates in place with no sudo when the binary's dir is writable (Linux as root)", () => {
+    const t = resolveInstallTarget({
+      platform: "linux",
+      execPath: "/usr/local/bin/devlair",
+      home: "/root",
+      pathEnv: "/usr/local/bin:/usr/bin",
+      isWritableDir: () => true,
+    });
+    expect(t).toEqual({ path: "/usr/local/bin/devlair", allowSudo: false });
+  });
+
+  it("relocates to ~/.devlair/bin (no sudo) on macOS when it is on PATH", () => {
+    const t = resolveInstallTarget({
+      platform: "darwin",
+      execPath: "/usr/local/bin/devlair",
+      home: HOME,
+      pathEnv: `${USER_BIN}:/usr/local/bin:/usr/bin`,
+      isWritableDir: (dir) => dir === USER_BIN, // legacy /usr/local/bin not writable
+    });
+    expect(t).toEqual({
+      path: `${USER_BIN}/devlair`,
+      allowSudo: false,
+      migrateFrom: "/usr/local/bin/devlair",
+    });
+  });
+
+  it("tolerates a trailing slash on the PATH entry", () => {
+    const t = resolveInstallTarget({
+      platform: "darwin",
+      execPath: "/usr/local/bin/devlair",
+      home: HOME,
+      pathEnv: `${USER_BIN}/:/usr/bin`,
+      isWritableDir: () => false,
+    });
+    expect(t.path).toBe(`${USER_BIN}/devlair`);
+    expect(t.allowSudo).toBe(false);
+  });
+
+  it("falls back to an in-place sudo update on macOS when ~/.devlair/bin is not on PATH", () => {
+    const t = resolveInstallTarget({
+      platform: "darwin",
+      execPath: "/usr/local/bin/devlair",
+      home: HOME,
+      pathEnv: "/usr/local/bin:/usr/bin",
+      isWritableDir: () => false,
+    });
+    expect(t.path).toBe("/usr/local/bin/devlair");
+    expect(t.allowSudo).toBe(true);
+    expect(t.migrateFrom).toBeUndefined();
+    expect(t.note).toContain("devlair init");
+  });
+
+  it("does not relocate when already running from ~/.devlair/bin", () => {
+    const t = resolveInstallTarget({
+      platform: "darwin",
+      execPath: `${USER_BIN}/devlair`,
+      home: HOME,
+      pathEnv: `${USER_BIN}:/usr/local/bin`,
+      isWritableDir: (dir) => dir === USER_BIN,
+    });
+    expect(t).toEqual({ path: `${USER_BIN}/devlair`, allowSudo: false });
+  });
+
+  it("allows a sudo fallback on unelevated Linux with an unwritable dir", () => {
+    const t = resolveInstallTarget({
+      platform: "linux",
+      execPath: "/usr/local/bin/devlair",
+      home: "/home/dev",
+      pathEnv: "/usr/local/bin:/usr/bin",
+      isWritableDir: () => false,
+    });
+    expect(t).toEqual({ path: "/usr/local/bin/devlair", allowSudo: true });
+  });
+});

--- a/cli/src/lib/self-update.ts
+++ b/cli/src/lib/self-update.ts
@@ -1,0 +1,95 @@
+/**
+ * Self-update install-target resolution.
+ *
+ * The recurring macOS "permission denied" failures during `devlair upgrade`
+ * all traced back to one thing: the binary lived in root-owned /usr/local/bin
+ * while the process runs as a normal user (Homebrew forbids root). Every
+ * self-mutation then needed a bespoke sudo workaround, and each patch only
+ * covered one path.
+ *
+ * The fix is to write the new binary into a user-owned location. The devlair
+ * shell module already puts ~/.devlair/bin ahead of /usr/local/bin on PATH, so
+ * relocating there shadows any legacy system copy with no root required. This
+ * module decides — as a pure function, so it is unit-testable — where the new
+ * binary should go for the machine we're running on.
+ */
+
+import { constants, accessSync } from "node:fs";
+import { delimiter, dirname, join } from "node:path";
+
+export interface InstallTarget {
+  /** Absolute path the new binary should be written to. */
+  path: string;
+  /** Whether a `sudo -n` fallback may be attempted if the direct write fails. */
+  allowSudo: boolean;
+  /** A legacy binary to best-effort remove after a successful install (migration). */
+  migrateFrom?: string;
+  /** A user-facing note appended to the success message. */
+  note?: string;
+}
+
+export interface ResolveOptions {
+  platform: NodeJS.Platform;
+  /** The running binary's real path (process.execPath). */
+  execPath: string;
+  /** The user's home directory. */
+  home: string;
+  /** The PATH environment string. */
+  pathEnv: string;
+  /** Predicate: can we create/replace files in this directory? Injected for testability. */
+  isWritableDir: (dir: string) => boolean;
+}
+
+/** True when `dir` is one of the entries in the PATH string. */
+function onPath(dir: string, pathEnv: string): boolean {
+  return pathEnv
+    .split(delimiter)
+    .map((p) => p.replace(/\/+$/, ""))
+    .includes(dir.replace(/\/+$/, ""));
+}
+
+/**
+ * Decide where the self-update should install the new binary.
+ *
+ * 1. If the directory the binary already runs from is writable, update in place
+ *    with no sudo. This covers Linux (the process is elevated to root, so
+ *    /usr/local/bin is writable), Homebrew prefixes, and machines already
+ *    installed under ~/.devlair/bin.
+ * 2. macOS with a legacy root-owned install: if ~/.devlair/bin is on PATH (the
+ *    devlair shell block puts it ahead of /usr/local/bin), relocate there — no
+ *    root needed, and the old copy is shadowed and then retired.
+ * 3. Otherwise fall back to an in-place update, allowing a cached-credential
+ *    `sudo -n` attempt; the caller degrades gracefully if that fails.
+ */
+export function resolveInstallTarget(opts: ResolveOptions): InstallTarget {
+  const { platform, execPath, home, pathEnv, isWritableDir } = opts;
+  const execDir = dirname(execPath);
+
+  if (isWritableDir(execDir)) {
+    return { path: execPath, allowSudo: false };
+  }
+
+  if (platform === "darwin") {
+    const userBinDir = join(home, ".devlair", "bin");
+    if (onPath(userBinDir, pathEnv)) {
+      return { path: join(userBinDir, "devlair"), allowSudo: false, migrateFrom: execPath };
+    }
+    return {
+      path: execPath,
+      allowSudo: true,
+      note: "run `devlair init` so future updates install without sudo",
+    };
+  }
+
+  return { path: execPath, allowSudo: true };
+}
+
+/** Real writability check used in production (injected as a predicate in tests). */
+export function isWritableDir(dir: string): boolean {
+  try {
+    accessSync(dir, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -17,10 +17,22 @@ INSTALL_DIR="/usr/local/bin"
 SHARE_DIR="/usr/local/share/devlair"
 CHANNEL="v2"
 
-# Computed after we know INSTALL_DIR — reused for binary install, modules
-# install, and any apt-get fallbacks below so the sudo decision is made once.
+# macOS: install the binary into a user-owned dir so self-update never needs
+# root. The devlair shell module puts ~/.devlair/bin ahead of /usr/local/bin on
+# PATH; we also ensure that PATH entry below so `devlair` resolves before init.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  INSTALL_DIR="$HOME/.devlair/bin"
+  mkdir -p "$INSTALL_DIR"
+fi
+
+# Privilege is decided per target: the binary dir and the shared modules dir may
+# have different owners (user-owned ~/.devlair/bin + root-owned /usr/local on
+# macOS). MAYBE_SUDO gates the binary + Linux apt/dpkg steps; SHARE_SUDO gates
+# the modules install under /usr/local/share.
 MAYBE_SUDO=""
 [[ ! -w "$INSTALL_DIR" ]] && MAYBE_SUDO="sudo"
+SHARE_SUDO=""
+[[ ! -w "/usr/local/share" ]] && SHARE_SUDO="sudo"
 
 # ── Dracula-styled output ─────────────────────────────────────────────────────
 # Keep in sync with Dracula palette (cli/src/lib/theme.ts) — drift produces
@@ -196,6 +208,17 @@ $MAYBE_SUDO mv "$TMP" "${INSTALL_DIR}/${BIN}"
 $MAYBE_SUDO chmod 755 "${INSTALL_DIR}/${BIN}"
 ok "${INSTALL_DIR}/${BIN}"
 
+# macOS: make ~/.devlair/bin reachable before `devlair init` runs (init's shell
+# module manages the canonical PATH line; this is the pre-init bootstrap). The
+# guard on ".devlair/bin" also matches that managed line, so we never duplicate.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  ZSHRC="$HOME/.zshrc"
+  if ! grep -qsF '.devlair/bin' "$ZSHRC" 2>/dev/null; then
+    printf '\n# devlair\nexport PATH="$HOME/.devlair/bin:$PATH"\n' >> "$ZSHRC"
+    meta "added ~/.devlair/bin to PATH in ~/.zshrc"
+  fi
+fi
+
 # ── v2: fetch modules tarball ─────────────────────────────────────────────────
 # v2 shell modules live outside the compiled binary and ship as a separate
 # tarball. v1 is self-contained and does not need this step.
@@ -223,12 +246,12 @@ if [[ "$CHANNEL" != "v1" ]]; then
   chmod -R u=rwX,go=rX "$STAGE_DIR/modules"
   rm -f "$TMP_MODULES"
 
-  $MAYBE_SUDO rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
-  [[ -d "$SHARE_DIR" ]] && $MAYBE_SUDO mv "$SHARE_DIR" "${SHARE_DIR}.old"
-  $MAYBE_SUDO mkdir -m 755 -p "$SHARE_DIR"
-  $MAYBE_SUDO mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
-  $MAYBE_SUDO chmod 755 "${SHARE_DIR}/modules"
-  $MAYBE_SUDO rm -rf "${SHARE_DIR}.old"
+  $SHARE_SUDO rm -rf "${SHARE_DIR}.old" 2>/dev/null || true
+  [[ -d "$SHARE_DIR" ]] && $SHARE_SUDO mv "$SHARE_DIR" "${SHARE_DIR}.old"
+  $SHARE_SUDO mkdir -m 755 -p "$SHARE_DIR"
+  $SHARE_SUDO mv "$STAGE_DIR/modules" "${SHARE_DIR}/modules"
+  $SHARE_SUDO chmod 755 "${SHARE_DIR}/modules"
+  $SHARE_SUDO rm -rf "${SHARE_DIR}.old"
   rm -rf "$STAGE_DIR"
   ok "modules installed to ${SHARE_DIR}/modules"
 
@@ -280,6 +303,8 @@ printf "  %s%s%s\n\n" "$C_COMMENT" "${INSTALL_DIR}/${BIN}" "$C_RESET"
 
 printf "%sNext step:%s\n" "$C_BOLD" "$C_RESET"
 if [[ "$OS_SUFFIX" == "darwin" ]]; then
+  printf "  %sOpen a new terminal%s %s(or run: source ~/.zshrc)%s, then:\n" \
+    "$C_PURPLE" "$C_RESET" "$C_COMMENT" "$C_RESET"
   printf "  %sdevlair init%s\n\n" "$C_PURPLE" "$C_RESET"
 else
   printf "  %sdevlair init%s  %s(will prompt for sudo if needed)%s\n\n" \


### PR DESCRIPTION
## Summary

Ends the recurring macOS `EACCES: permission denied, rename … /usr/local/bin/devlair` failures during `devlair upgrade` by fixing the structural root cause instead of patching another path.

- **Root cause:** the binary lived in root-owned `/usr/local/bin` while the process runs as a normal user (Homebrew forbids root). Every self-mutation needed a bespoke sudo workaround, so the next root-owned path always broke next.
- **`cli/src/lib/self-update.ts`** (new): pure, unit-tested resolver picks the install target — writable-in-place (Linux as root), relocate to user-owned `~/.devlair/bin` (already ahead on PATH via the shell module), or a graceful `sudo -n` fallback.
- **`cli/src/commands/upgrade.tsx`**: stage the download inside the target dir so the swap is an atomic same-filesystem rename (also kills the cross-device EACCES); no hardcoded path; re-exec the freshly installed binary; calm `skipped` message on genuine failure instead of a red stack dump.
- **`cli/src/index.tsx`**: prime sudo only when root is truly required — the common macOS upgrade is now prompt-free.
- **`install.sh`**: macOS installs to `~/.devlair/bin` (per-target sudo split so modules still land under `/usr/local/share`), ensures PATH, adjusts next-step message.

Linux is unchanged (elevates as root). Legacy `/usr/local/bin` installs migrate automatically on the first upgrade. Uninstall already removes both locations. Modules dir stays at `/usr/local/share` (written only at install time, never during upgrade).

Closes #266

## Test plan

- [ ] `bun test` — resolver unit tests (all branches) pass
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bash -n install.sh` — parses
- [ ] Manual: macOS upgrade from a `/usr/local/bin` install migrates to `~/.devlair/bin` with no sudo prompt
- [ ] Manual: fresh macOS install lands in `~/.devlair/bin`, PATH set, `devlair init` reachable after new shell
- [ ] Manual: Linux upgrade still updates in place as root

🤖 Generated with [Claude Code](https://claude.com/claude-code)