### PR TITLE
feat: pin releases, fix macOS install drift + doctor logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.s
 
 The installer downloads the `devlair` binary to `/usr/local/bin` and auto-elevates with `sudo` when that path is not writable — so the same command works on macOS, Linux, and WSL.
 
+By default the installer resolves the latest published release. To install a specific version, pass a `v`-prefixed tag — either via the `--version` flag (needs `bash -s --`) or the `DEVLAIR_VERSION` environment variable:
+
+```bash
+# Pin a release with the environment variable
+curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | DEVLAIR_VERSION=v3.2.1 bash
+
+# ...or with the --version flag
+curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | bash -s -- --version v3.2.1
+```
+
 **2. Provision the machine**
 
 ```bash

--- a/cli/modules/configs/shell-aliases.zsh
+++ b/cli/modules/configs/shell-aliases.zsh
@@ -70,6 +70,10 @@ if [ -n "$WSL_DISTRO_NAME" ] && command -v wslview &>/dev/null; then
 fi
 
 # ── Claude Code ───────────────────────────────────────────────────────────────
+# Owned here (not left to claude.ai/install.sh's own zshrc append) so it
+# survives shell.sh's refresh, which rewrites .zshrc as header+this block and
+# drops anything a third-party installer appended after it.
+export PATH="$HOME/.local/bin:$PATH"
 export CLAUDE_CODE_DISABLE_1M_CONTEXT=1
 # Use 1M context for a single session: CLAUDE_CODE_DISABLE_1M_CONTEXT=0 claude
 

--- a/cli/modules/configs/zshrc-header.sh
+++ b/cli/modules/configs/zshrc-header.sh
@@ -2,9 +2,6 @@
 export EDITOR=vim
 export LANG=en_US.UTF-8
 
-# Path
-export PATH="$HOME/.local/bin:$PATH"
-
 # zimfw
 ZIM_HOME="$HOME/.zim"
 if [[ ! -e "$ZIM_HOME/zimfw.zsh" ]]; then

--- a/cli/modules/shell.sh
+++ b/cli/modules/shell.sh
@@ -30,6 +30,7 @@ _clean_zshrc() {
     /^export BUN_INSTALL=/ { next }
     /\[ -s "\$BUN_INSTALL\/bin\/bun" \]/ { next }
     /# bun/ { next }
+    /^export PATH="\$HOME\/\.local\/bin:\$PATH"$/ { next }
     { print }
   ' <<< "$text"
 }

--- a/cli/src/commands/doctor.tsx
+++ b/cli/src/commands/doctor.tsx
@@ -15,6 +15,7 @@ import { Logo } from "../components/Logo.js";
 import type { DoctorFlags } from "../lib/args.js";
 import { resolveBrand } from "../lib/brand.js";
 import { buildModuleContext } from "../lib/context.js";
+import { createRunLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
 import { MODULE_SPECS, REAPPLY_KEYS, resolveOrder } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
@@ -219,6 +220,15 @@ export function DoctorView({ flags }: { flags: DoctorFlags }) {
   // Phase 1: Run all modules in check mode
   useEffect(() => {
     const abortController = new AbortController();
+    // Per-run log dir so a failed `doctor` leaves something to inspect, matching
+    // `init`/`uninstall`. Best-effort — never block the run because we couldn't mkdir.
+    let runLogDir: string | null = null;
+    try {
+      runLogDir = createRunLogDir(context.userHome, "doctor-");
+    } catch {
+      // Logging is best-effort.
+    }
+    const ownership = invokerOwnership();
 
     async function runChecks() {
       const specs = MODULE_SPECS.filter((s) => s.platforms.has(platform));
@@ -230,7 +240,11 @@ export function DoctorView({ flags }: { flags: DoctorFlags }) {
 
         try {
           const scriptPath = moduleScriptPath(spec.key);
-          const iter = runModule(scriptPath, context, "check", { signal: abortController.signal });
+          const iter = runModule(scriptPath, context, "check", {
+            signal: abortController.signal,
+            logFile: runLogDir ? moduleLogPath(runLogDir, spec.key) : undefined,
+            chownUidGid: ownership ?? undefined,
+          });
 
           let first = true;
           while (true) {
@@ -297,7 +311,12 @@ export function DoctorView({ flags }: { flags: DoctorFlags }) {
 
         try {
           const scriptPath = moduleScriptPath(spec.key);
-          const iter = runModule(scriptPath, ctx, "run", { signal });
+          const iter = runModule(scriptPath, ctx, "run", {
+            signal,
+            // Distinct from the check-phase log so a --fix re-apply doesn't clobber it.
+            logFile: runLogDir ? moduleLogPath(runLogDir, `${spec.key}-fix`) : undefined,
+            chownUidGid: ownership ?? undefined,
+          });
 
           while (true) {
             const { value, done } = await iter.next();

--- a/cli/src/commands/init.tsx
+++ b/cli/src/commands/init.tsx
@@ -17,7 +17,7 @@ import { OptionalHint, Summary } from "../components/Summary.js";
 import type { InitFlags } from "../lib/args.js";
 import { resolveBrand } from "../lib/brand.js";
 import { buildModuleContext } from "../lib/context.js";
-import { createInitLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
+import { createRunLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
 import type { Group, ModuleSpec } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
@@ -141,7 +141,7 @@ function useModuleExecution(specs: ModuleSpec[], context: ModuleContext, autoSta
     // Avoid creating empty dirs when the wizard is cancelled before running.
     let runLogDir: string | null = null;
     try {
-      runLogDir = createInitLogDir(context.userHome);
+      runLogDir = createRunLogDir(context.userHome);
       setLogDir(runLogDir);
     } catch {
       // Logging is best-effort — never block a run because we couldn't mkdir.

--- a/cli/src/commands/uninstall.tsx
+++ b/cli/src/commands/uninstall.tsx
@@ -22,7 +22,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { type ModuleRun, Progress } from "../components/Progress.js";
 import type { UninstallFlags } from "../lib/args.js";
 import { buildModuleContext, resolveInvokingUser } from "../lib/context.js";
-import { createInitLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
+import { createRunLogDir, invokerOwnership, moduleLogPath } from "../lib/logs.js";
 import { resolveTeardownOrder } from "../lib/modules.js";
 import { moduleScriptPath } from "../lib/paths.js";
 import { detectPlatform, detectWslVersion } from "../lib/platform.js";
@@ -219,7 +219,7 @@ export function UninstallView({
     const abort = new AbortController();
     let logDir: string | null = null;
     try {
-      logDir = createInitLogDir(userHome);
+      logDir = createRunLogDir(userHome);
     } catch {
       // best-effort logging
     }

--- a/cli/src/lib/logs.ts
+++ b/cli/src/lib/logs.ts
@@ -1,19 +1,19 @@
-// Per-run log directory for `devlair init`. Each module's stderr is streamed
-// to its own file so failures can be diagnosed without re-running with extra
-// flags.
+// Per-run log directory for `devlair init` / `uninstall` / `doctor`. Each
+// module's stderr is streamed to its own file so failures can be diagnosed
+// without re-running with extra flags. Directory names are prefixed per command
+// (`init-`, `doctor-`) so pruning keeps each command's history independently.
 
 import { chmodSync, chownSync, lstatSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const KEEP_RUNS = 10;
-const LOG_DIR_PREFIX = "init-";
 
-function runDirName(now: Date): string {
+function runDirName(now: Date, prefix: string): string {
   const iso = now
     .toISOString()
     .replace(/[:.]/g, "-")
     .replace(/-\d{3}Z$/, "Z");
-  return `${LOG_DIR_PREFIX}${iso}`;
+  return `${prefix}${iso}`;
 }
 
 /**
@@ -41,12 +41,14 @@ function rejectSymlink(path: string): void {
 }
 
 /**
- * Create `<userHome>/.devlair/logs/init-<ts>/` (mode 0700) and prune older
- * `init-*` directories to the most recent KEEP_RUNS, including the new one.
+ * Create `<userHome>/.devlair/logs/<prefix><ts>/` (mode 0700) and prune older
+ * `<prefix>*` directories to the most recent KEEP_RUNS, including the new one.
+ * Pruning is scoped to the given prefix, so `doctor-*` runs never evict
+ * `init-*` history and vice versa.
  *
  * Returns the absolute path to the new directory.
  */
-export function createInitLogDir(userHome: string, now: Date = new Date()): string {
+export function createRunLogDir(userHome: string, prefix = "init-", now: Date = new Date()): string {
   const devlairDir = join(userHome, ".devlair");
   const logsRoot = join(devlairDir, "logs");
 
@@ -61,7 +63,7 @@ export function createInitLogDir(userHome: string, now: Date = new Date()): stri
   // created dirs; an existing ~/.devlair/logs with 0755 would stay 0755.
   chmodSync(logsRoot, 0o700);
 
-  const runDir = join(logsRoot, runDirName(now));
+  const runDir = join(logsRoot, runDirName(now, prefix));
   mkdirSync(runDir, { mode: 0o700 });
   chmodSync(runDir, 0o700);
 
@@ -71,14 +73,14 @@ export function createInitLogDir(userHome: string, now: Date = new Date()): stri
     chownSync(runDir, ownership[0], ownership[1]);
   }
 
-  pruneOldRuns(logsRoot, KEEP_RUNS);
+  pruneOldRuns(logsRoot, prefix, KEEP_RUNS);
   return runDir;
 }
 
-function pruneOldRuns(logsRoot: string, keep: number): void {
+function pruneOldRuns(logsRoot: string, prefix: string, keep: number): void {
   let names: string[];
   try {
-    names = readdirSync(logsRoot).filter((name) => name.startsWith(LOG_DIR_PREFIX));
+    names = readdirSync(logsRoot).filter((name) => name.startsWith(prefix));
   } catch {
     return;
   }

--- a/cli/src/test/logs.test.ts
+++ b/cli/src/test/logs.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createInitLogDir, moduleLogPath } from "../lib/logs.js";
+import { createRunLogDir, moduleLogPath } from "../lib/logs.js";
 
 let home: string;
 
@@ -16,13 +16,18 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-describe("createInitLogDir", () => {
+describe("createRunLogDir", () => {
   test("creates ~/.devlair/logs/init-<ts>/ with mode 0700", () => {
-    const dir = createInitLogDir(home);
+    const dir = createRunLogDir(home);
     const st = statSync(dir);
     expect(st.isDirectory()).toBe(true);
     expect(st.mode & 0o777).toBe(0o700);
     expect(dir.startsWith(join(home, ".devlair", "logs", "init-"))).toBe(true);
+  });
+
+  test("uses the given prefix for the run directory name", () => {
+    const dir = createRunLogDir(home, "doctor-");
+    expect(dir.startsWith(join(home, ".devlair", "logs", "doctor-"))).toBe(true);
   });
 
   test("prunes older runs, keeping the 10 most recent", () => {
@@ -35,7 +40,7 @@ describe("createInitLogDir", () => {
     }
     // Explicit `now` newer than every seed (00..11) so the result is
     // deterministic regardless of the wall clock.
-    createInitLogDir(home, new Date(Date.UTC(2025, 0, 1, 0, 0, 30)));
+    createRunLogDir(home, "init-", new Date(Date.UTC(2025, 0, 1, 0, 0, 30)));
     const remaining = readdirSync(logsRoot)
       .filter((n) => n.startsWith("init-"))
       .sort();
@@ -48,17 +53,34 @@ describe("createInitLogDir", () => {
     // The just-created run is retained.
     expect(remaining.some((n) => n.endsWith("-30Z"))).toBe(true);
   });
+
+  test("pruning is scoped per prefix — doctor runs never evict init runs", () => {
+    const logsRoot = join(home, ".devlair", "logs");
+    mkdirSync(logsRoot, { recursive: true });
+    // Seed 12 init runs, then create 12 doctor runs. Each prefix prunes to 10
+    // independently, so the init history must be untouched by doctor pruning.
+    for (let i = 0; i < 12; i++) {
+      mkdirSync(join(logsRoot, `init-2025-01-01T00-00-${i.toString().padStart(2, "0")}Z`));
+    }
+    for (let i = 0; i < 12; i++) {
+      createRunLogDir(home, "doctor-", new Date(Date.UTC(2025, 0, 2, 0, 0, i)));
+    }
+    const initRuns = readdirSync(logsRoot).filter((n) => n.startsWith("init-"));
+    const doctorRuns = readdirSync(logsRoot).filter((n) => n.startsWith("doctor-"));
+    expect(initRuns.length).toBe(12); // untouched by doctor pruning
+    expect(doctorRuns.length).toBe(10); // doctor pruned to KEEP_RUNS
+  });
 });
 
 describe("moduleLogPath", () => {
   test("resolves <runDir>/<key>.log", () => {
-    const dir = createInitLogDir(home);
+    const dir = createRunLogDir(home);
     expect(moduleLogPath(dir, "tailscale")).toBe(join(dir, "tailscale.log"));
   });
 
   test("runner writes module stderr to the log file", async () => {
     const { runModule } = await import("../lib/runner.js");
-    const dir = createInitLogDir(home);
+    const dir = createRunLogDir(home);
     const script = join(home, "noisy.sh");
     writeFileSync(script, '#!/usr/bin/env bash\necho "line one" >&2\necho "line two" >&2\n', { mode: 0o755 });
     const logFile = moduleLogPath(dir, "noisy");

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ done
 # channel so asset naming and the v1/macOS guard below stay consistent.
 if [[ -n "$PIN_VERSION" ]]; then
   [[ "$PIN_VERSION" =~ ^[0-9] ]] && PIN_VERSION="v${PIN_VERSION}"   # allow "3.2.1" → "v3.2.1"
-  if [[ ! "$PIN_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then
+  if [[ ! "$PIN_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
     err "Invalid --version '${PIN_VERSION}' — expected a v-prefixed release, e.g. v3.2.1"
     exit 1
   fi

--- a/install.sh
+++ b/install.sh
@@ -176,6 +176,30 @@ if [[ -z "${LATEST:-}" ]]; then
   exit 1
 fi
 
+# ── Guard: newest tag must have a published release ───────────────────────────
+# LATEST comes from the /releases API, which omits any tag whose GitHub Release
+# was deleted. When that happens the resolver silently falls back to an older
+# release and every fresh install is downgraded — with no error, because the
+# stale release still downloads fine. Cross-check against /tags: if a strictly
+# newer stable tag exists on this channel without a release, fail loudly rather
+# than install stale. Best-effort — a tags-API hiccup must not block installs
+# that already resolved a valid release.
+NEWEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/tags?per_page=100" 2>/dev/null \
+  | grep -oE '"name": *"v[0-9]+\.[0-9]+\.[0-9]+"' \
+  | grep -o '"v[^"]*"' | tr -d '"' \
+  | { if [[ "$CHANNEL" == "v1" ]]; then grep '^v1\.'; else grep -v '^v1\.'; fi; } \
+  | sort -V | tail -1) || true
+if [[ -n "${NEWEST_TAG:-}" && "$NEWEST_TAG" != "$LATEST" ]]; then
+  # Only fail when the tag is strictly newer than the resolved release; sort -V
+  # puts the greater version last, so a trailing NEWEST_TAG means release is behind.
+  if [[ "$(printf '%s\n%s\n' "$LATEST" "$NEWEST_TAG" | sort -V | tail -1)" == "$NEWEST_TAG" ]]; then
+    err "Tag ${NEWEST_TAG} exists but has no published GitHub Release."
+    meta "Refusing to install stale ${LATEST} — a release was likely deleted."
+    meta "Please report this at https://github.com/${REPO}/issues"
+    exit 1
+  fi
+fi
+
 ASSET="${ASSET_PREFIX}-${OS_SUFFIX}-${ARCH_SUFFIX}"
 ok "release ${LATEST}"
 meta "asset: ${ASSET}"

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,10 @@
 # Usage (macOS):
 #   curl -fsSL https://raw.githubusercontent.com/ettoreaquino/devlair/main/install.sh | bash
 #
+# Install a specific release (default: latest published release):
+#   curl -fsSL .../install.sh | bash -s -- --version v3.2.1
+#   curl -fsSL .../install.sh | DEVLAIR_VERSION=v3.2.1 bash
+#
 # The script auto-elevates only when /usr/local/bin is not writable.
 # On macOS with Homebrew, sudo is usually not required.
 set -euo pipefail
@@ -16,6 +20,9 @@ BIN="devlair"
 INSTALL_DIR="/usr/local/bin"
 SHARE_DIR="/usr/local/share/devlair"
 CHANNEL="v2"
+# Optional pin to a specific release tag (e.g. v3.2.1). Empty = resolve latest.
+# Settable via env for the pipe-to-bash case, or --version for the -s -- case.
+PIN_VERSION="${DEVLAIR_VERSION:-}"
 
 # macOS: install the binary into a user-owned dir so self-update never needs
 # root. The devlair shell module puts ~/.devlair/bin ahead of /usr/local/bin on
@@ -98,21 +105,43 @@ verify_checksum() {
 }
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --v1)    CHANNEL="v1" ;;
     --pre)   ;;                # no-op: v2 is now the default
+    --version)
+      PIN_VERSION="${2:-}"
+      [[ -z "$PIN_VERSION" ]] && { err "--version requires an argument, e.g. --version v3.2.1"; exit 1; }
+      shift
+      ;;
+    --version=*)
+      PIN_VERSION="${1#--version=}"
+      ;;
     -h|--help)
-      sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
+      # Print the leading comment block (everything after the shebang up to the
+      # first non-comment line), so usage stays in sync with the header above.
+      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
       exit 0
       ;;
     *)
-      err "Unknown option: $arg"
+      err "Unknown option: $1"
       err "Run with --help for usage."
       exit 1
       ;;
   esac
+  shift
 done
+
+# Normalize + validate a pinned version, then let the pinned major pick the
+# channel so asset naming and the v1/macOS guard below stay consistent.
+if [[ -n "$PIN_VERSION" ]]; then
+  [[ "$PIN_VERSION" =~ ^[0-9] ]] && PIN_VERSION="v${PIN_VERSION}"   # allow "3.2.1" → "v3.2.1"
+  if [[ ! "$PIN_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9] ]]; then
+    err "Invalid --version '${PIN_VERSION}' — expected a v-prefixed release, e.g. v3.2.1"
+    exit 1
+  fi
+  if [[ "$PIN_VERSION" =~ ^v1\. ]]; then CHANNEL="v1"; else CHANNEL="v2"; fi
+fi
 
 # ── Detect OS + architecture ──────────────────────────────────────────────────
 OS=$(uname -s)
@@ -147,8 +176,12 @@ printf "\n%s%s devlair installer%s  %s· channel: %s · os: %s · arch: %s%s\n\n
 
 # ── Channel configuration ─────────────────────────────────────────────────────
 section "Resolving release"
-if [[ "$CHANNEL" == "v1" ]]; then
-  ASSET_PREFIX="devlair"
+ASSET_PREFIX=$([[ "$CHANNEL" == "v1" ]] && echo "devlair" || echo "devlair-cli")
+if [[ -n "$PIN_VERSION" ]]; then
+  # Explicit pin — skip "latest" resolution and the tag/release guard entirely
+  # (the guard only makes sense for latest; pinning an older release is valid).
+  LATEST="$PIN_VERSION"
+elif [[ "$CHANNEL" == "v1" ]]; then
   LATEST=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=30" \
     | grep -o '"tag_name": *"v1\.[^"]*"' \
     | head -1 \
@@ -157,7 +190,6 @@ if [[ "$CHANNEL" == "v1" ]]; then
     err "Unexpected version format: $LATEST"; exit 1
   fi
 else
-  ASSET_PREFIX="devlair-cli"
   # Default channel = the latest non-v1 release (v2, v3, …). Don't hardcode a
   # major here, or the installer silently pins to the previous line after a
   # major bump (e.g. v3.0.0 ships but `v2\.` keeps resolving the old v2.x).
@@ -183,20 +215,22 @@ fi
 # stale release still downloads fine. Cross-check against /tags: if a strictly
 # newer stable tag exists on this channel without a release, fail loudly rather
 # than install stale. Best-effort — a tags-API hiccup must not block installs
-# that already resolved a valid release.
-NEWEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/tags?per_page=100" 2>/dev/null \
-  | grep -oE '"name": *"v[0-9]+\.[0-9]+\.[0-9]+"' \
-  | grep -o '"v[^"]*"' | tr -d '"' \
-  | { if [[ "$CHANNEL" == "v1" ]]; then grep '^v1\.'; else grep -v '^v1\.'; fi; } \
-  | sort -V | tail -1) || true
-if [[ -n "${NEWEST_TAG:-}" && "$NEWEST_TAG" != "$LATEST" ]]; then
-  # Only fail when the tag is strictly newer than the resolved release; sort -V
-  # puts the greater version last, so a trailing NEWEST_TAG means release is behind.
-  if [[ "$(printf '%s\n%s\n' "$LATEST" "$NEWEST_TAG" | sort -V | tail -1)" == "$NEWEST_TAG" ]]; then
-    err "Tag ${NEWEST_TAG} exists but has no published GitHub Release."
-    meta "Refusing to install stale ${LATEST} — a release was likely deleted."
-    meta "Please report this at https://github.com/${REPO}/issues"
-    exit 1
+# that already resolved a valid release. Skipped entirely when PIN_VERSION is set.
+if [[ -z "$PIN_VERSION" ]]; then
+  NEWEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/tags?per_page=100" 2>/dev/null \
+    | grep -oE '"name": *"v[0-9]+\.[0-9]+\.[0-9]+"' \
+    | grep -o '"v[^"]*"' | tr -d '"' \
+    | { if [[ "$CHANNEL" == "v1" ]]; then grep '^v1\.'; else grep -v '^v1\.'; fi; } \
+    | sort -V | tail -1) || true
+  if [[ -n "${NEWEST_TAG:-}" && "$NEWEST_TAG" != "$LATEST" ]]; then
+    # Only fail when the tag is strictly newer than the resolved release; sort -V
+    # puts the greater version last, so a trailing NEWEST_TAG means release is behind.
+    if [[ "$(printf '%s\n%s\n' "$LATEST" "$NEWEST_TAG" | sort -V | tail -1)" == "$NEWEST_TAG" ]]; then
+      err "Tag ${NEWEST_TAG} exists but has no published GitHub Release."
+      meta "Refusing to install stale ${LATEST} — a release was likely deleted."
+      meta "Please report this at https://github.com/${REPO}/issues"
+      exit 1
+    fi
   fi
 fi
 
@@ -211,7 +245,11 @@ TMP=$(mktemp)
 TMP_CHECKSUMS=$(mktemp)
 cleanup() { rm -f "${TMP:-}" "${TMP_CHECKSUMS:-}" "${TMP_MODULES:-}"; rm -rf "${STAGE_DIR:-}"; }
 trap cleanup EXIT
-curl -fsSL "${BASE_URL}/${ASSET}" -o "$TMP"
+if ! curl -fsSL "${BASE_URL}/${ASSET}" -o "$TMP"; then
+  err "Could not download ${ASSET} for ${LATEST}."
+  meta "Check that release ${LATEST} exists at https://github.com/${REPO}/releases"
+  exit 1
+fi
 curl -fsSL "${BASE_URL}/checksums.txt" -o "$TMP_CHECKSUMS"
 ok "downloaded ${ASSET}"
 


### PR DESCRIPTION
## Summary

Resolves all three bugs in #269 plus adds release version pinning to the installer.

- **fix(shell)** — Bug 2: `shell.sh` rewrites `~/.zshrc` as `header + managed block` on every run, discarding anything `claude.ai/install.sh` appended after it. Moved the `~/.local/bin` PATH export into devlair's managed Claude Code block (same pattern as pyenv/nvm/bun) so `claude` stays reachable across `init` reruns, and added a `_clean_zshrc` filter to strip the upstream installer's duplicate line.
- **fix(doctor)** — Bug 3: `doctor` now writes per-run module logs like `init`/`uninstall`. Generalized `createInitLogDir` → `createRunLogDir(userHome, prefix)` so `doctor-<ts>/` runs prune independently from `init-<ts>/` history.
- **fix(install)** — Bug 1 guard: `install.sh` resolves "latest" from the Releases API, which omits tags whose Release was deleted — silently downgrading fresh installs (the v3.2.2–v3.2.4 deletion pinned installs to v3.2.1). Now cross-checks against `/tags` and fails loudly if a strictly-newer stable tag has no release.
- **feat(install)** — New capability: pin any published release via `--version v3.2.1` or `DEVLAIR_VERSION=v3.2.1`. The env var covers the plain pipe-to-bash case; the flag wins over the env var. Bare `3.2.1` is normalized; the pinned major selects the channel; a missing release fails with a clear message. Pinning skips the latest-resolution and the drift guard by design.

Closes #269

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome) — clean, 49 files
- [x] `bun test` — 201 pass, 0 fail (added log-prefix + per-prefix pruning tests)
- [x] Ran `devlair doctor` live → created `~/.devlair/logs/doctor-<ts>/<module>.log` (mode 0600)
- [x] Bug 1 guard verified live (v3.2.4 tag == release → passes) and across simulated scenarios (deleted release fires, double-digit semver ordering, empty-tags best-effort)
- [x] `install.sh` version pinning verified: env var, `--version v*` (space), `--version=v*` (equals), flag-over-env precedence, `3.2.1`→`v3.2.1` normalization, malformed-input rejection, v1-major → v1-channel inference, clear 404 message on missing release
- [x] `bash -n install.sh` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)