### PR TITLE
fix(macos): minimal arrow prompt + robust VS Code code CLI symlink

### DIFF
--- a/cli/modules/_lib.sh
+++ b/cli/modules/_lib.sh
@@ -225,13 +225,16 @@ download_script() {
 # is "staff", not the username.
 chown_user() {
   _is_root || return 0
-  chown "${USERNAME:?USERNAME not set}" "$1"
+  # -h: chown the path itself, not its target. Without it, chowning a
+  # symlink (e.g. the VS Code CLI shim in ~/.devlair/bin) follows the link
+  # and re-owns whatever it points to instead.
+  chown -h "${USERNAME:?USERNAME not set}" "$1"
 }
 
 # chown_user_r DIR -- recursive chown to the target user (root only; else no-op).
 chown_user_r() {
   _is_root || return 0
-  chown -R "${USERNAME:?USERNAME not set}" "$1"
+  chown -R -h "${USERNAME:?USERNAME not set}" "$1"
 }
 
 # update_json FILE PATCH_JSON -- shallow-merge a JSON patch into a file.

--- a/cli/modules/configs/shell-aliases.zsh
+++ b/cli/modules/configs/shell-aliases.zsh
@@ -24,9 +24,6 @@ alias dps='docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
 alias ts='tailscale status'
 alias t='tmux new-session -A -s dev'
 alias bcat='bat --paging=never'
-if [[ "$_dl_uname" == "Darwin" ]] && [ -d "/Applications/Visual Studio Code.app" ] && ! command -v code &>/dev/null; then
-  alias code='/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
-fi
 tmx() {
   if [ "$1" = "new" ]; then
     shift

--- a/cli/modules/configs/zshrc-header.sh
+++ b/cli/modules/configs/zshrc-header.sh
@@ -13,6 +13,11 @@ if [[ ! "$ZIM_HOME/init.zsh" -nt "$HOME/.zimrc" ]]; then
 fi
 source "$ZIM_HOME/init.zsh"
 
+# Minimal arrow prompt (Dracula palette) — overrides the dracula/zsh theme's
+# default `user@host path %` format. Must come after init.zsh so it wins over
+# the theme's own PROMPT assignment.
+PROMPT='%(?.%F{#50fa7b}.%F{#ff5555})➜%f %F{#8be9fd}%1~%f '
+
 # zimfw's `environment` module turns on NO_CLOBBER, which makes `>>` to a
 # *nonexistent* file an error (e.g. Homebrew's `... >> ~/.zprofile` on a clean
 # machine). APPEND_CREATE lets `>>` create the file while keeping NO_CLOBBER's

--- a/cli/modules/devtools.sh
+++ b/cli/modules/devtools.sh
@@ -15,6 +15,21 @@ MODE=${1:-run}
 
 _AWS_CLI_GPG_KEY_URL="https://awscli.amazonaws.com/awscli-exe-linux-public-key.asc"
 
+# _link_vscode_cli -- symlink the `code` CLI into ~/.devlair/bin, which is
+# unconditionally first on PATH (see shell-aliases.zsh). This is more robust
+# than depending on Homebrew's own cask shim or a shell-startup-time alias:
+# it works regardless of PATH ordering, and re-runs (VS Code installed
+# manually, pre-existing app, doctor/upgrade) always keep it up to date.
+_link_vscode_cli() {
+  local app_cli="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+  [[ -x "$app_cli" ]] || return 0
+  local bin_dir="$USER_HOME/.devlair/bin"
+  mkdir -p "$bin_dir"
+  ln -sf "$app_cli" "$bin_dir/code"
+  chown_user "$bin_dir/code"
+  chown_user "$bin_dir"
+}
+
 do_run() {
   local -a installed=() skipped=()
 
@@ -222,10 +237,12 @@ do_run() {
   # ── VS Code ──────────────────────────────────────────────────────────────────
   if cmd_exists code || [[ -d "/Applications/Visual Studio Code.app" ]]; then
     skipped+=(vscode)
+    [[ "$PLATFORM" == "macos" ]] && _link_vscode_cli
   elif [[ "$PLATFORM" == "macos" ]]; then
     brew_install --cask visual-studio-code
     json_install "vscode" "brew:cask:visual-studio-code" true
     installed+=(vscode)
+    _link_vscode_cli
   elif [[ "$PLATFORM" == "linux" ]]; then
     json_progress "installing vscode"
     install -m 0755 -d /etc/apt/keyrings
@@ -297,6 +314,7 @@ do_uninstall() {
   rm_user_path "$USER_HOME/.fzf"
   rm_user_path "$USER_HOME/.local/bin/uv"
   rm_user_path "$USER_HOME/.local/bin/uvx"
+  [[ "$PLATFORM" == "macos" ]] && rm_user_path "$USER_HOME/.devlair/bin/code"
 
   if [[ "$remove_packages" == "true" ]]; then
     if [[ "$PLATFORM" == "macos" ]]; then

--- a/cli/modules/devtools.sh
+++ b/cli/modules/devtools.sh
@@ -14,14 +14,17 @@ PLATFORM=$(ctx_get platform)
 MODE=${1:-run}
 
 _AWS_CLI_GPG_KEY_URL="https://awscli.amazonaws.com/awscli-exe-linux-public-key.asc"
+_VSCODE_APP_DIR="/Applications/Visual Studio Code.app"
 
 # _link_vscode_cli -- symlink the `code` CLI into ~/.devlair/bin, which is
 # unconditionally first on PATH (see shell-aliases.zsh). This is more robust
 # than depending on Homebrew's own cask shim or a shell-startup-time alias:
 # it works regardless of PATH ordering, and re-runs (VS Code installed
 # manually, pre-existing app, doctor/upgrade) always keep it up to date.
+# macOS-only: no-ops immediately on any platform where the app bundle isn't
+# present, so callers don't need their own platform guard.
 _link_vscode_cli() {
-  local app_cli="/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+  local app_cli="$_VSCODE_APP_DIR/Contents/Resources/app/bin/code"
   [[ -x "$app_cli" ]] || return 0
   local bin_dir="$USER_HOME/.devlair/bin"
   mkdir -p "$bin_dir"
@@ -235,9 +238,9 @@ do_run() {
   fi
 
   # ── VS Code ──────────────────────────────────────────────────────────────────
-  if cmd_exists code || [[ -d "/Applications/Visual Studio Code.app" ]]; then
+  if cmd_exists code || [[ -d "$_VSCODE_APP_DIR" ]]; then
     skipped+=(vscode)
-    [[ "$PLATFORM" == "macos" ]] && _link_vscode_cli
+    _link_vscode_cli
   elif [[ "$PLATFORM" == "macos" ]]; then
     brew_install --cask visual-studio-code
     json_install "vscode" "brew:cask:visual-studio-code" true
@@ -277,7 +280,7 @@ do_check() {
     fi
   done
 
-  if cmd_exists code || [[ -d "/Applications/Visual Studio Code.app" ]]; then
+  if cmd_exists code || [[ -d "$_VSCODE_APP_DIR" ]]; then
     json_check "vscode" "ok" "installed"
   else
     json_check "vscode" "warn" "missing"


### PR DESCRIPTION
## Summary
- Overrides the Dracula zsh theme's default `user@host path %` prompt with a minimal `➜ path` arrow style (Dracula palette colors), set after zimfw's `init.zsh` sourcing so it wins over the theme's own `PROMPT`.
- Replaces the fragile shell-startup-time `code` alias (only defined when VS Code's app dir was *missing* at devtools-install time) with a `_link_vscode_cli` helper that symlinks the app's `bin/code` script into `~/.devlair/bin/code` — unconditionally first on `PATH` — on every devtools run, in both the fresh-install and already-installed branches. Self-heals regardless of how/when VS Code got there.
- Removes the now-redundant conditional alias from `shell-aliases.zsh`.
- Cleans up the symlink in the devtools uninstall path.

Closes #272

## Test plan
- [x] `bun test` — 201 pass
- [x] `bun run lint` (biome) — clean
- [x] `bash -n` syntax check on modified shell modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)