### PR TITLE
fix(macos): prompt lands on upgrade + no Terminal window during init

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Applies the full 16-color Dracula palette to your default GNOME Terminal profile
 <details>
 <summary><b>Terminal.app</b> — Dracula color scheme (macOS)</summary>
 
-Downloads the official [Dracula theme for Terminal.app](https://draculatheme.com/terminal) from the `dracula/terminal-app` release, imports it via `open`, sets it as the default profile, and applies it as the startup (on-open) window profile. macOS-only — auto-skipped on Linux and WSL. The `reapply` flag ensures the theme is re-applied during `devlair upgrade` if it has drifted.
+Downloads the official [Dracula theme for Terminal.app](https://draculatheme.com/terminal) from the `dracula/terminal-app` release, registers it via `defaults write` (no `open`, so no stray Terminal window appears during init), sets it as the default profile, and applies it as the startup (on-open) window profile. macOS-only — auto-skipped on Linux and WSL. The `reapply` flag ensures the theme is re-applied during `devlair upgrade` if it has drifted.
 
 </details>
 

--- a/cli/modules/macos-terminal.sh
+++ b/cli/modules/macos-terminal.sh
@@ -18,38 +18,28 @@ _DRACULA_COMMIT="9ca4acf67fa43c51b21248a243407fd1549f4268"
 _DRACULA_URL="https://raw.githubusercontent.com/dracula/terminal-app/${_DRACULA_COMMIT}/Dracula.terminal"
 _DRACULA_SHA256="2d29ed73a31c343098cb405f12fdb48462382b37eb793300c2109e4a281b794d"
 
-_defaults_read_profile() {
+# _user_defaults ARGS... -- run `defaults ARGS...` against the target user's GUI
+# (Aqua) preferences session, where Terminal.app reads and writes its settings.
+# As root we bridge into that session with `launchctl asuser` (a bare `sudo -u`
+# lands in the wrong per-user context, so Terminal never sees the change); as the
+# user we call defaults directly. Registering the theme through `defaults` —
+# rather than `open`ing the .terminal file — is what avoids spawning a stray
+# Terminal window during init.
+_user_defaults() {
   if _is_root; then
-    sudo -u "$USERNAME" defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || true
+    launchctl asuser "$(id -u "$USERNAME")" sudo -u "$USERNAME" defaults "$@"
   else
-    defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || true
+    defaults "$@"
   fi
 }
 
-# Terminal.app registers profiles by filename stem, not the plist name key.
-_terminal_prefs_path() {
-  if _is_root; then
-    echo "/Users/$USERNAME/Library/Preferences/com.apple.Terminal.plist"
-  else
-    echo "$HOME/Library/Preferences/com.apple.Terminal.plist"
-  fi
+_defaults_read_profile() {
+  _user_defaults read com.apple.Terminal "Default Window Settings" 2>/dev/null || true
 }
 
 _dracula_profile_registered() {
-  /usr/libexec/PlistBuddy -c "Print :'Window Settings':Dracula" "$(_terminal_prefs_path)" > /dev/null 2>&1
-}
-
-_open_terminal_file() {
-  local path=$1
-  if _is_root; then
-    local uid
-    uid=$(id -u "$USERNAME")
-    # launchctl asuser bridges to the user's Aqua/GUI session so Terminal.app
-    # registers the imported theme (plain sudo -u cannot reach the GUI session).
-    launchctl asuser "$uid" /usr/bin/open "$path" >&2
-  else
-    /usr/bin/open "$path" >&2
-  fi
+  _user_defaults read com.apple.Terminal "Window Settings" 2>/dev/null \
+    | grep -qE '^[[:space:]]+Dracula = '
 }
 
 do_run() {
@@ -61,16 +51,14 @@ do_run() {
   fi
 
   json_progress "downloading Dracula.terminal"
-  # The file must be named Dracula.terminal — Terminal.app uses the filename stem
-  # as the registered profile name, ignoring the name key inside the plist.
   local tmpdir tmp
   tmpdir=$(mktemp -d)
   tmp="$tmpdir/Dracula.terminal"
 
   curl -fsSL "$_DRACULA_URL" -o "$tmp" >&2
 
-  # Verify SHA-256 before handing to Terminal.app — .terminal plists support
-  # CommandString which Terminal.app executes as a shell on every new window.
+  # Verify SHA-256 before importing — .terminal plists support CommandString,
+  # which Terminal.app executes as a shell on every new window.
   local actual
   actual=$(shasum -a 256 "$tmp" | awk '{print $1}')
   if [[ "$actual" != "$_DRACULA_SHA256" ]]; then
@@ -80,14 +68,13 @@ do_run() {
   fi
 
   json_progress "importing Dracula theme"
-  _open_terminal_file "$tmp"
-  # Terminal.app needs a moment to register the imported profile before defaults write can reference it by name
-  sleep 1
-
-  run_shell_as "$USERNAME" "
-    defaults write com.apple.Terminal 'Default Window Settings' 'Dracula'
-    defaults write com.apple.Terminal 'Startup Window Settings' 'Dracula'
-  " >&2
+  # A .terminal file is a complete Window-Settings dict, so -dict-add stores it
+  # verbatim under the "Dracula" profile name. Importing through `defaults` this
+  # way (instead of `open`ing the file) registers the theme WITHOUT popping open
+  # a new Terminal window, and needs no settle delay.
+  _user_defaults write com.apple.Terminal "Window Settings" -dict-add "Dracula" "$(cat "$tmp")" >&2
+  _user_defaults write com.apple.Terminal "Default Window Settings" "Dracula" >&2
+  _user_defaults write com.apple.Terminal "Startup Window Settings" "Dracula" >&2
 
   rm -rf "$tmpdir"
   json_result "ok" "Dracula theme imported and set as default"
@@ -104,10 +91,8 @@ do_check() {
 }
 
 do_uninstall() {
-  run_shell_as "$USERNAME" "
-    defaults delete com.apple.Terminal 'Default Window Settings' 2>/dev/null || true
-    defaults delete com.apple.Terminal 'Startup Window Settings' 2>/dev/null || true
-  " >&2
+  _user_defaults delete com.apple.Terminal "Default Window Settings" 2>/dev/null || true
+  _user_defaults delete com.apple.Terminal "Startup Window Settings" 2>/dev/null || true
   json_result "ok" "Terminal.app default profile reset"
 }
 

--- a/cli/modules/zsh.sh
+++ b/cli/modules/zsh.sh
@@ -85,11 +85,24 @@ EOF
     chown_user "$zshenv"
   fi
 
-  # Write .zshrc header (only if not already managed by devlair)
-  if [[ ! -f "$zshrc" ]] || ! grep -q "devlair" "$zshrc"; then
+  # Write / refresh the devlair-managed .zshrc header. Devlair owns the region
+  # above shell.sh's aliases marker, so the header is re-applied on every run —
+  # otherwise template changes (e.g. the minimal-arrow prompt) never reach a
+  # machine that an older devlair already provisioned. shell.sh owns everything
+  # from the aliases marker down and rewrites it on its own pass; here we only
+  # refresh the header above it.
+  json_progress "writing .zshrc header"
+  local aliases_marker="# ── devlair aliases ─"  # must match shell.sh's MARKER
+  if [[ -f "$zshrc" ]] && grep -qF "$aliases_marker" "$zshrc"; then
+    # Refresh the header in place, preserving the aliases block below it (so a
+    # `--only zsh` run doesn't drop aliases that shell.sh isn't there to rewrite).
+    local aliases_block
+    aliases_block=$(awk -v m="$aliases_marker" 'index($0, m){seen=1} seen' "$zshrc")
+    { cat "$SCRIPT_DIR/configs/zshrc-header.sh"; printf '%s\n' "$aliases_block"; } > "$zshrc"
+  else
     cp "$SCRIPT_DIR/configs/zshrc-header.sh" "$zshrc"
-    chown_user "$zshrc"
   fi
+  chown_user "$zshrc"
 
   # Bootstrap zimfw and install modules as the user
   json_progress "installing zimfw plugins"

--- a/cli/modules/zsh.sh
+++ b/cli/modules/zsh.sh
@@ -98,7 +98,7 @@ EOF
     # `--only zsh` run doesn't drop aliases that shell.sh isn't there to rewrite).
     local aliases_block
     aliases_block=$(awk -v m="$aliases_marker" 'index($0, m){seen=1} seen' "$zshrc")
-    { cat "$SCRIPT_DIR/configs/zshrc-header.sh"; printf '%s\n' "$aliases_block"; } > "$zshrc"
+    { cat "$SCRIPT_DIR/configs/zshrc-header.sh"; printf '%s\n' "$aliases_block"; } > "${zshrc}.tmp" && mv "${zshrc}.tmp" "$zshrc"
   else
     cp "$SCRIPT_DIR/configs/zshrc-header.sh" "$zshrc"
   fi

--- a/cli/src/test/homebrew.test.ts
+++ b/cli/src/test/homebrew.test.ts
@@ -38,4 +38,23 @@ describe("managed zsh config", () => {
     expect(header).toContain("setopt APPEND_CREATE");
     expect(header.indexOf("setopt APPEND_CREATE")).toBeGreaterThan(header.indexOf('source "$ZIM_HOME/init.zsh"'));
   });
+
+  // The minimal-arrow prompt only wins if its PROMPT assignment runs AFTER the
+  // dracula/zsh theme (sourced by init.zsh) sets its own. Guards the template so
+  // the override can't be silently dropped again (issue #272 follow-up).
+  test("zshrc-header overrides PROMPT after sourcing init.zsh", () => {
+    const header = readFileSync(join(import.meta.dir, "../../modules/configs/zshrc-header.sh"), "utf8");
+    expect(header).toMatch(/^PROMPT=/m);
+    expect(header.search(/^PROMPT=/m)).toBeGreaterThan(header.indexOf('source "$ZIM_HOME/init.zsh"'));
+  });
+
+  // zsh.sh must RE-APPLY the header on every run (keyed off shell.sh's aliases
+  // marker), not skip when .zshrc already contains "devlair" — otherwise a
+  // template change never reaches a machine an older devlair provisioned, which
+  // is exactly why the #273 prompt fix didn't land on upgrade.
+  test("zsh.sh refreshes the managed header instead of skipping when managed", () => {
+    const zsh = readFileSync(join(import.meta.dir, "../../modules/zsh.sh"), "utf8");
+    expect(zsh).not.toContain('! grep -q "devlair" "$zshrc"');
+    expect(zsh).toContain("aliases_marker");
+  });
 });


### PR DESCRIPTION
## Summary

Two macOS `devlair init` defects surfaced testing v3.3.1 (follow-up to #272/#273):

- **Minimal-arrow prompt never reached upgraded machines.** The `PROMPT` override from #273 is correct and *does* win over the dracula/zsh theme, but `zsh.sh` only wrote the header when `.zshrc` didn't already contain `"devlair"` — so on any machine an earlier devlair had provisioned, the updated header was never re-applied. `zsh.sh` now refreshes the managed header on **every** run (keyed off shell.sh's aliases marker), preserving the aliases block below it for `--only zsh` runs.
- **A stray Terminal window popped up during init.** `macos-terminal.sh` imported the theme by `open`-ing the `.terminal` file, which makes Terminal.app launch a new window. It now registers the profile via `defaults write com.apple.Terminal "Window Settings" -dict-add "Dracula" …` — same registration, **no window**, no settle-`sleep`. A new `_user_defaults` helper still bridges to the user's Aqua session via `launchctl asuser` under `sudo devlair init`.
- Added guard tests: the header template keeps its `PROMPT` override (after `source init.zsh`), and `zsh.sh` refreshes rather than skips when already managed.

Closes #275

## Test plan

- [x] `bash -n` on both changed scripts
- [x] Live: final `PROMPT` resolves to the minimal arrow through real zsh (header + aliases)
- [x] Simulated stale-managed `.zshrc` → refresh lands the prompt, preserves aliases, no duplicate markers
- [x] `defaults -dict-add` import mechanics verified on a scratch domain (nested dict registers, idempotent overwrite, no window)
- [x] `bun test` — 203 pass
- [x] `bun run lint` / `bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)